### PR TITLE
test verbose logging

### DIFF
--- a/gradle/testVerbose.gradle
+++ b/gradle/testVerbose.gradle
@@ -1,0 +1,29 @@
+tasks.withType(Test) {
+    afterTest { desc, result ->
+        //logger.quiet " -- Executed test ${desc.name} [${desc.className}] with result: ${result.resultType}"
+    }
+    testLogging {
+        events "passed", "skipped", "failed"//, "standardOut"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+
+        // set options for log level DEBUG and INFO
+        debug {
+            events "passed", "skipped", "failed"//, "started", "standardOut", "standardError"
+            exceptionFormat "full"
+        }
+        info.events = debug.events
+        info.exceptionFormat = debug.exceptionFormat
+
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                logger.quiet "\n${'-' * repeatLength}\n${startItem}${output}${endItem}\n${'-' * repeatLength}"
+            }
+        }
+    }
+}

--- a/security-jwt/build.gradle
+++ b/security-jwt/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"
 apply from: "${rootProject.projectDir}/gradle/webdriverbinaries.gradle"
-
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"
 
 test {
     testLogging.showStandardStreams = true

--- a/security-ldap/build.gradle
+++ b/security-ldap/build.gradle
@@ -5,3 +5,5 @@ dependencies {
 
     testCompile "com.unboundid:unboundid-ldapsdk:4.0.7"
 }
+
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"

--- a/security-oauth2/build.gradle
+++ b/security-oauth2/build.gradle
@@ -25,3 +25,5 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.20"
     testCompile project(":security-jwt")
 }
+
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"

--- a/security-session/build.gradle
+++ b/security-session/build.gradle
@@ -24,6 +24,6 @@ dependencies {
 
 apply from: "${rootProject.projectDir}/gradle/geb.gradle"
 apply from: "${rootProject.projectDir}/gradle/webdriverbinaries.gradle"
-
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"
 
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/security/build.gradle
+++ b/security/build.gradle
@@ -13,10 +13,7 @@ dependencies {
     testCompile "io.projectreactor:reactor-core:3.2.5.RELEASE"
 }
 
-//tasks.withType(Test) {
-//    testLogging {
-//        showStandardStreams = true
-//        exceptionFormat = 'full'
-//    }
-//}
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"
+
+
 //compileTestGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']


### PR DESCRIPTION
This gets more verbosity when executing tests: 

```
... requires authentication PASSED
... without authentication PASSED
...  authenticated user PASSED
... one of those roles PASSED
... logged in user PASSED
...  logged in user PASSED
...-----------> 16% EXECUTING [25s]
------------------------------------------------------------------------
|  Results: SUCCESS (167 tests, 167 successes, 0 failures, 0 skipped)  |
------------------------------------------------------------------------
```