### PR TITLE
Fixes issue #90 with jwt validation - removing check for supported alg:s

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtils.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtils.java
@@ -89,26 +89,20 @@ public final class JwtTokenValidatorUtils {
 
         final JWSAlgorithm algorithm = signedJWT.getHeader().getAlgorithm();
         for (final SignatureConfiguration config : signatureConfigurations) {
-            if (config.supports(algorithm)) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Using signature configuration: {}", config.toString());
-                }
-                try {
-                    if (config.verify(signedJWT)) {
-                        return Optional.of(signedJWT);
-                    } else {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("JWT Signature verification failed: {}", signedJWT.getParsedString());
-                        }
-                    }
-                } catch (final JOSEException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Using signature configuration: {}", config.toString());
+            }
+            try {
+                if (config.verify(signedJWT)) {
+                    return Optional.of(signedJWT);
+                } else {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Verification fails with signature configuration: {}, passing to the next one", config);
+                        LOG.debug("JWT Signature verification failed: {}", signedJWT.getParsedString());
                     }
                 }
-            } else {
+            } catch (final JOSEException e) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("{}", config.supportedAlgorithmsMessage());
+                    LOG.debug("Verification fails with signature configuration: {}, passing to the next one", config);
                 }
             }
         }


### PR DESCRIPTION
As per comments on issue #90, the specification states that the `alg` key of the jwk-set is optional and we can therefore not use it to check if the key-set supports the relevant algorithm. Specifically this breaks azure openid connect authentication as the azure key-set does not use `alg` and jwt validation therefore always fails with azure active directory. 

Just removing the check seems to do the trick. The `config.verify` call which is still there in the for loop will compare against the `kid` and do the appropriate validations. 

This change seems good to me and fixes the issue with azure openid auth, but I would be the first to admit that I'm not expert-level with jwt, jwk, openid, oauth etc so please feel free to change or reject if there are implications here that I missed. 

closes: https://github.com/micronaut-projects/micronaut-security/issues/90