### PR TITLE
first validate signature with config alg supported

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtils.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtils.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -90,17 +91,19 @@ public final class JwtTokenValidatorUtils {
 
         final JWSAlgorithm algorithm = signedJWT.getHeader().getAlgorithm();
 
-        for (final SignatureConfiguration config : signatureConfigurations.stream()
+        List<SignatureConfiguration> supportedSignatureConfigurations = signatureConfigurations.stream()
                 .filter(c -> c.supports(algorithm))
-                .collect(Collectors.toList())) {
+                .collect(Collectors.toList());
+
+        for (final SignatureConfiguration config : supportedSignatureConfigurations) {
             Optional<JWT> jwt = verifySignedJWTWithSignatureConfiguration(config, signedJWT);
             if (jwt.isPresent()) {
                 return jwt;
             }
         }
-        for (final SignatureConfiguration config : signatureConfigurations.stream()
-                .filter(c -> !c.supports(algorithm))
-                .collect(Collectors.toList())) {
+        List<SignatureConfiguration> unsupportedSignatureConfigurations = new ArrayList<>(signatureConfigurations);
+        unsupportedSignatureConfigurations.removeAll(supportedSignatureConfigurations);
+        for (final SignatureConfiguration config : unsupportedSignatureConfigurations) {
             Optional<JWT> jwt = verifySignedJWTWithSignatureConfiguration(config, signedJWT);
             if (jwt.isPresent()) {
                 return jwt;

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtilsSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/validator/JwtTokenValidatorUtilsSpec.groovy
@@ -1,0 +1,63 @@
+package io.micronaut.security.token.jwt.validator
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.JWSObject
+import com.nimbusds.jose.Payload
+import com.nimbusds.jose.crypto.MACSigner
+import com.nimbusds.jwt.JWT
+import com.nimbusds.jwt.JWTParser
+import com.nimbusds.jwt.SignedJWT
+import io.micronaut.security.token.jwt.signature.SignatureConfiguration
+import spock.lang.Specification
+
+import java.security.SecureRandom
+
+class JwtTokenValidatorUtilsSpec extends Specification {
+
+    void "compatible signature configuration are used first"() {
+        when:
+        SignedJWT jwt = buildSignedJWT()
+        def incompatibleSignatureConfiguration = Mock(SignatureConfiguration) {
+            1 * supports(_) >> false
+            0 * verify(_)
+        }
+        def compatibleSignatureConfiguration = Mock(SignatureConfiguration) {
+            1 * supports(_) >> true
+            1 * verify(_) >> Optional.of(jwt)
+        }
+
+        Optional<JWT> result = JwtTokenValidatorUtils.validateSignedJWTSignature(jwt, [incompatibleSignatureConfiguration,
+                                                                                 compatibleSignatureConfiguration])
+
+        then:
+        result.isPresent()
+    }
+
+    void "if no compatible signature configuration, every configuration is attempted"() {
+        when:
+        SignedJWT jwt = buildSignedJWT()
+        def incompatibleSignatureConfiguration = Mock(SignatureConfiguration) {
+            1 * supports(_) >> false
+            1 * verify(_) >> Optional.empty()
+        }
+        def compatibleSignatureConfiguration = Mock(SignatureConfiguration) {
+            1 * supports(_) >> false
+            1 * verify(_) >> Optional.of(jwt)
+        }
+        Optional<JWT> result = JwtTokenValidatorUtils.validateSignedJWTSignature(jwt, [incompatibleSignatureConfiguration,
+                                                                                       compatibleSignatureConfiguration])
+        then:
+        result.isPresent()
+    }
+
+    private SignedJWT buildSignedJWT() {
+        JWSObject jwsObject = new JWSObject(new JWSHeader(JWSAlgorithm.HS256), new Payload("Hello, world!"))
+        byte[] sharedKey = new byte[32]
+        new SecureRandom().nextBytes(sharedKey)
+        jwsObject.sign(new MACSigner(sharedKey))
+        JWT jwt = JWTParser.parse(jwsObject.serialize())
+        assert jwt instanceof SignedJWT
+        (SignedJWT) jwt
+    }
+}


### PR DESCRIPTION
After this change: https://github.com/micronaut-projects/micronaut-security/pull/95

We are attempting to validate a signed JWT against every signature configuration. It would be more efficient to attempt to validate the signature against signature configuration which declare themselves as compatible. 