### PR TITLE
refactor: split DefaultOpenIdAuthorization methods

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
@@ -16,20 +16,25 @@
 package io.micronaut.security.oauth2.endpoint.authorization.response;
 
 import com.nimbusds.jwt.JWT;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.security.authentication.AuthenticationException;
 import io.micronaut.security.authentication.AuthenticationFailed;
 import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.endpoint.SecureEndpoint;
 import io.micronaut.security.oauth2.endpoint.authorization.state.InvalidStateException;
 import io.micronaut.security.oauth2.endpoint.authorization.state.State;
+import io.micronaut.security.oauth2.endpoint.authorization.state.validation.StateValidator;
 import io.micronaut.security.oauth2.endpoint.token.request.TokenEndpointClient;
 import io.micronaut.security.oauth2.endpoint.token.request.context.OpenIdCodeTokenRequestContext;
-import io.micronaut.security.oauth2.endpoint.token.response.*;
+import io.micronaut.security.oauth2.endpoint.token.response.DefaultOpenIdUserDetailsMapper;
+import io.micronaut.security.oauth2.endpoint.token.response.JWTOpenIdClaims;
+import io.micronaut.security.oauth2.endpoint.token.response.OpenIdClaims;
+import io.micronaut.security.oauth2.endpoint.token.response.OpenIdTokenResponse;
+import io.micronaut.security.oauth2.endpoint.token.response.OpenIdUserDetailsMapper;
 import io.micronaut.security.oauth2.endpoint.token.response.validation.OpenIdTokenResponseValidator;
-import io.micronaut.security.oauth2.endpoint.authorization.state.validation.StateValidator;
-import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
 import io.micronaut.security.oauth2.url.OauthRouteUrlBuilder;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
@@ -37,7 +42,6 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Singleton;
 import java.text.ParseException;
 import java.util.Optional;
@@ -86,59 +90,124 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
             OpenIdProviderMetadata openIdProviderMetadata,
             @Nullable OpenIdUserDetailsMapper userDetailsMapper,
             SecureEndpoint tokenEndpoint) {
+        try {
+            validateState(authorizationResponse, clientConfiguration);
+        } catch (InvalidStateException e) {
+            return Flowable.just(new AuthenticationFailed("State validation failed: " + e.getMessage()));
+        }
+        return Flowable.fromPublisher(sendRequest(authorizationResponse, clientConfiguration, tokenEndpoint))
+                .switchMap(response -> createAuthenticationResponse(authorizationResponse.getNonce(),
+                        clientConfiguration,
+                        openIdProviderMetadata,
+                        response,
+                        userDetailsMapper,
+                        authorizationResponse.getState()));
+    }
 
-        State state;
+
+    /**
+     * Validates the Authorization response state.
+     * @param authorizationResponse The authorization response
+     * @param clientConfiguration The client configuration
+     * @throws InvalidStateException if the state did not pass validation
+     */
+    protected void validateState(OpenIdAuthorizationResponse authorizationResponse, OauthClientConfiguration clientConfiguration) throws InvalidStateException {
         if (stateValidator != null) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Validating state found in the authorization response from provider [{}]", clientConfiguration.getName());
             }
-            state = authorizationResponse.getState();
-            try {
-                stateValidator.validate(authorizationResponse.getCallbackRequest(), state);
-            } catch (InvalidStateException e) {
-                return Flowable.just(new AuthenticationFailed("State validation failed: " + e.getMessage()));
-            }
-
+            State state = authorizationResponse.getState();
+            stateValidator.validate(authorizationResponse.getCallbackRequest(), state);
         } else {
-            state = null;
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Skipping state validation, no state validator found");
             }
         }
