### PR TITLE
Base 64 state

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDes.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDes.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.util.Base64;
 
 /**
  * Jackson based implementation for state serdes.
@@ -45,8 +46,10 @@ public class JacksonStateSerDes implements StateSerDes {
     }
 
     @Override
-    public State deserialize(String state) {
+    public State deserialize(String base64State) {
         try {
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(base64State);
+            String state = new String(decodedBytes);
             return objectMapper.readValue(state, DefaultState.class);
         } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
@@ -59,7 +62,8 @@ public class JacksonStateSerDes implements StateSerDes {
     @Override
     public String serialize(State state) {
         try {
-            return objectMapper.writeValueAsString(state);
+            String originalInput = objectMapper.writeValueAsString(state);
+            return Base64.getEncoder().encodeToString(originalInput.getBytes());
         } catch (JsonProcessingException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Failed to serialize the authorization request state to JSON", e);

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OauthAuthorizationRedirectSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OauthAuthorizationRedirectSpec.groovy
@@ -53,8 +53,14 @@ class OauthAuthorizationRedirectSpec extends Specification {
         !location.contains("scope=")
         location.contains("response_type=code")
         location.contains("redirect_uri=http://localhost:" + embeddedServer.getPort() + "/oauth/callback/twitter")
-        location.contains("state={\"nonce\":\"")
         location.contains("client_id=myclient")
+
+        when:
+        String sublocation = location.substring(location.indexOf('state=') + 'state='.length())
+        sublocation = sublocation.substring(0, sublocation.indexOf('&client_id='))
+
+        then:
+        new String(Base64.getUrlDecoder().decode(sublocation)).startsWith("{\"nonce\":\"")
 
         cleanup:
         context.close()

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectSpec.groovy
@@ -61,7 +61,8 @@ class OpenIdAuthorizationRedirectSpec extends Specification implements OpenIDInt
         location.contains("scope=openid email profile")
         location.contains("response_type=code")
         location.contains("redirect_uri=http://localhost:" + embeddedServer.getPort() + "/oauth/callback/keycloak")
-        location.contains("state={\"nonce\":\"")
+
+        stateParser(location).contains("{\"nonce\":\"")
         location.contains("client_id=myclient")
 
         when:
@@ -74,7 +75,7 @@ class OpenIdAuthorizationRedirectSpec extends Specification implements OpenIDInt
         !location.contains("scope=")
         location.contains("response_type=code")
         location.contains("redirect_uri=http://localhost:" + embeddedServer.getPort() + "/oauth/callback/twitter")
-        location.contains("state={\"nonce\":\"")
+        stateParser(location).contains("{\"nonce\":\"")
         location.contains("client_id=myclient")
 
         cleanup:
@@ -117,7 +118,7 @@ class OpenIdAuthorizationRedirectSpec extends Specification implements OpenIDInt
         location.contains("scope=openid email profile")
         location.contains("response_type=code")
         location.contains("redirect_uri=http://localhost:" + embeddedServer.getPort() + "/oauth/callback/keycloak")
-        location.contains("state={\"nonce\":\"")
+        stateParser(location).contains("{\"nonce\":\"")
         location.contains("client_id=myclient")
 
         when:
@@ -162,7 +163,7 @@ class OpenIdAuthorizationRedirectSpec extends Specification implements OpenIDInt
         location.contains("scope=openid email profile")
         location.contains("response_type=code")
         location.contains("redirect_uri=http://localhost:" + embeddedServer.getPort() + "/oauth/callback/keycloak")
-        location.contains("state={\"nonce\":\"")
+        stateParser(location).contains("{\"nonce\":\"")
         location.contains("client_id=myclient")
 
         when:
@@ -185,5 +186,11 @@ class OpenIdAuthorizationRedirectSpec extends Specification implements OpenIDInt
         Publisher<UserDetails> createUserDetails(TokenResponse tokenResponse) {
             return Flowable.just(new UserDetails("twitterUser", Collections.emptyList()))
         }
+    }
+
+    private String stateParser(String location) {
+        String sublocation = location.substring(location.indexOf('state=') + 'state='.length())
+        sublocation = sublocation.substring(0, sublocation.indexOf('&client_id='))
+        new String(Base64.getUrlDecoder().decode(sublocation))
     }
 }


### PR DESCRIPTION
This provides a solution for oidc proviers which return invalid state responses. e.g. `sign in with apple`

`/oauth/callback/apple?code=XXXXXXXXXXXX&state="{&quot;nonce&quot;:&quot;ea8eec4d-e2e5-4a72-9fd8-fc347d26f0e4&quot;}"`