### PR TITLE
refactor: add expiration to TokenResponse

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/AbstractClientCredentialsClient.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/AbstractClientCredentialsClient.java
@@ -24,7 +24,6 @@ import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.endpoint.token.request.TokenEndpointClient;
 import io.micronaut.security.oauth2.endpoint.token.request.context.ClientCredentialsTokenRequestContext;
 import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
-import io.micronaut.security.oauth2.endpoint.token.response.TokenResponseExpiration;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +78,7 @@ public abstract class AbstractClientCredentialsClient implements ClientCredentia
         String resolvedScope = scope != null ? scope : NOSCOPE;
 
         CacheableProcessor<TokenResponse> publisher = scopeToPublisherMap.computeIfAbsent(resolvedScope,
-                key -> new CacheableProcessor<>(TokenResponseExpiration::new));
+                key -> new CacheableProcessor<>());
 
         if (force || isExpired(publisher.getElement())) {
             publisher.clear();
@@ -129,11 +128,7 @@ public abstract class AbstractClientCredentialsClient implements ClientCredentia
                 LOG.trace("cannot parse access token {} to JWT", tokenResponse.getAccessToken());
             }
         }
-        if (tokenResponse instanceof TokenResponseExpiration) {
-            TokenResponseExpiration tokenResponseExpiration = (TokenResponseExpiration) tokenResponse;
-            return Optional.ofNullable(tokenResponseExpiration.getExpiration());
-        }
-        return Optional.empty();
+        return tokenResponse.getExpiresInDate();
     }
 
     /**

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/CacheableProcessor.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/CacheableProcessor.java
@@ -25,7 +25,6 @@ import org.reactivestreams.Subscription;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -52,22 +51,11 @@ class CacheableProcessor<T> implements Processor<T, T> {
     @NonNull
     private Queue<ElementSubscription<T>> subscriptions = new ConcurrentLinkedQueue<>();
 
-    @Nullable
-    private final Function<T, T> transformer;
-
     /**
      * Constructor.
      */
     CacheableProcessor() {
-        this.transformer = null;
-    }
 
-    /**
-     *
-     * @param transformer A transformation function to be applied when an element is received.
-     */
-    CacheableProcessor(@NonNull Function<T, T> transformer) {
-        this.transformer = transformer;
     }
 
     /**
@@ -95,7 +83,7 @@ class CacheableProcessor<T> implements Processor<T, T> {
 
     @Override
     public void onNext(T el) {
-        this.element = transformer != null ? transformer.apply(el) : el;
+        this.element = el;
         flowData();
     }
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponse.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponse.java
@@ -22,6 +22,10 @@ import io.micronaut.core.annotation.Introspected;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Optional;
+
 /**
  * Represent the response of an authorization server to a valid access token request.
  *
@@ -39,6 +43,9 @@ public class TokenResponse {
     private Integer expiresIn;
     private String refreshToken;
     private String scope;
+
+    @Nullable
+    private Date expiresInDate;
 
     /**
      * Instantiates Access Token Response.
@@ -96,6 +103,20 @@ public class TokenResponse {
      */
     public void setExpiresIn(@Nullable Integer expiresIn) {
         this.expiresIn = expiresIn;
+        if (expiresIn != null) {
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.SECOND, expiresIn);
+            this.expiresInDate = calendar.getTime();
+        }
+    }
+
+    /**
+     *
+     * @return Expiration date of the access token. Calculated with the {@link TokenResponse#expiresIn} received by the authorization server.
+     */
+    @NonNull
+    public Optional<Date> getExpiresInDate() {
+        return Optional.ofNullable(expiresInDate);
     }
 
     /**

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseExpiration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseExpiration.java
@@ -17,19 +17,16 @@ package io.micronaut.security.oauth2.endpoint.token.response;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.micronaut.core.annotation.Introspected;
-
-import java.util.Calendar;
 import java.util.Date;
 
 /**
+ * @deprecated Use {@link TokenResponse#getExpiresInDate()} instead.
  * @author Sergio del Amo
  * @since 2.2.0
  */
+@Deprecated
 @Introspected
 public class TokenResponseExpiration extends TokenResponse {
-
-    @Nullable
-    private Date expiration;
 
     /**
      *
@@ -44,27 +41,11 @@ public class TokenResponseExpiration extends TokenResponse {
     }
 
     /**
-     * Populates Expiration date with the expires in value.
-     *
-     * @param expiresIn The lifetime in seconds of the access token.
-     */
-    @Override
-    public void setExpiresIn(Integer expiresIn) {
-        super.setExpiresIn(expiresIn);
-
-        if (expiresIn != null) {
-            Calendar calendar = Calendar.getInstance();
-            calendar.add(Calendar.SECOND, expiresIn);
-            this.expiration = calendar.getTime();
-        }
-    }
-
-    /**
      *
      * @return Expiration date of the access token. Calculated with the expires in recevied by the authorization server.
      */
     @Nullable
     public Date getExpiration() {
-        return expiration;
+        return getExpiresInDate().orElse(null);
     }
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/TokenResponseSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.security.oauth2.endpoint.token.response
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.json.JsonSlurper
+import groovy.time.TimeCategory
 import io.micronaut.core.beans.BeanIntrospection
 import io.micronaut.security.oauth2.ApplicationContextSpecification
 import spock.lang.Shared
@@ -36,5 +37,37 @@ class TokenResponseSpec extends ApplicationContextSpecification {
         m["expires_in"] == 3600
         m["refresh_token"] == "IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk"
         m["scope"] == "create"
+    }
+
+    void "TokenResponse::getExpiration uses expiresIn"() {
+        when:
+        TokenResponse tokenResponse = new TokenResponse()
+
+        then:
+        !tokenResponse.getExpiresInDate().isPresent()
+
+        when:
+        tokenResponse.expiresIn = 3600
+
+        then:
+        tokenResponse.getExpiresInDate().isPresent()
+
+        when:
+        Date halfAnHour = new Date()
+        use(TimeCategory) {
+            halfAnHour += 30.minutes
+        }
+
+        then:
+        tokenResponse.getExpiresInDate().get().after(halfAnHour)
+
+        when:
+        Date twoHours = new Date()
+        use(TimeCategory) {
+            twoHours += 2.hours
+        }
+
+        then:
+        tokenResponse.getExpiresInDate().get().before(twoHours)
     }
 }


### PR DESCRIPTION
This moves the logic of calculating an expiration date for a token directly into the `TokenResponse` POJO. So that it is easier to get rid of `CacheableProcessor`. 