### PR TITLE
Opt-out kotlin stdlib api dependency closes #414

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ gebVersion=3.4
 seleniumVersion=3.141.59
 geckodriverVersion=0.26.0
 org.gradle.caching=true
+kotlin.stdlib.default.dependency=false
 # Needed for documentation generation. Needs to be Grails 3.2.x not 3.3.x
 grailsVersion=3.3.10
 testssecurity=security/src/test/groovy/io/micronaut/docs


### PR DESCRIPTION
Disable Kotlin stdlib as api dependency closes #414 using **gradle.properties**
`kotlin.stdlib.default.dependency=false`