### PR TITLE
Add missing REDIRECT_URI_MISMATCH enum element

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationError.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationError.java
@@ -38,6 +38,7 @@ public enum AuthorizationError {
     INVALID_REQUEST_URI("invalid_request_uri"),
     REQUEST_NOT_SUPPORTED("request_not_supported"),
     REQUEST_URI_NOT_SUPPORTED("request_uri_not_supported"),
+    REDIRECT_URI_MISMATCH("redirect_uri_mismatch"),
     REGISTRATION_NOT_SUPPORTED("registration_not_supported");
 
     private String errorCode;


### PR DESCRIPTION
Simple fix of redirect URI mismatch error:
```
java.lang.IllegalArgumentException: No enum constant io.micronaut.security.oauth2.endpoint.authorization.response.AuthorizationError.REDIRECT_URI_MISMATCH
	at java.base/java.lang.Enum.valueOf(Enum.java:240)
	at io.micronaut.security.oauth2.endpoint.authorization.response.AuthorizationError.valueOf(AuthorizationError.java:25)
	at io.micronaut.security.oauth2.endpoint.authorization.response.DefaultAuthorizationErrorResponse.getError(DefaultAuthorizationErrorResponse.java:61)
[...]