### PR TITLE
Make it possible to inject OpenIdProviderMetadata

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
@@ -75,7 +75,7 @@ class OpenIdClientFactory {
      * @param defaultHttpConfiguration The default HTTP client configuration
      * @return The OpenID configuration
      */
-    @Prototype
+    @EachBean(OpenIdClientConfiguration.class)
     DefaultOpenIdProviderMetadata openIdConfiguration(@Parameter OauthClientConfiguration oauthClientConfiguration,
                                                       @Parameter OpenIdClientConfiguration openIdClientConfiguration,
                                                       HttpClientConfiguration defaultHttpConfiguration) {


### PR DESCRIPTION
In the old commit `@EachBean` was changed to `@Prototype` with "bean loop fix" comment but it contained a lot of other changes as well. At least nowadays tests are passing and having access to `OpenIdProviderMetadata` is very much needed because it contains configuration resolved from issuer url.