### PR TITLE
Check if the Authorization value is long enough to substring the prefix

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
@@ -20,7 +20,6 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpHeaderValues;
 import io.micronaut.http.HttpRequest;
-import io.micronaut.security.config.SecurityConfigurationProperties;
 import io.micronaut.security.filters.AuthenticationFetcher;
 import io.micronaut.security.token.config.TokenConfiguration;
 import io.reactivex.Flowable;

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
@@ -60,6 +60,7 @@ public class BasicAuthAuthenticationFetcher implements AuthenticationFetcher {
     @Override
     public Publisher<Authentication> fetchAuthentication(HttpRequest<?> request) {
         Optional<UsernamePasswordCredentials> credentials = request.getHeaders().getAuthorization()
+                .filter(s -> s.length() >= PREFIX.length())
                 .map(s -> s.substring(PREFIX.length()))
                 .flatMap(this::decode);
 


### PR DESCRIPTION
The authentication fetcher `BasicAuthAuthenticationFetcher` strips away the leading `Basic ` prefix in order to get the Base64 encoded payload. The problem is that this substringing lacks a check that ensures that the header field has at least the length of the prefix (If not, `substring` will throw a `StringIndexOutOfBoundsException` exception that breaks the authentication flow).

Example:

`Authorization: ` --> StringIndexOutOfBoundsException
`Authorization: 123` --> StringIndexOutOfBoundsException
`Authorization: Basic` --> StringIndexOutOfBoundsException
`Authorization: Basic ` --> `Authorization: Basic` (Header values are trimmed) -->  StringIndexOutOfBoundsException
`Authorization: Basic <PROPERBASE64PAYLOAD>` --> Ok

This PR adds a check that ensure that the length of the header field is >= the prefix length. If not, an `Optional.empty` is passed down the chain and the following map/flatMaps actions are not executed/skipped