### PR TITLE
Fix TokenError deserialization issue

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationError.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationError.java
@@ -16,6 +16,8 @@
 
 package io.micronaut.security.oauth2.endpoint.authorization.response;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * OAuth 2.0 and Open ID authentication error response codes.
  *
@@ -55,6 +57,7 @@ public enum AuthorizationError {
      * @return An errorCode code.
      */
     @Override
+    @JsonValue
     public String toString() {
         return errorCode;
     }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenError.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenError.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.security.oauth2.endpoint.token.response;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">Token Error Response</a>
  */
@@ -41,6 +43,7 @@ public enum TokenError {
      * @return An errorCode code.
      */
     @Override
+    @JsonValue
     public String toString() {
         return errorCode;
     }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenErrorResponse.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenErrorResponse.java
@@ -88,4 +88,9 @@ public class TokenErrorResponse {
     public void setErrorUri(String errorUri) {
         this.errorUri = errorUri;
     }
+
+    @Override
+    public String toString() {
+        return "error: " + this.error.toString() + ", errorDescription: " + this.errorDescription + ", errorUri: " + this.errorUri;
+    }
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenErrorSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenErrorSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.security.oauth2.endpoint.token.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+class TokenErrorSpec extends Specification {
+
+    void "TokenError should be deserializable from a string"() {
+        setup:
+        def objectMapper = new ObjectMapper()
+        when:
+        def deserializationResult = objectMapper.readValue('"unauthorized_client"', TokenError)
+        then:
+        deserializationResult == TokenError.UNAUTHORIZED_CLIENT
+    }
+}


### PR DESCRIPTION
This pull request fixes deserialization of enums in error messages and improves the message for errors when retrieving a token.

In my case there was a misconfigured client secret. There was not meaningful error in the logs, only debug messages of failed deserialization (see below). After I fixed the enum deserialization issue I also had to fix the message, because there was no information about the actual error in the logs.

```
17:52:08.657 [nioEventLoopGroup-1-29] DEBUG i.m.http.client.DefaultHttpClient - Sending HTTP Request: POST /auth/realms/master/protocol/openid-connect/token
17:52:08.657 [nioEventLoopGroup-1-29] DEBUG i.m.http.client.DefaultHttpClient - Chosen Server: localhost(8080)
17:52:08.667 [nioEventLoopGroup-1-29] DEBUG i.m.http.client.DefaultHttpClient - Unable to decode response body using codec JsonMediaTypeCodec:Error decoding JSON stream for type [class io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse]: Cannot deserialize value of type `io.micronaut.security.oauth2.endpoint.token.response.TokenError` from String "unauthorized_client": value not one of declared Enum instance names: [INVALID_CLIENT, INVALID_GRANT, UNAUTHORIZED_CLIENT, INVALID_REQUEST, INVALID_SCOPE, UNSUPPORTED_GRANT_TYPE]
 at [Source: (byte[])"{"error":"unauthorized_client","error_description":"Invalid client secret"}"; line: 1, column: 10] (through reference chain: io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse["error"])
io.micronaut.http.codec.CodecException: Error decoding JSON stream for type [class io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse]: Cannot deserialize value of type `io.micronaut.security.oauth2.endpoint.token.response.TokenError` from String "unauthorized_client": value not one of declared Enum instance names: [INVALID_CLIENT, INVALID_GRANT, UNAUTHORIZED_CLIENT, INVALID_REQUEST, INVALID_SCOPE, UNSUPPORTED_GRANT_TYPE]
 at [Source: (byte[])"{"error":"unauthorized_client","error_description":"Invalid client secret"}"; line: 1, column: 10] (through reference chain: io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse["error"])
        at io.micronaut.jackson.codec.JsonMediaTypeCodec.decode(JsonMediaTypeCodec.java:139)
        at io.micronaut.http.client.FullNettyClientHttpResponse.convertByteBuf(FullNettyClientHttpResponse.java:238)
        at io.micronaut.http.client.FullNettyClientHttpResponse.lambda$getBody$1(FullNettyClientHttpResponse.java:188)
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1138)
        at io.micronaut.http.client.FullNettyClientHttpResponse.getBody(FullNettyClientHttpResponse.java:166)
        at io.micronaut.http.client.FullNettyClientHttpResponse.getBody(FullNettyClientHttpResponse.java:136)
        at io.micronaut.http.client.exceptions.HttpClientResponseException.initResponse(HttpClientResponseException.java:93)
        at io.micronaut.http.client.exceptions.HttpClientResponseException.<init>(HttpClientResponseException.java:62)
        at io.micronaut.http.client.DefaultHttpClient$10.channelRead0(DefaultHttpClient.java:1773)
        at io.micronaut.http.client.DefaultHttpClient$10.channelRead0(DefaultHttpClient.java:1725)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.micronaut.http.netty.stream.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:185)
        at io.micronaut.http.netty.stream.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:180)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:438)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:323)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:297)
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:253)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:644)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:579)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:496)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:458)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.micronaut.http.context.ServerRequestContext.with(ServerRequestContext.java:52)
        at io.micronaut.http.context.ServerRequestContext.lambda$instrument$0(ServerRequestContext.java:68)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:844)
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `io.micronaut.security.oauth2.endpoint.token.response.TokenError` from String "unauthorized_client": value not one of declared Enum instance names: [INVALID_CLIENT, INVALID_GRANT, UNAUTHORIZED_CLIENT, INVALID_REQUEST, INVALID_SCOPE, UNSUPPORTED_GRANT_TYPE]
 at [Source: (byte[])"{"error":"unauthorized_client","error_description":"Invalid client secret"}"; line: 1, column: 10] (through reference chain: io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse["error"])
        at com.fasterxml.jackson.databind.exc.InvalidFormatException.from(InvalidFormatException.java:67)
        at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1549)
        at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:911)
        at com.fasterxml.jackson.databind.deser.std.EnumDeserializer._deserializeAltString(EnumDeserializer.java:255)
        at com.fasterxml.jackson.databind.deser.std.EnumDeserializer.deserialize(EnumDeserializer.java:179)
        at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:127)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4013)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3091)
        at io.micronaut.jackson.codec.JsonMediaTypeCodec.decode(JsonMediaTypeCodec.java:136)
        ... 51 common frames omitted
17:52:08.668 [nioEventLoopGroup-1-29] ERROR i.m.h.s.netty.RoutingInBoundHandler - Unexpected error occurred: Bad Request
io.micronaut.http.client.exceptions.HttpClientResponseException: Bad Request
        at io.micronaut.http.client.DefaultHttpClient$10.channelRead0(DefaultHttpClient.java:1773)
        at io.micronaut.http.client.DefaultHttpClient$10.channelRead0(DefaultHttpClient.java:1725)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.micronaut.http.netty.stream.HttpStreamsHandler.channelRead(HttpStreamsHandler.java:185)
        at io.micronaut.http.netty.stream.HttpStreamsClientHandler.channelRead(HttpStreamsClientHandler.java:180)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:102)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:438)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:323)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:297)
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:253)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:644)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:579)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:496)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:458)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at io.micronaut.http.context.ServerRequestContext.with(ServerRequestContext.java:52)
        at io.micronaut.http.context.ServerRequestContext.lambda$instrument$0(ServerRequestContext.java:68)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:844)
17:52:08.668 [nioEventLoopGroup-1-27] DEBUG i.m.h.s.netty.RoutingInBoundHandler - Encoding emitted response object [Internal Server Error: Bad Request] using codec: io.micronaut.jackson.codec.JsonMediaTypeCodec@7e7fe6d
17:52:08.669 [nioEventLoopGroup-1-27] DEBUG i.m.c.e.ApplicationEventPublisher - Publishing event: io.micronaut.http.context.event.HttpRequestTerminatedEvent[source=GET /oauth/callback/keycloak?state=%7B%22nonce%22%3A%22428b96c2-5b07-4e52-93af-f04df544c7c5%22%7D&session_state=5102b2a6-7b26-4f14-979a-405ff2639a94&code=171a01bc-f785-414e-aa2b-45f3d7409de2.5102b2a6-7b26-4f14-979a-405ff2639a94.9f362b28-62d8-4ecf-9132-afcc4141e68a]
```