-
-        String nonce = authorizationResponse.getNonce();
-
-        OpenIdCodeTokenRequestContext requestContext = new OpenIdCodeTokenRequestContext(authorizationResponse, oauthRouteUrlBuilder, tokenEndpoint, clientConfiguration);
-
-        return Flowable.fromPublisher(
-                tokenEndpointClient.sendRequest(requestContext))
-                .switchMap(response -> {
-                    if (LOG.isTraceEnabled()) {
-                        LOG.trace("Token endpoint returned a success response. Validating the JWT");
-                    }
-                    return Flowable.create(emitter -> {
-                        Optional<JWT> jwt = tokenResponseValidator.validate(clientConfiguration, openIdProviderMetadata, response, nonce);
-                        if (jwt.isPresent()) {
-                            try {
-                                if (LOG.isTraceEnabled()) {
-                                    LOG.trace("Token validation succeeded. Creating a user details");
-                                }
-                                OpenIdClaims claims = new JWTOpenIdClaims(jwt.get().getJWTClaimsSet());
-                                OpenIdUserDetailsMapper openIdUserDetailsMapper = userDetailsMapper != null ? userDetailsMapper : defaultUserDetailsMapper;
-                                emitter.onNext(openIdUserDetailsMapper.createAuthenticationResponse(clientConfiguration.getName(), response, claims, state));
-                                emitter.onComplete();
-                            } catch (ParseException e) {
-                                //Should never happen as validation succeeded
-                                emitter.onError(e);
-                            }
-                        } else {
-                            if (LOG.isTraceEnabled()) {
-                                LOG.trace("Token validation failed. Failing authentication");
-                            }
-                            emitter.onError(new AuthenticationException(new AuthenticationFailed("JWT validation failed")));
-                        }
-                    }, BackpressureStrategy.ERROR);
-                });
     }
 
+    /**
+     *
+     * @param authorizationResponse The authorization response
+     * @param clientConfiguration The client configuration
+     * @param tokenEndpoint The token endpoint
+     * @return The open id token response from the Authorization server
+     */
+    protected Publisher<OpenIdTokenResponse> sendRequest(OpenIdAuthorizationResponse authorizationResponse,
+                                               OauthClientConfiguration clientConfiguration,
+                                               SecureEndpoint tokenEndpoint) {
+        OpenIdCodeTokenRequestContext requestContext = new OpenIdCodeTokenRequestContext(authorizationResponse, oauthRouteUrlBuilder, tokenEndpoint, clientConfiguration);
+        return tokenEndpointClient.sendRequest(requestContext);
+    }
+
+    /**
+     *
+     * @param nonce Nonce
+     * @param clientConfiguration The client configuration
+     * @param openIdProviderMetadata The provider metadata
+     * @param openIdTokenResponse OpenID token response
+     * @param userDetailsMapper The user details mapper
+     * @param state State
+     * @return An authentication response publisher
+     */
+    protected Flowable<AuthenticationResponse> createAuthenticationResponse(String nonce,
+                                                                            OauthClientConfiguration clientConfiguration,
+                                                                            OpenIdProviderMetadata openIdProviderMetadata,
+                                                                            OpenIdTokenResponse openIdTokenResponse,
+                                                                            @Nullable OpenIdUserDetailsMapper userDetailsMapper,
+                                                                            @Nullable State state) {
+        return Flowable.create(emitter -> {
+            try {
+                Optional<AuthenticationResponse> authenticationResponse = validateOpenIdTokenResponse(nonce,
+                        clientConfiguration,
+                        openIdProviderMetadata,
+                        openIdTokenResponse,
+                        userDetailsMapper,
+                        state);
+                if (authenticationResponse.isPresent()) {
+                    emitter.onNext(authenticationResponse.get());
+                    emitter.onComplete();
+                } else {
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Token validation failed. Failing authentication");
+                    }
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed("JWT validation failed")));
+                }
+            } catch (ParseException e) {
+                //Should never happen as validation succeeded
+                emitter.onError(e);
+            }
+        }, BackpressureStrategy.ERROR);
+    }
+
+    /**
+     *
+     * @param nonce Nonce
+     * @param clientConfiguration The client configuration
+     * @param openIdProviderMetadata The provider metadata
+     * @param openIdTokenResponse OpenID token response
+     * @param userDetailsMapper The user details mapper
+     * @param state State
+     * @return An Authentication response if the open id token could  be validated
+     * @throws ParseException If the payload of the JWT doesn't represent a valid JSON object and a JWT claims set.
+     */
+    protected Optional<AuthenticationResponse> validateOpenIdTokenResponse(String nonce,
+                                                                           OauthClientConfiguration clientConfiguration,
+                                                                           OpenIdProviderMetadata openIdProviderMetadata,
+                                                                           OpenIdTokenResponse openIdTokenResponse,
+                                                                           @Nullable OpenIdUserDetailsMapper userDetailsMapper,
+                                                                           @Nullable State state) throws ParseException {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Token endpoint returned a success response. Validating the JWT");
+        }
+        Optional<JWT> jwt = tokenResponseValidator.validate(clientConfiguration, openIdProviderMetadata, openIdTokenResponse, nonce);
+        if (jwt.isPresent()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Token validation succeeded. Creating a user details");
+            }
+            OpenIdClaims claims = new JWTOpenIdClaims(jwt.get().getJWTClaimsSet());
+            OpenIdUserDetailsMapper openIdUserDetailsMapper = userDetailsMapper != null ? userDetailsMapper : defaultUserDetailsMapper;
+            return Optional.of(openIdUserDetailsMapper.createAuthenticationResponse(clientConfiguration.getName(), openIdTokenResponse, claims, state));
+        }
+        return Optional.empty();
+    }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/DefaultOpenIdAuthorizationResponseHandler.java
@@ -111,7 +111,7 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
      * @param clientConfiguration The client configuration
      * @throws InvalidStateException if the state did not pass validation
      */
