### PR TITLE
refactor: IdTokenClaimsValidator

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/IdTokenClaimsValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/IdTokenClaimsValidator.java
@@ -18,14 +18,12 @@ package io.micronaut.security.oauth2.client;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.security.config.SecurityConfigurationProperties;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
 import io.micronaut.security.token.jwt.generator.claims.JwtClaims;
 import io.micronaut.security.token.jwt.validator.GenericJwtClaimsValidator;
 import io.micronaut.security.token.jwt.validator.JwtClaimsValidator;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,10 +49,10 @@ import java.util.Optional;
 @Requires(property = JwtClaimsValidator.PREFIX + ".openid-idtoken", notEquals = StringUtils.FALSE)
 @Singleton
 public class IdTokenClaimsValidator implements GenericJwtClaimsValidator {
-    private static final Logger LOG = LoggerFactory.getLogger(IdTokenClaimsValidator.class);
-    private static final String AUTHORIZED_PARTY = "azp";
+    protected static final Logger LOG = LoggerFactory.getLogger(IdTokenClaimsValidator.class);
+    protected static final String AUTHORIZED_PARTY = "azp";
 
-    private final Collection<OauthClientConfiguration> oauthClientConfigurations;
+    protected final Collection<OauthClientConfiguration> oauthClientConfigurations;
 
     /**
      *
@@ -66,72 +64,177 @@ public class IdTokenClaimsValidator implements GenericJwtClaimsValidator {
 
     @Override
     public boolean validate(JwtClaims claims) {
-        return validate(claims, null);
+        Optional<String> claimIssuerOptional = parseIssuerClaim(claims);
+        if (!claimIssuerOptional.isPresent()) {
+            return false;
+        }
+        String iss = claimIssuerOptional.get();
+
+        Optional<List<String>> audiencesOptional = parseAudiences(claims);
+        if (!audiencesOptional.isPresent()) {
+            return false;
+        }
+        List<String> audiences = audiencesOptional.get();
+        return validateIssuerAudienceAndAzp(claims, iss, audiences);
     }
 
-    @Override
-    public boolean validate(@NonNull JwtClaims claims, @Nullable HttpRequest<?> request) {
-        Object obj = claims.get(JwtClaims.ISSUER);
+    /**
+     *
+     * @param claims JWT Claims
+     * @return the iss claim value wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<String> parseIssuerClaim(JwtClaims claims) {
+        return parseClaimString(claims, JwtClaims.ISSUER);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param claimName Claim Name
+     * @return the claim value wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<Object> parseClaim(JwtClaims claims, String claimName) {
+        Object obj = claims.get(claimName);
         if (obj == null) {
             if (LOG.isTraceEnabled()) {
-                LOG.trace("{} claim not present", JwtClaims.ISSUER);
+                LOG.trace("{} claim not present", claimName);
             }
-            return false;
+            return Optional.empty();
         }
-        String iss = obj.toString();
-        obj = claims.get(JwtClaims.AUDIENCE);
-        if (obj == null) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("{} claim not present", JwtClaims.AUDIENCE);
-            }
-            return false;
+        return Optional.of(obj);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param claimName Claim Name
+     * @return the claim value as a String wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<String> parseClaimString(JwtClaims claims, String claimName) {
+        return parseClaim(claims, claimName).map(Object::toString);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param claimName Claim Name
+     * @return the claim value as a list of Strings wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<List<String>> parseClaimList(JwtClaims claims, String claimName) {
+        Optional<Object> objectOptional = parseClaim(claims, claimName);
+        if (!objectOptional.isPresent()) {
+            return Optional.empty();
         }
-        List<String> audiences = new ArrayList<>();
+        Object obj = objectOptional.get();
+        List<String> result = new ArrayList<>();
         if (obj instanceof List) {
             for (Object listObj : (List<?>) obj) {
-                audiences.add(listObj.toString());
+                result.add(listObj.toString());
             }
         } else {
-            audiences.add(obj.toString());
+            result.add(obj.toString());
         }
-        for (OauthClientConfiguration oauthClientConfiguration : oauthClientConfigurations) {
-            Optional<OpenIdClientConfiguration> openIdClientConfigurationOptional = oauthClientConfiguration.getOpenid();
-            if (openIdClientConfigurationOptional.isPresent()) {
-                OpenIdClientConfiguration openIdClientConfiguration = openIdClientConfigurationOptional.get();
-                if (openIdClientConfiguration.getIssuer().isPresent()) {
-                    Optional<URL> issuerOptional = openIdClientConfiguration.getIssuer();
-                    if (issuerOptional.isPresent()) {
-                        String issuer = issuerOptional.get().toString();
-                        String clientId = oauthClientConfiguration.getClientId();
-                        if (issuer.equalsIgnoreCase(iss) ||
-                                audiences.contains(clientId) &&
-                                        validateAzp(clientId, claims, audiences)) {
-                            return true;
-                        }
-                    }
-                }
+        return Optional.of(result);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @return the aud claim value a list of strings wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<List<String>> parseAudiences(JwtClaims claims) {
+        return parseClaimList(claims, JwtClaims.AUDIENCE);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param iss Issuer claim
+     * @param audiences aud claim as a list of string
+     * @return true if an OAuth 2.0 client issuer matches the iss claim, any of the audiences in the aud claim matches the OAuth 2.0 client_id and for multiple audiencies the azp claim is present and matches OAuth 2.0 client_id
+     */
+    protected boolean validateIssuerAudienceAndAzp(@NonNull JwtClaims claims,
+                                                   @NonNull String iss,
+                                                   @NonNull List<String> audiences) {
+        return oauthClientConfigurations.stream().anyMatch(oauthClientConfiguration -> validateIssuerAudienceAndAzp(claims, iss, audiences, oauthClientConfiguration));
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param iss Issuer claim
+     * @param audiences aud claim as a list of string
+     * @param oauthClientConfiguration OAuth 2.0 client configuration
+     * @return true if the OAuth 2.0 client OpenID issuer matches the iss claim, any of the audiences in the aud claim matches the OAuth 2.0 client_id and for multiple audiencies the azp claim is present and matches OAuth 2.0 client_id
+     */
+    protected boolean validateIssuerAudienceAndAzp(@NonNull JwtClaims claims,
+                                                   @NonNull String iss,
+                                                   @NonNull List<String> audiences,
+                                                   @NonNull OauthClientConfiguration oauthClientConfiguration) {
+        Optional<OpenIdClientConfiguration> openIdClientConfigurationOptional = oauthClientConfiguration.getOpenid();
+        if (openIdClientConfigurationOptional.isPresent()) {
+            OpenIdClientConfiguration openIdClientConfiguration = openIdClientConfigurationOptional.get();
+            return validateIssuerAudienceAndAzp(claims, iss, audiences, oauthClientConfiguration.getClientId(), openIdClientConfiguration);
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param iss Issuer claim
+     * @param audiences aud claim as a list of string
+     * @param clientId OAuth 2.0 client_id
+     * @param openIdClientConfiguration OpenID OAuth 2.0 client configuration
+     * @return true if the OAuth 2.0 client OpenID issuer matches the iss claim, any of the audiences in the aud claim matches the OAuth 2.0 client_id and for multiple audiencies the azp claim is present and matches OAuth 2.0 client_id
+     */
+    protected boolean validateIssuerAudienceAndAzp(@NonNull JwtClaims claims,
+                                                   @NonNull String iss,
+                                                   @NonNull List<String> audiences,
+                                                   @NonNull String clientId,
+                                                   @NonNull OpenIdClientConfiguration openIdClientConfiguration) {
+        if (openIdClientConfiguration.getIssuer().isPresent()) {
+            Optional<URL> issuerOptional = openIdClientConfiguration.getIssuer();
+            if (issuerOptional.isPresent()) {
+                String issuer = issuerOptional.get().toString();
+                return issuer.equalsIgnoreCase(iss) ||
+                        audiences.contains(clientId) &&
+                                validateAzp(claims, clientId, audiences);
             }
         }
         return false;
     }
 
-    private boolean validateAzp(@NonNull String clientId,
-                                @NonNull JwtClaims claims,
-                                @NonNull List<String> audiences) {
+    /**
+     *
+     * @param claims JWT Claims
+     * @return the azp claim value wrapped in an {@link Optional}. If not found, an empty {@link Optional} is returned.
+     */
+    protected Optional<String> parseAzpClaim(JwtClaims claims) {
+        return parseClaimString(claims, AUTHORIZED_PARTY);
+    }
+
+    /**
+     *
+     * @param claims JWT Claims
+     * @param clientId OAuth 2.0 client ID
+     * @param audiences audiences specified in the JWT Claims
+     * @return true for single audiences, for multiple audiences returns true azp claim is present and matches OAuth 2.0 client_id
+     */
+    protected boolean validateAzp(@NonNull JwtClaims claims,
+                                  @NonNull String clientId,
+                                  @NonNull List<String> audiences) {
         if (audiences.size() < 2) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("{} claim is not required for single audiences", AUTHORIZED_PARTY);
             }
             return true;
         }
-        Object obj = claims.get(AUTHORIZED_PARTY);
-        if (obj == null) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("{} claim not present", AUTHORIZED_PARTY);
-            }
+       Optional<String> azpOptional = parseAzpClaim(claims);
+        if (!azpOptional.isPresent()) {
             return false;
         }
-        String azp = obj.toString();
+        String azp = azpOptional.get();
         boolean result = azp.equalsIgnoreCase(clientId);
         if (!result) {
             if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
I have refactored `IdTokenClaimsValidator` so that it is easy to create replacement and reuse logic. While reviewing https://github.com/micronaut-projects/micronaut-openapi/pull/448 I had to create such a replacement: 

```java
@Singleton
@Replaces(IdTokenClaimsValidator.class)
public class IdTokenClaimsValidatorReplacement extends IdTokenClaimsValidator {
    public static final String CLIENT_ID = "client_id";
    public IdTokenClaimsValidatorReplacement(Collection<OauthClientConfiguration> oauthClientConfigurations) {
        super(oauthClientConfigurations);
    }

    @Override
    public boolean validate(JwtClaims claims) {
        Optional<String> claimIssuerOptional = parseIssuerClaim(claims);
        if (!claimIssuerOptional.isPresent()) {
            return false;
        }
        String iss = claimIssuerOptional.get();

        Optional<List<String>> audiencesOptional = parseAudiences(claims);
        if (!audiencesOptional.isPresent()) {
            if (validateClientIdClaim(claims)) {
                return true;
            }
            return false;
        }
        List<String> audiences = audiencesOptional.get();
        return validateIssuerAudienceAndAzp(claims, iss, audiences);
    }

    protected boolean validateClientIdClaim(JwtClaims claims) {
        Optional<String> clientIdOptional = parseClaimString(claims, CLIENT_ID);
        if (clientIdOptional.isPresent()) {
            String clientId = clientIdOptional.get();
            for (OauthClientConfiguration oauthClientConfiguration : oauthClientConfigurations) {
                if (oauthClientConfiguration.getClientId().equalsIgnoreCase(clientId)) {
                    return true;
                }
            }
        }
        return false;
    }
}
```