### PR TITLE
doc: fix copy in client-credentials section

### DIFF
--- a/src/main/docs/guide/oauth/flows/clientcredentials/clientecredentialshttpclient.adoc
+++ b/src/main/docs/guide/oauth/flows/clientcredentials/clientecredentialshttpclient.adoc
@@ -1,4 +1,4 @@
-Micronaut Security includes api:security.oauth2.client.clientcredentials.propagation.ClientCredentialsHttpClientFilter[]. A https://docs.micronaut.io/latest/guide/index.html#clientFilter[HTTP Client Filter] which allows you to include automatically an access token at an outgoing request HTTP Header. It obtains the access token via a Client Credentials request.
+Micronaut Security includes api:security.oauth2.client.clientcredentials.propagation.ClientCredentialsHttpClientFilter[]. A https://docs.micronaut.io/latest/guide/index.html#clientFilter[HTTP Client Filter] which allows you to automatically include an access token to an outgoing request HTTP Header. It obtains the access token via a Client Credentials request.
 
 For example, the next configuration adds an access token to the requests' HTTP Headers done via the HTTP Client `inventory`. It obtains the access token with a Client Credentials request with the OAuth 2.0 client `companyauthorserver`.
 
@@ -12,7 +12,7 @@ micronaut:
           client-id: 'XXX'
           client-scret: 'YYY'
           client-credentials:
-            serviceid-regex: 'inventory'
+            service-id-regex: 'inventory'
           token:
             url: "https://foo.bar/token"
             auth-method': "client_secret_basic",


### PR DESCRIPTION
Fix typos in client credentials docs and config example