-    protected void validateState(OpenIdAuthorizationResponse authorizationResponse, OauthClientConfiguration clientConfiguration) throws InvalidStateException {
+    private void validateState(OpenIdAuthorizationResponse authorizationResponse, OauthClientConfiguration clientConfiguration) throws InvalidStateException {
         if (stateValidator != null) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Validating state found in the authorization response from provider [{}]", clientConfiguration.getName());
@@ -132,7 +132,7 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
      * @param tokenEndpoint The token endpoint
      * @return The open id token response from the Authorization server
      */
-    protected Publisher<OpenIdTokenResponse> sendRequest(OpenIdAuthorizationResponse authorizationResponse,
+    private Publisher<OpenIdTokenResponse> sendRequest(OpenIdAuthorizationResponse authorizationResponse,
                                                OauthClientConfiguration clientConfiguration,
                                                SecureEndpoint tokenEndpoint) {
         OpenIdCodeTokenRequestContext requestContext = new OpenIdCodeTokenRequestContext(authorizationResponse, oauthRouteUrlBuilder, tokenEndpoint, clientConfiguration);
@@ -149,7 +149,7 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
      * @param state State
      * @return An authentication response publisher
      */
-    protected Flowable<AuthenticationResponse> createAuthenticationResponse(String nonce,
+    private Flowable<AuthenticationResponse> createAuthenticationResponse(String nonce,
                                                                             OauthClientConfiguration clientConfiguration,
                                                                             OpenIdProviderMetadata openIdProviderMetadata,
                                                                             OpenIdTokenResponse openIdTokenResponse,
@@ -190,7 +190,7 @@ public class DefaultOpenIdAuthorizationResponseHandler implements OpenIdAuthoriz
      * @return An Authentication response if the open id token could  be validated
      * @throws ParseException If the payload of the JWT doesn't represent a valid JSON object and a JWT claims set.
      */
-    protected Optional<AuthenticationResponse> validateOpenIdTokenResponse(String nonce,
+    private Optional<AuthenticationResponse> validateOpenIdTokenResponse(String nonce,
                                                                            OauthClientConfiguration clientConfiguration,
                                                                            OpenIdProviderMetadata openIdProviderMetadata,
                                                                            OpenIdTokenResponse openIdTokenResponse,


### PR DESCRIPTION
The goal is that you can override easily the request being made to the token endpoint. If you are working with an authorization server non standard. 

e.g. You could just override the `sendRequest` method. 


```java
    protected Publisher<OpenIdTokenResponse> sendRequest(OpenIdAuthorizationResponse authorizationResponse,
                                                         OauthClientConfiguration clientConfiguration,
                                                         SecureEndpoint tokenEndpoint) {
        return httpClient.retrieve(createRequest(authorizationResponse, clientConfiguration), OpenIdTokenResponse.class);
    }

    private HttpRequest<?> createRequest(OpenIdAuthorizationResponse authorizationResponse,
                                      OauthClientConfiguration clientConfiguration) {
        return HttpRequest.POST("/api/v1/openid/token", new HashMap<String, String>() {{
            put("code", authorizationResponse.getCode());
            put("client_id", clientConfiguration.getClientId());
            put("grant_type", GrantType.AUTHORIZATION_CODE.toString());
        }}).contentType(MediaType.APPLICATION_FORM_URLENCODED)
                .accept(MediaType.APPLICATION_JSON)
                .basicAuth(clientConfiguration.getClientId(), clientConfiguration.getClientSecret());
    }
```