### PR TITLE
feat: add equals and hashcode to TokenResponse

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponse.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponse.java
@@ -132,4 +132,39 @@ public class TokenResponse {
         this.refreshToken = refreshToken;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TokenResponse that = (TokenResponse) o;
+
+        if (!accessToken.equals(that.accessToken)) {
+            return false;
+        }
+        if (!tokenType.equals(that.tokenType)) {
+            return false;
+        }
+        if (expiresIn != null ? !expiresIn.equals(that.expiresIn) : that.expiresIn != null) {
+            return false;
+        }
+        if (refreshToken != null ? !refreshToken.equals(that.refreshToken) : that.refreshToken != null) {
+            return false;
+        }
+        return scope != null ? scope.equals(that.scope) : that.scope == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = accessToken.hashCode();
+        result = 31 * result + tokenType.hashCode();
+        result = 31 * result + (expiresIn != null ? expiresIn.hashCode() : 0);
+        result = 31 * result + (refreshToken != null ? refreshToken.hashCode() : 0);
+        result = 31 * result + (scope != null ? scope.hashCode() : 0);
+        return result;
+    }
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseSpec.groovy
@@ -19,6 +19,28 @@ class TokenResponseSpec extends ApplicationContextSpecification {
         noExceptionThrown()
     }
 
+    void "TokenResponse implements equals and hash code"() {
+        given:
+        TokenResponse respOne = new TokenResponse()
+        respOne.with {
+            accessToken = "2YotnFZFEjr1zCsicMWpAA"
+            tokenType = "example"
+            expiresIn = 3600
+            refreshToken = "tGzv3JOkF0XG5Qx2TlKWIA"
+        }
+
+        TokenResponse respTwo = new TokenResponse()
+        respTwo.with {
+            accessToken = "2YotnFZFEjr1zCsicMWpAA"
+            tokenType = "example"
+            expiresIn = 3600
+            refreshToken = "tGzv3JOkF0XG5Qx2TlKWIA"
+        }
+
+        expect:
+        respOne == respTwo
+    }
+
     void "TokenResponse uses snake case for its fields"() {
         when:
         TokenResponse tokenResponse = new TokenResponse()


### PR DESCRIPTION
I want to use equals for `TokenResponse` in a separate PR.