### PR TITLE
Remove NonNull annotation of refreshToken parameter

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
@@ -164,7 +164,7 @@ public class DefaultAccessRefreshTokenGenerator implements AccessRefreshTokenGen
      */
     @NonNull
     @Override
-    public Optional<AccessRefreshToken> generate(String refreshToken, @NonNull UserDetails userDetails) {
+    public Optional<AccessRefreshToken> generate(@Nullable String refreshToken, @NonNull UserDetails userDetails) {
         Optional<String> optionalAccessToken = tokenGenerator.generateToken(userDetails, accessTokenExpiration(userDetails));
         if (!optionalAccessToken.isPresent()) {
             if (LOG.isDebugEnabled()) {

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
@@ -137,7 +137,7 @@ public class DefaultAccessRefreshTokenGenerator implements AccessRefreshTokenGen
      * @return The http response
      */
     @NonNull
-    public Optional<AccessRefreshToken> generate(@NonNull String refreshToken, @NonNull Map<String, ?> oldClaims) {
+    public Optional<AccessRefreshToken> generate(String refreshToken, @NonNull Map<String, ?> oldClaims) {
         Map<String, Object> claims = claimsGenerator.generateClaimsSet(oldClaims, accessTokenExpiration(oldClaims));
 
         Optional<String> optionalAccessToken = tokenGenerator.generateToken(claims);
@@ -164,7 +164,7 @@ public class DefaultAccessRefreshTokenGenerator implements AccessRefreshTokenGen
      */
     @NonNull
     @Override
-    public Optional<AccessRefreshToken> generate(@NonNull String refreshToken, @NonNull UserDetails userDetails) {
+    public Optional<AccessRefreshToken> generate(String refreshToken, @NonNull UserDetails userDetails) {
         Optional<String> optionalAccessToken = tokenGenerator.generateToken(userDetails, accessTokenExpiration(userDetails));
         if (!optionalAccessToken.isPresent()) {
             if (LOG.isDebugEnabled()) {

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/generator/DefaultAccessRefreshTokenGenerator.java
@@ -137,7 +137,7 @@ public class DefaultAccessRefreshTokenGenerator implements AccessRefreshTokenGen
      * @return The http response
      */
     @NonNull
-    public Optional<AccessRefreshToken> generate(String refreshToken, @NonNull Map<String, ?> oldClaims) {
+    public Optional<AccessRefreshToken> generate(@Nullable String refreshToken, @NonNull Map<String, ?> oldClaims) {
         Map<String, Object> claims = claimsGenerator.generateClaimsSet(oldClaims, accessTokenExpiration(oldClaims));
 
         Optional<String> optionalAccessToken = tokenGenerator.generateToken(claims);


### PR DESCRIPTION
I think it is not valid, because `refreshToken` parameter can be `null` if `RefreshTokenValidator` and `RefreshTokenPersistence` beans are not provided.

Now it is hard to extend and override those methods, because in Kotlin it results in non-nullable type and invalid checking agains `null` value. 