### PR TITLE
fix client credentials client publishing multiple tokens (#500)

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check Dependencies
         run: ./gradlew useLatestVersions
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.5.2
+        uses: peter-evans/create-pull-request@v3.6.0
         with:
           token: ${{ secrets.GH_TOKEN }}
           committer: micronaut-build <${{ secrets.MICRONAUT_BUILD_EMAIL }}>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=2.2.2-SNAPSHOT
+projectVersion=2.3.0-SNAPSHOT
 micronautDocsVersion=1.0.25
 micronautBuildVersion=1.1.5
 micronautTestVersion=2.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ githubSlug=micronaut-projects/micronaut-security
 developers=James Kleeh,Sergio del Amo
 
 githubBranch=master
-githubCoreBranch=2.2.x
+githubCoreBranch=2.3.x
 bomProperty=micronautSecurityVersion
 
 kotlin.stdlib.default.dependency=false

--- a/security-jwt/build.gradle
+++ b/security-jwt/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 ext {
-    nimbusJoseJwtVersion = '9.1.3'
+    nimbusJoseJwtVersion = '9.2'
     bouncyCastleVersion = '1.67'
 }
 


### PR DESCRIPTION
@ritikmishra

> I had looked into using BehaviorProcessor/BehaviorSubject, but it wasn't easy to know if an access token request was pending using those objects.

> This still isn't perfect. In the example demonstrating #500, 6 access token requests get made at once when the token is expired/not cached. Ideally, only 1 request would get made.

I have used computeIfAbsent istead of getAndDefault and computIfPresent and it seems to solve the issue described by @ritikmishra in the second item. 

I failed also to fix this with a `BehaviorProcessor`
