### PR TITLE
Fix README title (s/RabbitMQ/Security/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Micronaut RabbitMQ
+# Micronaut Security
 
 [![Build Status](https://travis-ci.org/micronaut-projects/micronaut-security.svg?branch=master)](https://travis-ci.org/micronaut-projects/micronaut-security)
 


### PR DESCRIPTION
Looks like the README for Micronaut Security was copied from Micronaut RabbitMQ as a template, but the title wasn't updated.