### PR TITLE
Change to the appropriate class to override

### DIFF
--- a/src/main/docs/guide/authenticationStrategies/jwt/jwtGenerator/jwtGeneratorSignature.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/jwtGenerator/jwtGeneratorSignature.adoc
@@ -9,7 +9,7 @@ To verify signed JWT tokens, you need to have in your app a bean of type link:{a
 link:{api}/io/micronaut/security/token/jwt/signature/rsa/RSASignatureGeneratorConfiguration.html[RSASignatureGeneratorConfiguration],
 link:{api}/io/micronaut/security/token/jwt/signature/ec/ECSignatureGeneratorConfiguration.html[ECSignatureGeneratorConfiguration],
 link:{api}/io/micronaut/security/token/jwt/signature/ec/ECSignatureConfiguration.html[ECSignatureConfiguration], or
-link:{api}/io/micronaut/security/token/jwt/signature/secret/SecretSignatureConfiguration.html[SecretSignatureConfiguration].
+link:{api}/io/micronaut/security/token/jwt/signature/secret/SecretSignature.html[SecretSignature].
 
 You can setup a `SecretSignatureConfiguration` named `generator` easily via configuration properties:
 


### PR DESCRIPTION
overriding SecretSignatureConfiguration has no effect. overriding SecretSignature has the desired effect. One might want to look into the others as well, I have not verified their behavior myself.