### PR TITLE
fix: no routes for OAuth 2.0 clients with nosecret

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/OauthRouteBuilder.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/OauthRouteBuilder.java
@@ -29,13 +29,17 @@ import io.micronaut.inject.ExecutionHandle;
 import io.micronaut.inject.MethodExecutionHandle;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.AuthenticationMode;
+import io.micronaut.security.config.SecurityConfiguration;
 import io.micronaut.security.oauth2.client.OauthClient;
 import io.micronaut.security.oauth2.client.OpenIdClient;
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.configuration.OauthConfiguration;
 import io.micronaut.security.oauth2.url.OauthRouteUrlBuilder;
 import io.micronaut.web.router.DefaultRouteBuilder;
 import jakarta.inject.Singleton;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +65,7 @@ class OauthRouteBuilder extends DefaultRouteBuilder {
      * @param uriNamingStrategy The URI naming strategy
      * @param conversionService The conversion service
      * @param beanContext The bean context
+     * @param securityConfiguration Security configuration
      * @param oauthConfiguration Oauth configuration
      * @param oauthRouteUrlBuilder The oauth URL builder
      * @param controllerList The list of controllers
@@ -69,6 +74,7 @@ class OauthRouteBuilder extends DefaultRouteBuilder {
                       UriNamingStrategy uriNamingStrategy,
                       ConversionService conversionService,
                       BeanContext beanContext,
+                      SecurityConfiguration securityConfiguration,
                       OauthConfiguration oauthConfiguration,
                       OauthRouteUrlBuilder oauthRouteUrlBuilder,
                       List<OauthController> controllerList) {
@@ -79,9 +85,15 @@ class OauthRouteBuilder extends DefaultRouteBuilder {
         } else {
             AtomicBoolean endSessionRegistered = new AtomicBoolean();
 
-            controllerList.forEach(controller -> {
+            for (OauthController controller : controllerList) {
                 OauthClient client = controller.getClient();
                 String name = client.getName();
+
+                Optional<OauthClientConfiguration> oauthClientConfiguration = beanContext.findBean(OauthClientConfiguration.class, Qualifiers.byName(name));
+                if (shouldSkipRoutes(securityConfiguration, oauthClientConfiguration)) {
+                    debug(LOG, "client {} does not define a client secret and idtoken authentication is enabled. Skipping registration of routes", name);
+                    continue;
+                }
                 boolean isDefaultProvider = oauthConfiguration.getDefaultProvider().filter(provider -> provider.equals(name)).isPresent();
 
                 BeanDefinition<OauthController> bd = beanContext.getBeanDefinition(OauthController.class, Qualifiers.byName(name));
@@ -130,11 +142,17 @@ class OauthRouteBuilder extends DefaultRouteBuilder {
                         buildRoute(HttpMethod.GET, logoutUri, (MethodExecutionHandle) executionHandle);
                     });
                 }
-            });
+            }
 
             if (!endSessionRegistered.get() && LOG.isDebugEnabled()) {
                 LOG.debug("Skipped registration of logout route. No openid clients found that support end session");
             }
         }
