### PR TITLE
feat: allow NonceClaimValidator to be disabled

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/DefaultOpenIdTokenResponseValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/DefaultOpenIdTokenResponseValidator.java
@@ -61,7 +61,7 @@ public class DefaultOpenIdTokenResponseValidator implements OpenIdTokenResponseV
      */
     public DefaultOpenIdTokenResponseValidator(Collection<OpenIdClaimsValidator> idTokenValidators,
                                                Collection<GenericJwtClaimsValidator> genericJwtClaimsValidators,
-                                               NonceClaimValidator nonceClaimValidator,
+                                               @Nullable NonceClaimValidator nonceClaimValidator,
                                                JwkValidator jwkValidator) {
         this.openIdClaimsValidators = idTokenValidators;
         this.genericJwtClaimsValidators = genericJwtClaimsValidators;
@@ -93,6 +93,12 @@ public class DefaultOpenIdTokenResponseValidator implements OpenIdTokenResponseV
                 if (genericJwtClaimsValidators.stream().allMatch(validator -> validator.validate(claims))) {
                     if (openIdClaimsValidators.stream().allMatch(validator ->
                             validator.validate(claims, clientConfiguration, openIdProviderMetadata))) {
+                        if (nonceClaimValidator == null) {
+                            if (LOG.isTraceEnabled()) {
+                                LOG.trace("Skipping nonce validation because no bean of type {} present. ", NonceClaimValidator.class.getSimpleName());
+                            }
+                            return jwt;
+                        }
                         if (nonceClaimValidator.validate(claims, clientConfiguration, openIdProviderMetadata, nonce)) {
                             return jwt;
                         }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidator.java
@@ -15,11 +15,15 @@
  */
 package io.micronaut.security.oauth2.endpoint.token.response.validation;
 
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.endpoint.token.response.OpenIdClaims;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.security.token.jwt.validator.JwtClaimsValidator;
+
 import javax.inject.Singleton;
 
 /**
@@ -28,6 +32,7 @@ import javax.inject.Singleton;
  * @author James Kleeh
  * @since 1.2.0
  */
+@Requires(property = JwtClaimsValidator.PREFIX + ".nonce", notEquals = StringUtils.FALSE)
 @Singleton
 public class NonceClaimValidator {
 

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidatorDisableSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidatorDisableSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.security.oauth2.endpoint.token.response.validation
+
+import io.micronaut.security.oauth2.ApplicationContextSpecification
+
+class NonceClaimValidatorDisableSpec extends ApplicationContextSpecification {
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + ['micronaut.security.token.jwt.claims-validators.nonce': false]
+    }
+
+    void "NonceClaimsValidator can be disabled with micronaut.security.token.jwt.claims-validators.nonce.enabled"() {
+        expect:
+        !applicationContext.containsBean(NonceClaimValidator)
+    }
+}

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidatorSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/NonceClaimValidatorSpec.groovy
@@ -1,0 +1,11 @@
+package io.micronaut.security.oauth2.endpoint.token.response.validation
+
+import io.micronaut.security.oauth2.ApplicationContextSpecification
+
+class NonceClaimValidatorSpec extends ApplicationContextSpecification {
+
+    void "NonceClaimsValidator bean exists by default"() {
+        expect:
+        applicationContext.containsBean(NonceClaimValidator)
+    }
+}


### PR DESCRIPTION
Other claims validator such as [`ExpirationJwtClaimsValidator.java`](https://github.com/micronaut-projects/micronaut-security/blob/master/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/ExpirationJwtClaimsValidator.java) or  [`SubjectNotNullJwtClaimsValidator`](https://github.com/micronaut-projects/micronaut-security/blob/master/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/SubjectNotNullJwtClaimsValidator.java) can be disabled via configuration. I think we should do the same for the nonce validator. 