### PR TITLE
test: Keycloak can be ignored sys testcontainers

### DIFF
--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/Keycloak.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/Keycloak.groovy
@@ -8,6 +8,7 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
 import java.time.Duration
 
 class Keycloak {
+    static final String SYS_TESTCONTAINERS = "testcontainers"
     static final String CLIENT_ID = "myclient"
     private static String clientSecret
     private static String issuer

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
@@ -24,7 +24,6 @@ import javax.inject.Named
 import javax.inject.Singleton
 import java.security.Principal
 
-@IgnoreIf({ sys['testcontainers'] == false })
 class AuthenticationModeIdTokenSpec extends GebEmbeddedServerSpecification {
 
     @Override
@@ -34,15 +33,20 @@ class AuthenticationModeIdTokenSpec extends GebEmbeddedServerSpecification {
 
     @Override
     Map<String, Object> getConfiguration() {
-        super.configuration + [
-                'micronaut.security.authentication': 'idtoken',
-                "micronaut.security.oauth2.clients.keycloak.openid.issuer" : Keycloak.issuer,
-                "micronaut.security.oauth2.clients.keycloak.client-id" : Keycloak.CLIENT_ID,
-                "micronaut.security.oauth2.clients.keycloak.client-secret" : Keycloak.clientSecret,
+        Map m = super.configuration + [
+                'micronaut.security.authentication'              : 'idtoken',
                 "micronaut.security.endpoints.logout.get-allowed": true,
         ] as Map<String, Object>
+        if ((System.getProperty(Keycloak.SYS_TESTCONTAINERS) == null) || Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS))) {
+            m.putAll([    "micronaut.security.oauth2.clients.keycloak.openid.issuer" : Keycloak.issuer,
+                          "micronaut.security.oauth2.clients.keycloak.client-id" : Keycloak.CLIENT_ID,
+                          "micronaut.security.oauth2.clients.keycloak.client-secret" : Keycloak.clientSecret,
+            ] as Map<String, Object>)
+        }
+        m
     }
 
+    @IgnoreIf({ System.getProperty(Keycloak.SYS_TESTCONTAINERS) != null && !Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS)) })
     void "test a full login"() {
         given:
         browser.baseUrl = "http://localhost:${embeddedServer.port}"

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectWithJustOpenIdSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectWithJustOpenIdSpec.groovy
@@ -17,20 +17,24 @@ import spock.lang.IgnoreIf
 
 import java.nio.charset.StandardCharsets
 
-@IgnoreIf({ sys['testcontainers'] == false })
 class OpenIdAuthorizationRedirectWithJustOpenIdSpec extends EmbeddedServerSpecification {
 
     @Override
     Map<String, Object> getConfiguration() {
-        Keycloak.init()
-        super.configuration  + [
+        Map<String, Object> m = super.configuration  + [
                 'micronaut.security.authentication': 'cookie',
-                "micronaut.security.oauth2.clients.keycloak.openid.issuer": Keycloak.issuer,
-                "micronaut.security.oauth2.clients.keycloak.client-id": Keycloak.CLIENT_ID,
-                "micronaut.security.oauth2.clients.keycloak.client-secret": Keycloak.clientSecret,
         ]
+        if (System.getProperty(Keycloak.SYS_TESTCONTAINERS) == null || Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS))) {
+            m.putAll([
+                    "micronaut.security.oauth2.clients.keycloak.openid.issuer": Keycloak.issuer,
+                    "micronaut.security.oauth2.clients.keycloak.client-id": Keycloak.CLIENT_ID,
+                    "micronaut.security.oauth2.clients.keycloak.client-secret": Keycloak.clientSecret,
+            ])
+        }
+        m
     }
 
+    @IgnoreIf({ System.getProperty(Keycloak.SYS_TESTCONTAINERS) != null && !Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS)) })
     void "test authorization redirect with just openid"() {
         given:
         RxHttpClient client = applicationContext.createBean(RxHttpClient.class, embeddedServer.getURL(), new DefaultHttpClientConfiguration(followRedirects: false))


### PR DESCRIPTION
To ignore the tests which require tescontainers pass system property `testcontainers`

```
./gradlew -Dtestcontainers=false test
```