+    }
+
+    private boolean shouldSkipRoutes(SecurityConfiguration securityConfiguration, Optional<OauthClientConfiguration> oauthClientConfiguration) {
+        return securityConfiguration.getAuthentication() == AuthenticationMode.IDTOKEN
+            && oauthClientConfiguration.isPresent()
+            && oauthClientConfiguration.get().getClientSecret() == null;
     }
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/routes/NoClientSecretNoOauthRoutesSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/routes/NoClientSecretNoOauthRoutesSpec.groovy
@@ -1,0 +1,96 @@
+package io.micronaut.security.oauth2.routes
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.oauth2.OpenIdMockEmbeddedServerSpecification
+import io.micronaut.security.oauth2.endpoint.endsession.request.EndSessionEndpoint
+import io.micronaut.web.router.RouteBuilder
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import spock.lang.Narrative
+import spock.lang.Shared
+import spock.lang.Unroll
+
+@Narrative('''
+For a config such as:
+
+micronaut:
+  security:
+    oauth2:
+      clients:
+        foo:
+          client-id: 'XXX'
+          openid:
+            issuer: 'blababla'
+        bar:
+          client-id: 'XXX'
+          client-secret: 'YYY'
+          openid:
+            issuer: 'blababla'
+
+Micronaut creates routes ('/oauth/callback/{name}','/oauth/login/{name}',) for OAuth 2.0 applications with a client secret.
+''')
+class NoClientSecretNoOauthRoutesSpec extends OpenIdMockEmbeddedServerSpecification {
+
+    @Shared
+    Set<String> paths = applicationContext.getBeansOfType(RouteBuilder).collect { it.uriRoutes }
+            .flatten()
+            .collect { it.uriMatchTemplate.toPathString() } as Set<String>
+
+    @Override
+    String getSpecName() {
+        'NoClientSecretNoOauthRoutesSpec'
+    }
+
+    @Override
+    Map<String, Object> getOauth2ClientConfiguration() {
+        [
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-id".toString()): 'XXXX',
+                ("micronaut.security.oauth2.clients.${openIdClientName}.openid.issuer".toString()): issuer,
+        ]
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+            "micronaut.security.authentication": "idtoken",
+            "micronaut.security.oauth2.clients.bar.client-id": 'XXXX',
+            "micronaut.security.oauth2.clients.bar.client-secret": 'YYYY',
+            "micronaut.security.oauth2.clients.bar.openid.issuer": issuer
+        ]
+    }
+
+    @Unroll
+    void "#route is not registered because no client secret is specified for OAuth 2.0 application"(String route) {
+        expect:
+        paths.every { it != route }
+
+        where:
+        route << [
+                '/oauth/callback/foo',
+                '/oauth/login/foo',
+                '/oauth/logout']
+    }
+
+    @Unroll
+    void "#route is registered because client id and client secret are specified for OAuth 2.0 application"(String route) {
+        expect:
+        paths.any { it == route }
+
+        where:
+        route << [
+                '/oauth/callback/bar',
+                '/oauth/login/bar']
+    }
+
+    @Requires(property = "spec.name", value = 'NoClientSecretNoOauthRoutesSpec')
+    @Named("foo")
+    @Singleton
+    static class CustomEndSessionEndpoint implements EndSessionEndpoint {
+        @Override
+        String getUrl(HttpRequest<?> originating, Authentication authentication) {
+            null
+        }
+    }
+}

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/routes/PublicClientNoSecretOauthRoutesSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/routes/PublicClientNoSecretOauthRoutesSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.security.oauth2.routes
+
+import io.micronaut.security.oauth2.OpenIdMockEmbeddedServerSpecification
+import io.micronaut.web.router.RouteBuilder
+import spock.lang.Shared
+import spock.lang.Unroll
+
+class PublicClientNoSecretOauthRoutesSpec extends OpenIdMockEmbeddedServerSpecification {
+
+    @Shared
+    Set<String> paths = applicationContext.getBeansOfType(RouteBuilder).collect { it.uriRoutes }
+            .flatten()
+            .collect { it.uriMatchTemplate.toPathString() } as Set<String>
+
+    @Override
+    Map<String, Object> getOauth2ClientConfiguration() {
+        [
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-id".toString()): 'XXXX',
+                ("micronaut.security.oauth2.clients.${openIdClientName}.openid.issuer".toString()): issuer,
+        ]
+    }
+
+    @Unroll
+    void "#route is registered for a public OAuth 2.0 application without a client secret"(String route) {
+        expect:
+        paths.any { it == route }
+
+        where:
+        route << [
+                '/oauth/callback/foo',
+                '/oauth/login/foo']
+    }
+}

--- a/src/main/docs/guide/oauth.adoc
+++ b/src/main/docs/guide/oauth.adoc
@@ -4,6 +4,8 @@ The easiest way to get started is by configuring a provider that supports OpenID
 
 Once you create an application client with a provider, you will get a client id and a client secret. The client id and secret combined with the issuer URL is all that is needed to enable the authentication code grant flow with an OpenID provider.
 
+If you only need to validate ID tokens issued by an OpenID provider for a client, for example with `micronaut.security.authentication` set to `idtoken`, configure the client id and OpenID issuer without a client secret. In that case, Micronaut uses OpenID discovery for token validation but does not register the OAuth login, callback, or logout routes for that client.
+
 For example, to configure Google as a provider:
 
 [configuration,subs="verbatim"]


### PR DESCRIPTION
close: https://github.com/micronaut-projects/micronaut-security/issues/439

When would you want an OAuth 2.0 Client with no secret? You want to have the minium security configuration in place to be able to validate idtokens. 

E.g. you have two services

[Gateway]

[Repository]

Gateway has the config: 

```yaml
micronaut:
  security:
     authentication: idtoken
     oauth2:
        clients:
            cognito:
               client-id: 'xxx'
               client-secret: 'xxx'
               openid:
                    issuer: 'https://blablaba'
```

The gateway does the authorization code grant flow with cognito and gets an idtoken. 

To communicate with repository service it passes the id token as a bearer token.

Repository does not need callback routes. It just needs the minimum config to register the JWKS endpoint obtained via cognito well-know/openid-configuration to be able to validate the idtoken the gateway includes in the request headers.

This will be the config for `repository`: 

```yaml
micronaut:
  security:
     authentication: idtoken
     oauth2:
        clients:
            cognito:
               client-id: 'xxx'
               openid:
                    issuer: 'https://blablaba'
```