### PR TITLE
Update Javadoc to make "user" not male-specific.

### DIFF
--- a/security/src/main/java/io/micronaut/security/handlers/RejectionHandler.java
+++ b/security/src/main/java/io/micronaut/security/handlers/RejectionHandler.java
@@ -30,7 +30,7 @@ public interface RejectionHandler {
     /**
      *
      * @param request {@link HttpRequest} being processed
-     * @param forbidden if true indicates that although the user was authenticated he did not had the necessary access privileges.
+     * @param forbidden if true indicates that although the user was authenticated they did not have the necessary access privileges.
      * @return Return a HTTP Response
      */
     Publisher<MutableHttpResponse<?>> reject(HttpRequest<?> request, boolean forbidden);


### PR DESCRIPTION
"User" can be a machine, woman, man, multiple entities etc. This PR removes verbiage I came across while reading the docs that specifies the user as a man.

I hope the maintainers of this project understand implicit bias and appreciate PRs like this in the hopes of making the Micronaut community inclusive of all kinds of Engineers.