### PR TITLE
Don`t call onComplete after onError in tests

### DIFF
--- a/security-jwt/src/test/groovy/io/micronaut/docs/signandencrypt/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/docs/signandencrypt/AuthenticationProviderUserPassword.groovy
@@ -23,10 +23,9 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         return Flowable.create({ emitter ->
             if (authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password') {
                 emitter.onNext(new UserDetails('user', []))
-                emitter.onComplete();
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
-                emitter.onComplete()
             }
         }, BackpressureStrategy.ERROR)
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/AuthenticationProviderUserPassword.groovy
@@ -22,10 +22,10 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({ emitter ->
             if (authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password') {
                 emitter.onNext(new UserDetails('user', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
         }, BackpressureStrategy.ERROR)
 
 

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/accesstokenexpiration/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/accesstokenexpiration/AuthenticationProviderUserPassword.groovy
@@ -23,10 +23,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({ emitter ->
             if (authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password') {
                 emitter.onNext(new UserDetails('user', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
         }, BackpressureStrategy.ERROR)
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/bearer/AccessRefreshTokenLoginHandlerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/bearer/AccessRefreshTokenLoginHandlerSpec.groovy
@@ -105,10 +105,9 @@ class AccessRefreshTokenLoginHandlerSpec extends EmbeddedServerSpecification {
                         emitter.onError(new AuthenticationException(new AuthenticationFailed(AuthenticationFailureReason.CREDENTIALS_DO_NOT_MATCH)))
                     } else {
                         emitter.onNext(new UserDetails(username, (username == "admin") ? ["ROLE_ADMIN"] : ["foo", "bar"]))
+                        emitter.onComplete()
                     }
                 }
-                emitter.onComplete()
-
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieAuthenticationSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieAuthenticationSpec.groovy
@@ -184,10 +184,10 @@ class JwtCookieAuthenticationSpec extends GebEmbeddedServerSpecification {
                 if ( authenticationRequest.getIdentity().equals("sherlock") &&
                         authenticationRequest.getSecret().equals("password") ) {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieExpirationSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieExpirationSpec.groovy
@@ -58,10 +58,11 @@ class JwtCookieExpirationSpec extends EmbeddedServerSpecification {
                 if ( authenticationRequest.getIdentity().equals("sherlock") &&
                         authenticationRequest.getSecret().equals("password") ) {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieMaxAgeSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieMaxAgeSpec.groovy
@@ -57,10 +57,11 @@ class JwtCookieMaxAgeSpec extends EmbeddedServerSpecification {
             Flowable.create({ emitter ->
                 if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookiePathAndDomainSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookiePathAndDomainSpec.groovy
@@ -139,10 +139,11 @@ class JwtCookiePathAndDomainSpec extends EmbeddedServerSpecification {
             Flowable.create({ emitter ->
                 if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteInvalidSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteInvalidSpec.groovy
@@ -61,10 +61,11 @@ class JwtCookieSameSiteInvalidSpec extends EmbeddedServerSpecification {
             Flowable.create({ emitter ->
                 if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteNoDefaultSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteNoDefaultSpec.groovy
@@ -60,10 +60,11 @@ HttpRequest loginRequest = HttpRequest.POST('/login', new LoginForm(username: 's
             Flowable.create({ emitter ->
                 if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieSameSiteSpec.groovy
@@ -62,10 +62,11 @@ class JwtCookieSameSiteSpec extends EmbeddedServerSpecification {
             Flowable.create({ emitter ->
                 if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                     emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/LoginControllerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/LoginControllerSpec.groovy
@@ -110,10 +110,11 @@ class LoginControllerSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
 
             }, BackpressureStrategy.ERROR)
         }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/OauthControllerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/endpoints/OauthControllerSpec.groovy
@@ -277,10 +277,11 @@ class OauthControllerSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/events/EventListenerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/events/EventListenerSpec.groovy
@@ -75,10 +75,11 @@ class EventListenerSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/refreshtokenexpiration/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/refreshtokenexpiration/AuthenticationProviderUserPassword.groovy
@@ -23,10 +23,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({emitter ->
             if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('user', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
 
         }, BackpressureStrategy.ERROR)
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksSpec.groovy
@@ -178,10 +178,11 @@ class JwksSpec extends Specification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/rsa/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/rsa/AuthenticationProviderUserPassword.groovy
@@ -23,10 +23,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({emitter ->
             if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('user', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
 
         }, BackpressureStrategy.ERROR)
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/rsagenerationvalidation/AuthenticationProviderUserPassword.java
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/rsagenerationvalidation/AuthenticationProviderUserPassword.java
@@ -24,10 +24,11 @@ public class AuthenticationProviderUserPassword implements AuthenticationProvide
         return Flowable.create(emitter -> {
             if (authenticationRequest.getIdentity().equals("user") && authenticationRequest.getSecret().equals("password")) {
                 emitter.onNext(new UserDetails("user", Collections.emptyList()));
+                emitter.onComplete();
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()));
             }
-            emitter.onComplete();
+
         }, BackpressureStrategy.ERROR);
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/multitenancy/principal/AuthenticationProviderUserPassword.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/multitenancy/principal/AuthenticationProviderUserPassword.groovy
@@ -19,12 +19,14 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({ emitter ->
             if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "elementary") {
                 emitter.onNext(new UserDetails('sherlock', []))
+                emitter.onComplete()
             } else if ( authenticationRequest.getIdentity() == "watson" && authenticationRequest.getSecret() == "elementary") {
                 emitter.onNext(new UserDetails('watson', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
 
         }, BackpressureStrategy.ERROR)
     }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/propagation/TokenPropagationSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/propagation/TokenPropagationSpec.groovy
@@ -174,10 +174,11 @@ class TokenPropagationSpec extends Specification {
                         Arrays.asList("sherlock", "watson").contains(authenticationRequest.getIdentity().toString()) &&
                         authenticationRequest.getSecret().equals("elementary")) {
                     emitter.onNext(new UserDetails(authenticationRequest.getIdentity().toString(), new ArrayList<>()))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
@@ -136,7 +136,6 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
                                 LOG.trace("Token validation failed. Failing authentication");
                             }
                             emitter.onError(new AuthenticationException(new AuthenticationFailed("JWT validation failed")));
-                            emitter.onComplete();
                         }
                     }, BackpressureStrategy.ERROR);
                 });

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OpenIdPasswordAuthenticationProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OpenIdPasswordAuthenticationProvider.java
@@ -106,7 +106,6 @@ public class OpenIdPasswordAuthenticationProvider implements AuthenticationProvi
                             }
                         } else {
                             emitter.onError(new AuthenticationException(new AuthenticationFailed("JWT validation failed")));
-                            emitter.onComplete();
                         }
                     }, BackpressureStrategy.ERROR);
                 });

--- a/security-session/src/test/groovy/io/micronaut/docs/security/session/AuthenticationProviderUserPassword.groovy
+++ b/security-session/src/test/groovy/io/micronaut/docs/security/session/AuthenticationProviderUserPassword.groovy
@@ -22,10 +22,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider  {
         Flowable.create({ emitter ->
             if ( authenticationRequest.getIdentity() == "sherlock" && authenticationRequest.getSecret() == "password") {
                 emitter.onNext(new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>()))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
         }, BackpressureStrategy.ERROR)
     }
 }

--- a/security-session/src/test/groovy/io/micronaut/security/session/SessionPriorLoginSpec.groovy
+++ b/security-session/src/test/groovy/io/micronaut/security/session/SessionPriorLoginSpec.groovy
@@ -66,10 +66,11 @@ class SessionPriorLoginSpec extends GebEmbeddedServerSpecification {
                         authenticationRequest.getSecret().equals("password") ) {
                     UserDetails userDetails = new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>());
                     emitter.onNext(userDetails);
+                    emitter.onComplete();
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()));
                 }
-                emitter.onComplete();
+
 
             }, BackpressureStrategy.ERROR);
         }

--- a/security-session/src/test/groovy/io/micronaut/security/session/SessionReUseSpec.groovy
+++ b/security-session/src/test/groovy/io/micronaut/security/session/SessionReUseSpec.groovy
@@ -111,10 +111,10 @@ class SessionReUseSpec extends EmbeddedServerSpecification {
                         authenticationRequest.getSecret().equals("password") ) {
                     UserDetails userDetails = new UserDetails((String) authenticationRequest.getIdentity(), new ArrayList<>());
                     emitter.onNext(userDetails);
+                    emitter.onComplete();
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()));
                 }
-                emitter.onComplete();
 
             }, BackpressureStrategy.ERROR);
         }

--- a/security/src/test/groovy/io/micronaut/docs/security/authentication/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/authentication/AuthenticationProviderUserPassword.groovy
@@ -29,7 +29,6 @@ public class AuthenticationProviderUserPassword implements AuthenticationProvide
                 emitter.onComplete();
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()));
-                emitter.onComplete();
             }
         }, BackpressureStrategy.ERROR);
 

--- a/security/src/test/groovy/io/micronaut/docs/security/principalparam/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/principalparam/AuthenticationProviderUserPassword.groovy
@@ -26,10 +26,11 @@ public class AuthenticationProviderUserPassword implements AuthenticationProvide
         return Flowable.create({emitter ->
             if (authenticationRequest.getIdentity().equals("user") && authenticationRequest.getSecret().equals("password")) {
                 emitter.onNext(new UserDetails("user", new ArrayList<>()));
+                emitter.onComplete();
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()));
             }
-            emitter.onComplete();
+
 
         }, BackpressureStrategy.ERROR)
 

--- a/security/src/test/groovy/io/micronaut/docs/security/securityRule/builtinendpoints/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/securityRule/builtinendpoints/AuthenticationProviderUserPassword.groovy
@@ -23,10 +23,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({emitter ->
             if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('user', []))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
 
         }, BackpressureStrategy.ERROR)
     }

--- a/security/src/test/groovy/io/micronaut/docs/security/securityRule/intercepturlmap/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/securityRule/intercepturlmap/AuthenticationProviderUserPassword.groovy
@@ -25,10 +25,11 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
                 emitter.onNext(new UserDetails((String) authenticationRequest.identity, []))
             } else if ( authenticationRequest.identity == 'admin' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails((String) authenticationRequest.identity, ['ROLE_ADMIN']))
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
         }, BackpressureStrategy.ERROR)
 
     }

--- a/security/src/test/groovy/io/micronaut/docs/security/securityRule/permitall/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/securityRule/permitall/AuthenticationProviderUserPassword.groovy
@@ -23,14 +23,14 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({emitter ->
             if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('user', []))
-
+                emitter.onComplete()
             } else if ( authenticationRequest.identity == 'admin' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('admin', ['ROLE_ADMIN']))
-
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
             }
-            emitter.onComplete()
+
         }, BackpressureStrategy.ERROR)
     }
 }

--- a/security/src/test/groovy/io/micronaut/docs/security/securityRule/secured/AuthenticationProviderUserPassword.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/securityRule/secured/AuthenticationProviderUserPassword.groovy
@@ -23,14 +23,15 @@ class AuthenticationProviderUserPassword implements AuthenticationProvider {
         Flowable.create({emitter ->
             if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('user', []))
-
+                emitter.onComplete()
             } else if ( authenticationRequest.identity == 'admin' && authenticationRequest.secret == 'password' ) {
                 emitter.onNext(new UserDetails('admin', ['ROLE_ADMIN']))
-
+                emitter.onComplete()
             } else {
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                emitter.onComplete()
             }
-            emitter.onComplete()
+
         }, BackpressureStrategy.ERROR)
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/HealthSensitivitySpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/HealthSensitivitySpec.groovy
@@ -217,11 +217,11 @@ class HealthSensitivitySpec extends Specification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
-
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security/src/test/groovy/io/micronaut/security/authentication/AuthenticatorSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/AuthenticatorSpec.groovy
@@ -61,7 +61,6 @@ class AuthenticatorSpec extends Specification {
         def authProviderFailed = Stub(AuthenticationProvider) {
             authenticate(_, _) >> Flowable.create({ emitter ->
                 emitter.onError(new AuthenticationException(new AuthenticationFailed()))
-                emitter.onComplete()
             }, BackpressureStrategy.ERROR)
         }
         Authenticator authenticator = new Authenticator([authProviderFailed], new SecurityConfigurationProperties())
@@ -80,7 +79,6 @@ class AuthenticatorSpec extends Specification {
                 Stub(AuthenticationProvider) {
                     authenticate(_, _) >> Flowable.create({ emitter ->
                         emitter.onError(new AuthenticationException(new AuthenticationFailed("failed")))
-                        emitter.onComplete()
                     }, BackpressureStrategy.ERROR)
                 },
                 Stub(AuthenticationProvider) {
@@ -110,7 +108,6 @@ class AuthenticatorSpec extends Specification {
                 Stub(AuthenticationProvider) {
                     authenticate(_, _) >>  Flowable.create({ emitter ->
                         emitter.onError(new AuthenticationException(new AuthenticationFailed("failed")))
-                        emitter.onComplete()
                     }, BackpressureStrategy.ERROR)
                 },
                 Stub(AuthenticationProvider) {
@@ -143,7 +140,6 @@ class AuthenticatorSpec extends Specification {
                 Stub(AuthenticationProvider) {
                     authenticate(_, _) >> Flowable.create({ emitter ->
                         emitter.onError(new AuthenticationException(new AuthenticationFailed("failed")))
-                        emitter.onComplete()
                     }, BackpressureStrategy.ERROR)
                 },
         ]

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -366,8 +366,8 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
                     emitter.onError(new AuthenticationException(authenticationFailed))
                 } else {
                     emitter.onNext(new UserDetails(username, (username == "admin") ?  ["ROLE_ADMIN"] : ["foo", "bar"]));
+                    emitter.onComplete()
                 }
-                emitter.onComplete()
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security/src/test/groovy/io/micronaut/security/denyall/DenyAllSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/denyall/DenyAllSpec.groovy
@@ -99,10 +99,11 @@ class DenyAllSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', ['ROLE_USER']))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
 
             }, BackpressureStrategy.ERROR)
         }

--- a/security/src/test/groovy/io/micronaut/security/events/EventListenerSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/events/EventListenerSpec.groovy
@@ -155,10 +155,11 @@ class EventListenerSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security/src/test/groovy/io/micronaut/security/rolesallowed/RolesAllowedSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rolesallowed/RolesAllowedSpec.groovy
@@ -81,10 +81,11 @@ class RolesAllowedSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', ['ROLE_USER']))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security/src/test/groovy/io/micronaut/security/token/basicauth/BasicAuthSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/token/basicauth/BasicAuthSpec.groovy
@@ -100,10 +100,11 @@ class BasicAuthSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', []))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
 
             }, BackpressureStrategy.ERROR)
         }

--- a/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceCustomRolesKeySpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceCustomRolesKeySpec.groovy
@@ -85,10 +85,11 @@ class SecurityServiceCustomRolesKeySpec extends EmbeddedServerSpecification {
                     emitter.onNext(new UserDetails('user', [], [customRoles: ['ROLE_USER']]))
                 } else if ( authenticationRequest.identity == 'user3' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', [], [otherCustomRoles: ['ROLE_USER']]))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }

--- a/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceSpec.groovy
@@ -109,10 +109,11 @@ class SecurityServiceSpec extends EmbeddedServerSpecification {
             Flowable.create({emitter ->
                 if ( authenticationRequest.identity == 'user' && authenticationRequest.secret == 'password' ) {
                     emitter.onNext(new UserDetails('user', ['ROLE_USER']))
+                    emitter.onComplete()
                 } else {
                     emitter.onError(new AuthenticationException(new AuthenticationFailed()))
                 }
-                emitter.onComplete()
+
             }, BackpressureStrategy.ERROR)
         }
     }


### PR DESCRIPTION
Based on https://github.com/micronaut-projects/micronaut-security/pull/287#discussion_r439682505 I have tried to remove the calls to onComplete after onError in our tests. However, it breaks the tests. It fails locally for me If I run ./gradlew build

@jameskleeh  Any idea what am I missing?