### PR TITLE
refactor: simpler refresh token generator

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/RefreshTokenConfiguration.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/RefreshTokenConfiguration.java
@@ -15,20 +15,33 @@
  */
 package io.micronaut.security.token.jwt.generator;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.core.util.Toggleable;
 
-import java.util.Optional;
-
 /**
- * Refresh token configuration
+ * Configuration for the {@link SignedRefreshTokenGenerator}.
  *
  * @author James Kleeh
+ * @author Sergio del Amo
  * @since 2.0.0
  */
 public interface RefreshTokenConfiguration extends Toggleable {
+    /**
+     *
+     * @return JWS Algorithm
+     */
+    @NonNull
+    JWSAlgorithm getJwsAlgorithm();
 
     /**
-     * @return The optional secret.
+     * @return Secret used to sign the refresh token.
      */
-    Optional<String> getSecret();
+    @NonNull
+    String getSecret();
+
+    /**
+     * @return true if the secret is Base64 encoded
+     */
+    boolean isBase64();
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationProperties.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationProperties.java
@@ -15,53 +15,115 @@
  */
 package io.micronaut.security.token.jwt.generator;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.security.token.jwt.config.JwtConfigurationProperties;
 
-import java.util.Optional;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 /**
- * Refresh token configuration.
+ * {@link ConfigurationProperties} implementation of {@link RefreshTokenConfiguration} to configure {@link SignedRefreshTokenGenerator}.
  *
  * @author James Kleeh
+ * @author Sergio del Amo
  * @since 2.0.0
  */
+@Introspected
+@Requires(property = RefreshTokenConfigurationProperties.PREFIX + ".secret")
+@Requires(property = RefreshTokenConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @ConfigurationProperties(RefreshTokenConfigurationProperties.PREFIX)
 public class RefreshTokenConfigurationProperties implements RefreshTokenConfiguration {
 
     public static final String PREFIX = JwtConfigurationProperties.PREFIX + ".generator.refresh-token";
+
+    /**
+     * The default secure value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final JWSAlgorithm DEFAULT_JWS_ALGORITHM = JWSAlgorithm.HS256;
+
+    /**
+     * The default base64 value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_BASE64 = false;
+
     /**
      * The default enable value.
      */
     @SuppressWarnings("WeakerAccess")
-    public static final boolean DEFAULT_ENABLED = false;
+    public static final boolean DEFAULT_ENABLED = true;
 
     private boolean enabled = DEFAULT_ENABLED;
+
+    @NonNull
+    @NotNull
+    private JWSAlgorithm jwsAlgorithm = DEFAULT_JWS_ALGORITHM;
+
+    @NonNull
+    @NotBlank
     private String secret;
 
-    @Override
-    public boolean isEnabled() {
-        return enabled;
-    }
+    private boolean base64 = DEFAULT_BASE64;
 
     /**
-     * @param enabled Whether refresh tokens should be included in authentication responses. Default value {@value #DEFAULT_ENABLED}.
+     * Sets whether {@link SignedRefreshTokenGenerator} is enabled. Default value ({@value #DEFAULT_ENABLED}).
+     *
+     * @param enabled True if it is enabled
      */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 
-    @Override
-    public Optional<String> getSecret() {
-        return Optional.ofNullable(secret);
+    /**
+     * {@link com.nimbusds.jose.JWSAlgorithm}. Defaults to HS256
+     *
+     * @param jwsAlgorithm JWS Algorithm
+     */
+    public void setJwsAlgorithm(@NonNull JWSAlgorithm jwsAlgorithm) {
+        this.jwsAlgorithm = jwsAlgorithm;
     }
 
     /**
-     * @param secret The secret used to sign refresh token values
+     * @param secret shared secret. For HS256 must be at least 256 bits.
      */
-    public void setSecret(String secret) {
-        ArgumentUtils.requireNonNull("secret", secret);
+    public void setSecret(@NonNull String secret) {
         this.secret = secret;
+    }
+
+    /**
+     * Indicates whether the supplied secret is base64 encoded. Default value {@value #DEFAULT_BASE64}.
+     *
+     * @param base64 boolean flag indicating whether the supplied secret is base64 encoded
+     */
+    public void setBase64(boolean base64) {
+        this.base64 = base64;
+    }
+
+    @NonNull
+    @Override
+    public JWSAlgorithm getJwsAlgorithm() {
+        return jwsAlgorithm;
+    }
+
+    @NonNull
+    @Override
+    public String getSecret() {
+        return secret;
+    }
+
+    @Override
+    public boolean isBase64() {
+        return base64;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/SecurityJwtBeansWithSecurityDisabledSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/SecurityJwtBeansWithSecurityDisabledSpec.groovy
@@ -24,7 +24,6 @@ import io.micronaut.security.token.jwt.endpoints.OauthControllerConfigurationPro
 import io.micronaut.security.token.jwt.generator.AccessRefreshTokenGenerator
 import io.micronaut.security.token.jwt.generator.AccessTokenConfigurationProperties
 import io.micronaut.security.token.jwt.generator.JwtTokenGenerator
-import io.micronaut.security.token.jwt.generator.RefreshTokenConfigurationProperties
 import io.micronaut.security.token.jwt.generator.claims.JWTClaimsSetGenerator
 import io.micronaut.security.token.jwt.render.BearerTokenRenderer
 import io.micronaut.security.token.jwt.signature.ec.ECSignatureFactory
@@ -77,7 +76,6 @@ class SecurityJwtBeansWithSecurityDisabledSpec extends Specification {
                 JWTClaimsSetGenerator,
                 AccessRefreshTokenGenerator,
                 AccessTokenConfigurationProperties,
-                RefreshTokenConfigurationProperties,
                 JwtTokenGenerator,
                 BearerTokenRenderer,
                 ECSignatureFactory,

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/SecurityJwtBeansWithSecurityJwtDisabledSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/SecurityJwtBeansWithSecurityJwtDisabledSpec.groovy
@@ -24,7 +24,6 @@ import io.micronaut.security.token.jwt.endpoints.OauthControllerConfigurationPro
 import io.micronaut.security.token.jwt.generator.AccessRefreshTokenGenerator
 import io.micronaut.security.token.jwt.generator.AccessTokenConfigurationProperties
 import io.micronaut.security.token.jwt.generator.JwtTokenGenerator
-import io.micronaut.security.token.jwt.generator.RefreshTokenConfigurationProperties
 import io.micronaut.security.token.jwt.generator.claims.JWTClaimsSetGenerator
 import io.micronaut.security.token.jwt.render.BearerTokenRenderer
 import io.micronaut.security.token.jwt.signature.ec.ECSignatureFactory
@@ -77,7 +76,6 @@ class SecurityJwtBeansWithSecurityJwtDisabledSpec extends Specification {
                 JWTClaimsSetGenerator,
                 AccessRefreshTokenGenerator,
                 AccessTokenConfigurationProperties,
-                RefreshTokenConfigurationProperties,
                 JwtTokenGenerator,
                 BearerTokenRenderer,
                 ECSignatureFactory,

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/OauthControllerPathConfigurableSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/OauthControllerPathConfigurableSpec.groovy
@@ -24,6 +24,7 @@ class OauthControllerPathConfigurableSpec extends EmbeddedServerSpecification {
     Map<String, Object> getConfiguration() {
         super.configuration + [
             'micronaut.security.endpoints.oauth.enabled': true,
+            'micronaut.security.token.jwt.generator.refresh-token.secret': 'pleaseChangeThisSecretForANewOne',
             'micronaut.security.endpoints.oauth.path': '/newtoken',
         ]
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationEnabledSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationEnabledSpec.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.security.token.jwt.generator
+
+import com.nimbusds.jose.JWSAlgorithm
+import io.micronaut.testutils.ApplicationContextSpecification
+
+class RefreshTokenConfigurationEnabledSpec extends ApplicationContextSpecification {
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'micronaut.security.token.jwt.generator.refresh-token.secret': 'pleaseChangeThisSecretForANewOne',
+        ] as Map<String, Object>
+    }
+
+    void "when you configure a secret a bean of type RefreshTokenConfiguration is found"() {
+        expect:
+        applicationContext.containsBean(RefreshTokenConfiguration)
+
+        when:
+        RefreshTokenConfiguration conf = applicationContext.getBean(RefreshTokenConfiguration)
+
+        then:
+        conf.secret == 'pleaseChangeThisSecretForANewOne'
+
+        and: 'algorithm defaults to HS256'
+        conf.jwsAlgorithm == JWSAlgorithm.HS256
+
+        and: 'base 64 defaults to false'
+        !conf.base64
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.security.token.jwt.generator
+
+import io.micronaut.testutils.ApplicationContextSpecification
+
+class RefreshTokenConfigurationSpec extends ApplicationContextSpecification {
+
+    void "by default no bean of type RefreshTokenConfiguration exists"() {
+        expect:
+        !applicationContext.containsBean(RefreshTokenConfiguration)
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationToggeableSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/RefreshTokenConfigurationToggeableSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.security.token.jwt.generator
+
+import io.micronaut.testutils.ApplicationContextSpecification
+
+class RefreshTokenConfigurationToggeableSpec extends ApplicationContextSpecification {
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'micronaut.security.token.jwt.generator.refresh-token.secret': 'pleaseChangeThisSecretForANewOne',
+                'micronaut.security.token.jwt.generator.refresh-token.enabled': 'false'
+        ] as Map<String, Object>
+    }
+
+    void "by default no bean of type RefreshTokenConfiguration exists"() {
+        expect:
+        !applicationContext.containsBean(RefreshTokenConfiguration)
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/SignedRefreshTokenGeneratorSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/SignedRefreshTokenGeneratorSpec.groovy
@@ -1,0 +1,62 @@
+package io.micronaut.security.token.jwt.generator
+
+import com.nimbusds.jose.JWSObject
+import io.micronaut.security.authentication.UserDetails
+import io.micronaut.testutils.ApplicationContextSpecification
+import spock.lang.Shared
+import spock.lang.Subject
+
+class SignedRefreshTokenGeneratorSpec extends ApplicationContextSpecification {
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'micronaut.security.token.jwt.generator.refresh-token.secret': 'pleaseChangeThisSecretForANewOne',
+        ] as Map<String, Object>
+    }
+
+    @Subject
+    @Shared
+    SignedRefreshTokenGenerator jwsRefreshTokenGenerator = applicationContext.getBean(SignedRefreshTokenGenerator)
+
+    void "get payload, signit and verify it"() {
+        given:
+        UserDetails user = new UserDetails("sherlock", [])
+
+        when: 'can generate a payload'
+        String payload = jwsRefreshTokenGenerator.createKey(user)
+
+        then:
+        payload
+
+        when:
+        Optional<String> signedPayloadOptional = jwsRefreshTokenGenerator.generate(user, payload)
+
+        then:
+        signedPayloadOptional.isPresent()
+
+        when:
+        String signedPayload = signedPayloadOptional.get()
+
+        then: 'signed payload is not same as payload'
+        payload != signedPayload
+
+        when:
+        JWSObject.parse(signedPayload)
+
+        then: 'signed payload is a JWS object'
+        noExceptionThrown()
+
+        when:
+        Optional<String> validated = jwsRefreshTokenGenerator.validate(signedPayload)
+
+        then:
+        validated.isPresent()
+        validated.get() == payload
+
+        when:
+        validated = jwsRefreshTokenGenerator.validate('bogus')
+
+        then:
+        !validated.isPresent()
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/testutils/ApplicationContextSpecification.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/testutils/ApplicationContextSpecification.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.testutils
+
+import io.micronaut.context.ApplicationContext
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class ApplicationContextSpecification extends Specification implements ConfigurationFixture {
+
+    @Shared
+    ApplicationContext applicationContext = ApplicationContext.run(configuration)
+}

--- a/src/main/docs/guide/authenticationStrategies/jwt/jwtGenerator.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/jwtGenerator.adoc
@@ -3,5 +3,3 @@ Micronaut relies on https://connect2id.com/products/nimbus-jose-jwt[Nimbus JOSE 
 The following configuration options are available:
 
 include::{includedir}configurationProperties/io.micronaut.security.token.jwt.generator.AccessTokenConfigurationProperties.adoc[]
-
-include::{includedir}configurationProperties/io.micronaut.security.token.jwt.generator.RefreshTokenConfigurationProperties.adoc[]

--- a/src/main/docs/guide/endpoints/refresh.adoc
+++ b/src/main/docs/guide/endpoints/refresh.adoc
@@ -1,14 +1,31 @@
 IMPORTANT: The refresh token functionality has changed dramatically starting in Micronaut Security 2.0. Please read this section if you are upgrading as it now behaves differently.
 
-Refresh tokens are non JWT tokens that can be used to obtain a new access token. By default, refresh tokens are disabled. To enable refresh tokens, the enabled flag in the table below must be set to true. In addition, applications must provide an implementation of api:security.token.refresh.RefreshTokenPersistence[].
+Refresh tokens can be used to obtain a new access token. By default, refresh tokens are not generated.
+
+To enable refresh token generation, you have to provide beans of type api:security.token.generator.RefreshTokenGenerator[],
+api:security.token.validator.RefreshTokenValidator[] and api:security.token.refresh.RefreshTokenPersistence[].
+
+The api:security.token.generator.RefreshTokenGenerator[] API is responsible for generating the token that gets included in the response.
+
+api:io.micronaut.security.token.jwt.generator.SignedRefreshTokenGenerator[] an implementation of both api:security.token.generator.RefreshTokenGenerator[] and  api:security.token.validator.RefreshTokenValidator[] has been provided. It creates and verifies a JWS (JSON web signature) encoded object whose payload is a UUID with a hash-based message authentication code (HMAC). You can configure it:
 
 include::{includedir}configurationProperties/io.micronaut.security.token.jwt.generator.RefreshTokenConfigurationProperties.adoc[]
 
-The api:security.token.generator.RefreshTokenGenerator[] API is responsible for generating the token that gets included in the response. A api:security.token.jwt.generator.SignedRefreshTokenGenerator[default implementation] has been provided that signs a UUID with the configured secret (see the table above).
+To enable it you will need to provide a secret:
+
+```yaml
+micronaut:
+    security:
+        token:
+            jwt:
+                generator:
+                    refresh-token:
+                        secret: 'pleaseChangeThisSecretForANewOne'
+```
 
 After a token is generated, this library has no knowledge of it. The value is not cached or stored anywhere. It is up to each application to decide how to store the token, support revocation, and retrieve user details when given a token.
 
-The api:security.token.refresh.RefreshTokenPersistence[] implementation will receive an event when refresh tokens are generated and then must persist the token along with a link to the user that it was generated for. The user information and the token are both available in the api:security.token.event.RefreshTokenGeneratedEvent[].
+The api:security.token.refresh.RefreshTokenPersistence[] implementation will receive an event when refresh tokens is generated and then must persist the token along with a link to the user that it was generated for. The user information and the token are both available in the api:security.token.event.RefreshTokenGeneratedEvent[].
 
 ### Refreshing the Token
 
@@ -18,9 +35,9 @@ include::{includedir}configurationProperties/io.micronaut.security.token.jwt.end
 
 The controller exposes an endpoint as defined by https://tools.ietf.org/html/rfc6749#section-6[section 6 of the OAuth 2.0 spec] - Refreshing an Access Token.
 
-The refresh token endpoint uses the api:security.token.validator.RefreshTokenValidator[] API to verify the token matches the format that is expected. The api:security.token.jwt.generator.SignedRefreshTokenGenerator[default implementation] attempts to decrypt the token with the provided secret. Any validator implementations should not be concerned with revocation status, existence, or any other persistence related validation.
+The refresh token endpoint uses the api:security.token.validator.RefreshTokenValidator[] API to verify the token matches the format that is expected. api:io.micronaut.security.token.jwt.generator.SignedRefreshTokenGenerator[] attempts to verify the signature and returns the payload. Any validator implementations should not be concerned with revocation status, existence, or any other persistence related validation.
 
-If the validator successfully validates the token, it is then passed to a api:security.token.refresh.RefreshTokenPersistence[] implementation, which each application must provide. A new access token is then created from the user details returned and then sent in the response.
+If the validator successfully validates the token, it is then passed to a api:security.token.refresh.RefreshTokenPersistence[] implementation, which each application must provide. A new access token is then created from the user details returned by `RefreshTokenPersistence::getUserDetails` and then sent in the response.
 
 Here is an example of a refresh token request. Send a POST request to the `/oauth/access_token` endpoint:
 


### PR DESCRIPTION
This is an attempt to simplify `refresh token` generation. 

This is our current implementation

https://github.com/micronaut-projects/micronaut-security/blob/5eab9f801fb43a11c7575078b83be7c648c84ac7/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/SignedRefreshTokenGenerator.java

and this is my proposed solution: 

https://github.com/micronaut-projects/micronaut-security/blob/simpler-refresh-token-generator/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/JwsRefreshTokenGenerator.java

It leverages [Nimbus JOSE](https://connect2id.com/products/nimbus-jose-jwt/examples/jws-with-hmac), which is already in the classpath, to sign a payload. 

Moreover, it has more configuration options. For example, it enables you to configure a different JWS Algorithm than default HS256.

It should be more familiar to Micronaut users since it is similar configuration than our [SecretSignatureConfiguration](https://github.com/micronaut-projects/micronaut-security/blob/master/security-jwt/src/main/java/io/micronaut/security/token/jwt/signature/secret/SecretSignatureConfiguration.java) used to sign JWT. 

Moreover, this PR removes the need to enable `refresh-token`. 

Instead of having:

```
micronaut:
  security:
    token:
      jwt:
        generator:
          refresh-token:
            enabled: true 
            secret: pleaseChangeThisSecretForANewOne 
```

it will suffice to have: 

```
micronaut:
  security:
    token:
      jwt:
        generator:
          refresh-token:
            secret: pleaseChangeThisSecretForANewOne 
```

That it is to say. When you have a bean of type `RefreshTokenGenerator`, `RefreshTokenValidator`, `RefreshTokenPersistence`, `AccessRefreshTokenGenerator` generates a refresh-token. 