### PR TITLE
hasRole check should case insensitive validation in both ways for String and Collections.

### DIFF
--- a/security/src/main/java/io/micronaut/security/utils/DefaultSecurityService.java
+++ b/security/src/main/java/io/micronaut/security/utils/DefaultSecurityService.java
@@ -37,7 +37,6 @@ public class DefaultSecurityService implements SecurityService {
     private final TokenConfiguration tokenConfiguration;
 
     /**
-     *
      * @param tokenConfiguration Token Configuration
      */
     public DefaultSecurityService(TokenConfiguration tokenConfiguration) {
@@ -89,8 +88,8 @@ public class DefaultSecurityService implements SecurityService {
     /**
      * If the current user has a specific role.
      *
-     * @param role the authority to check
-     * @param  rolesKey The map key to be used in the authentications attributes. E.g. "roles".
+     * @param role     the authority to check
+     * @param rolesKey The map key to be used in the authentications attributes. E.g. "roles".
      * @return true if the current user has the authority, false otherwise
      */
     @Override
@@ -101,14 +100,30 @@ public class DefaultSecurityService implements SecurityService {
         return getAuthentication().map(authentication -> {
             if (authentication.getAttributes() != null && authentication.getAttributes().containsKey(rolesKey)) {
                 Object authorities = authentication.getAttributes().get(rolesKey);
-                if (authorities instanceof Collection) {
-                    return ((Collection) authorities).contains(role);
-                } else if (authorities instanceof String) {
-                    return ((String) authorities).equalsIgnoreCase(role);
-                }
+                return containsRoleIgnoreCase(role, authorities);
             }
             return false;
         }).orElse(false);
+    }
+
+    /**
+     * Checks if current role is available in authorities instance.
+     * Performed checks are case-insensitive.
+     *
+     * @param role        the role to check
+     * @param authorities a role or collection of roles
+     * @return true if role is available otherwise false
+     */
+    private boolean containsRoleIgnoreCase(String role, Object authorities) {
+        boolean contains = false;
+        if (authorities instanceof Collection) {
+            Collection roles = ((Collection) authorities);
+            contains = roles.stream().anyMatch((currentRole) -> role.equalsIgnoreCase(currentRole.toString()));
+        } else if (authorities instanceof String) {
+            contains = ((String) authorities).equalsIgnoreCase(role);
+        }
+
+        return contains;
     }
 
 }

--- a/security/src/main/java/io/micronaut/security/utils/DefaultSecurityService.java
+++ b/security/src/main/java/io/micronaut/security/utils/DefaultSecurityService.java
@@ -100,7 +100,7 @@ public class DefaultSecurityService implements SecurityService {
         return getAuthentication().map(authentication -> {
             if (authentication.getAttributes() != null && authentication.getAttributes().containsKey(rolesKey)) {
                 Object authorities = authentication.getAttributes().get(rolesKey);
-                return containsRoleIgnoreCase(role, authorities);
+                return hasRoleIgnoreCase(role, authorities);
             }
             return false;
         }).orElse(false);
@@ -114,16 +114,16 @@ public class DefaultSecurityService implements SecurityService {
      * @param authorities a role or collection of roles
      * @return true if role is available otherwise false
      */
-    private boolean containsRoleIgnoreCase(String role, Object authorities) {
-        boolean contains = false;
+    private boolean hasRoleIgnoreCase(String role, Object authorities) {
+        boolean hasRole = false;
         if (authorities instanceof Collection) {
             Collection roles = ((Collection) authorities);
-            contains = roles.stream().anyMatch((currentRole) -> role.equalsIgnoreCase(currentRole.toString()));
+            hasRole = roles.stream().anyMatch((currentRole) -> role.equalsIgnoreCase(currentRole.toString()));
         } else if (authorities instanceof String) {
-            contains = ((String) authorities).equalsIgnoreCase(role);
+            hasRole = ((String) authorities).equalsIgnoreCase(role);
         }
 
-        return contains;
+        return hasRole;
     }
 
 }

--- a/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/utils/SecurityServiceSpec.groovy
@@ -79,6 +79,40 @@ class SecurityServiceSpec extends Specification {
         !hasRole
     }
 
+    void "verify SecurityService.isCurrentUserInRole() with case insensitive roles"() {
+        when:
+        HttpRequest request = HttpRequest.GET("${controllerPath}/roles?role=ROLE_USER")
+                .basicAuth("user", "password")
+        Boolean hasRole = client.toBlocking().retrieve(request, Boolean)
+
+        then:
+        hasRole
+
+        when:
+        request = HttpRequest.GET("${controllerPath}/roles?role=role_user")
+                .basicAuth("user", "password")
+        hasRole = client.toBlocking().retrieve(request, Boolean)
+
+        then:
+        hasRole
+
+        when:
+        request = HttpRequest.GET("${controllerPath}/roles?role=Role_User")
+                .basicAuth("user", "password")
+        hasRole = client.toBlocking().retrieve(request, Boolean)
+
+        then:
+        hasRole
+
+        when:
+        request = HttpRequest.GET("${controllerPath}/roles?role=role_admin")
+                .basicAuth("user", "password")
+        hasRole = client.toBlocking().retrieve(request, Boolean)
+
+        then:
+        !hasRole
+    }
+
     void "verify SecurityService.currentUserLogin()"() {
         when:
         String username = client.toBlocking().retrieve(HttpRequest.GET("${controllerPath}/currentuser").basicAuth("user", "password"), String)


### PR DESCRIPTION
As software engineer I would expect roles checks to be case-insensitive.

This change will perform equalsIgnoreCase for both strings and collections of roles.