### PR TITLE
Removing Serializable contract from Authentication

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/Authentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/Authentication.java
@@ -15,10 +15,9 @@
  */
 package io.micronaut.security.authentication;
 
-import javax.annotation.Nonnull;
-import java.io.Serializable;
 import java.security.Principal;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
  * Represents the state of an authentication.
@@ -26,7 +25,7 @@ import java.util.Map;
  * @author James Kleeh
  * @since 1.0
  */
-public interface Authentication extends Principal, Serializable {
+public interface Authentication extends Principal {
 
     /**
      * @return Any additional attributes in the authentication

--- a/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSerializationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSerializationSpec.groovy
@@ -1,37 +1,11 @@
 package io.micronaut.security.authentication
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.micronaut.core.serialize.JdkSerializer
 import io.micronaut.jackson.serialize.JacksonObjectSerializer
 import io.micronaut.security.authentication.jackson.SecurityJacksonModule
 import spock.lang.Specification
 
 class AuthenticationSerializationSpec extends Specification {
-
-    void "test authentication is serializable"() {
-        JdkSerializer serializer = new JdkSerializer()
-
-        when:
-        UserDetails userDetails = new UserDetails("john", ["X", "Y"], [attr1: 1, attr2: 2])
-        byte[] data = serializer.serialize(new AuthenticationUserDetailsAdapter(userDetails)).get()
-        Authentication deserialized = serializer.deserialize(data, Authentication).get()
-
-        then:
-        deserialized.name == "john"
-        deserialized.attributes.roles == ["X", "Y"]
-        deserialized.attributes.attr1 == 1
-        deserialized.attributes.attr2 == 2
-
-        when:
-        data = serializer.serialize(new DefaultAuthentication("john", [roles: ["X", "Y"], attr1: 1, attr2: 2])).get()
-        deserialized = serializer.deserialize(data, Authentication).get()
-
-        then:
-        deserialized.name == "john"
-        deserialized.attributes.roles == ["X", "Y"]
-        deserialized.attributes.attr1 == 1
-        deserialized.attributes.attr2 == 2
-    }
 
     void "test authentication is serializable to json"() {
         ObjectMapper objectMapper = new ObjectMapper()


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-security/issues/108 : removing 'Serializable' from Authentication to avoid breaking the Serialization contract.