### PR TITLE
Add support for Reactive security rules

### DIFF
--- a/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
+++ b/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
@@ -36,7 +36,6 @@ import io.micronaut.security.rules.SecurityRule;
 import io.micronaut.security.rules.SecurityRuleResult;
 import io.micronaut.web.router.RouteMatch;
 import io.reactivex.Flowable;
-import io.reactivex.Single;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,15 +89,14 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
     protected final SecurityConfiguration securityConfiguration;
 
     /**
-     * @param securityRules The list of security rules that will allow or reject the request
+     * @param securityRules          The list of security rules that will allow or reject the request
      * @param authenticationFetchers List of {@link AuthenticationFetcher} beans in the context.
-     * @param securityConfiguration The security configuration
+     * @param securityConfiguration  The security configuration
      */
     @Deprecated
-    public SecurityFilter(
-            Collection<SecurityRule> securityRules,
-            Collection<AuthenticationFetcher> authenticationFetchers,
-            SecurityConfiguration securityConfiguration) {
+    public SecurityFilter(Collection<SecurityRule> securityRules,
+                          Collection<AuthenticationFetcher> authenticationFetchers,
+                          SecurityConfiguration securityConfiguration) {
 
         this.authenticationFetchers = authenticationFetchers;
         this.securityConfiguration = securityConfiguration;
@@ -113,11 +111,10 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
      * @param securityConfiguration The security configuration
      */
     @Inject
-    public SecurityFilter(
-            Collection<SecurityRule> securityRules,
-            Collection<ReactiveSecurityRule> reactiveSecurityRules,
-            Collection<AuthenticationFetcher> authenticationFetchers,
-            SecurityConfiguration securityConfiguration) {
+    public SecurityFilter(Collection<SecurityRule> securityRules,
+                          Collection<ReactiveSecurityRule> reactiveSecurityRules,
+                          Collection<AuthenticationFetcher> authenticationFetchers,
+                          SecurityConfiguration securityConfiguration) {
 
         this.authenticationFetchers = authenticationFetchers;
         this.securityConfiguration = securityConfiguration;
@@ -196,8 +193,9 @@ public class SecurityFilter extends OncePerRequestHttpServerFilter {
                                 }
                                 return Publishers.empty();
                             } else if (ordered instanceof ReactiveSecurityRule) {
-                                return Single.fromPublisher(
+                                return Flowable.fromPublisher(
                                         ((ReactiveSecurityRule) ordered).check(request, routeMatch, attributes))
+                                        .firstElement()
                                         // Ideally should return just empty but filter the unknowns
                                         .filter((result) -> result != SecurityRuleResult.UNKNOWN)
                                         .doAfterSuccess((result) -> logResult(result, method, path, ordered))

--- a/security/src/main/java/io/micronaut/security/rules/AbstractBaseSecurityRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/AbstractBaseSecurityRule.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.rules;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.security.token.MapClaims;
+import io.micronaut.security.token.RolesFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A base class to extend from that provides helper methods to get the roles
+ * from the claims and compare them to the roles allowed by the rule.
+ *
+ * @author James Kleeh
+ * @author Steven Brown
+ * @since 2.4
+ */
+@Internal
+public abstract class AbstractBaseSecurityRule {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBaseSecurityRule.class);
+
+    private final RolesFinder rolesFinder;
+
+    /**
+     * @param rolesFinder Roles Parser
+     */
+    @Inject
+    public AbstractBaseSecurityRule(RolesFinder rolesFinder) {
+        this.rolesFinder = rolesFinder;
+    }
+
+    /**
+     * Appends {@link SecurityRule#IS_ANONYMOUS} if not authenticated. If the
+     * claims contain one or more roles, {@link SecurityRule#IS_AUTHENTICATED} is
+     * appended to the list.
+     *
+     * @param claims The claims of the token, null if not authenticated
+     * @return The granted roles
+     */
+    protected List<String> getRoles(Map<String, Object> claims) {
+        List<String> roles = new ArrayList<>();
+        if (claims == null) {
+            roles.add(SecurityRule.IS_ANONYMOUS);
+        } else {
+            if (!claims.isEmpty()) {
+                roles.addAll(rolesFinder.findInClaims(new MapClaims(claims)));
+            }
+            roles.add(SecurityRule.IS_ANONYMOUS);
+            roles.add(SecurityRule.IS_AUTHENTICATED);
+        }
+
+        return roles;
+    }
+
+    /**
+     * Compares the given roles to determine if the request is allowed by
+     * comparing if any of the granted roles is in the required roles list.
+     *
+     * @param requiredRoles The list of roles required to be authorized
+     * @param grantedRoles The list of roles granted to the user
+     * @return {@link SecurityRuleResult#REJECTED} if none of the granted roles
+     *  appears in the required roles list. {@link SecurityRuleResult#ALLOWED} otherwise.
+     */
+    protected SecurityRuleResult compareRoles(List<String> requiredRoles, List<String> grantedRoles) {
+        if (rolesFinder.hasAnyRequiredRoles(requiredRoles, grantedRoles)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The given roles [{}] matched one or more of the required roles [{}]. Allowing the request", grantedRoles, requiredRoles);
+            }
+            return SecurityRuleResult.ALLOWED;
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("None of the given roles [{}] matched the required roles [{}]. Rejecting the request", grantedRoles, requiredRoles);
+            }
+            return SecurityRuleResult.REJECTED;
+        }
+    }
+}

--- a/security/src/main/java/io/micronaut/security/rules/AbstractReactiveSecurityRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/AbstractReactiveSecurityRule.java
@@ -20,19 +20,19 @@ import io.micronaut.security.token.RolesFinder;
 import javax.inject.Inject;
 
 /**
- * A base {@link SecurityRule} class to extend from that provides
+ * A base {@link ReactiveSecurityRule} class to extend from that provides
  * helper methods to get the roles from the claims and compare them
  * to the roles allowed by the rule.
  *
- * @author James Kleeh
- * @since 1.0
+ * @author Steven Brown
+ * @since 2.4
  */
-public abstract class AbstractSecurityRule extends AbstractBaseSecurityRule implements SecurityRule {
+public abstract class AbstractReactiveSecurityRule extends AbstractBaseSecurityRule implements ReactiveSecurityRule {
     /**
      * @param rolesFinder Roles Parser
      */
     @Inject
-    public AbstractSecurityRule(RolesFinder rolesFinder) {
+    public AbstractReactiveSecurityRule(RolesFinder rolesFinder) {
         super(rolesFinder);
     }
 }

--- a/security/src/main/java/io/micronaut/security/rules/ReactiveSecurityRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/ReactiveSecurityRule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.rules;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.web.router.RouteMatch;
+import org.reactivestreams.Publisher;
+
+import java.util.Map;
+
+/**
+ * Informs the JWT filter what to do with the given request. Use this if your SecurityRule needs to
+ * do any blocking work.
+ *
+ * @author Steven Brown
+ * @since 2.4
+ */
+public interface ReactiveSecurityRule extends Ordered {
+  /**
+   * Returns a flowable of security result based on conditions.
+   *
+   * @param request The current request
+   * @param routeMatch The matched route or empty if no route was matched. e.g. static resource.
+   * @param claims The claims from the token. Null if not authenticated
+   * @return Flowable containing the SecurityRuleResult (allowed or rejected) or empty flowable on
+   *     Unknown
+   * @see SecurityRuleResult
+   */
+  Publisher<SecurityRuleResult> check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims);
+}

--- a/security/src/test/groovy/io/micronaut/security/filters/SecurityFilterSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/filters/SecurityFilterSpec.groovy
@@ -1,121 +1,177 @@
 package io.micronaut.security.filters
 
-import io.micronaut.core.convert.value.MutableConvertibleValues
-import io.micronaut.http.HttpMethod
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
-import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.security.EmbeddedServerSpecification
-import io.micronaut.security.authentication.Authentication
-import io.micronaut.security.authentication.AuthorizationException
-import io.micronaut.security.config.SecurityConfiguration
+import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.ReactiveSecurityRule
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.security.rules.SecurityRuleResult
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.web.router.RouteMatch
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
-import io.reactivex.subscribers.TestSubscriber
-import spock.lang.Unroll
+import org.jetbrains.annotations.Nullable
+import org.reactivestreams.Publisher
 
+import javax.inject.Singleton
 import java.util.concurrent.TimeUnit
 
 import static io.micronaut.security.rules.SecurityRuleResult.ALLOWED
 import static io.micronaut.security.rules.SecurityRuleResult.REJECTED
 import static io.micronaut.security.rules.SecurityRuleResult.UNKNOWN
 
+@MicronautTest(rebuildContext = true)
 class SecurityFilterSpec extends EmbeddedServerSpecification {
+
+    static final String magicString = 'Hello world'
 
     @Override
     String getSpecName() {
         'SecurityFilterSpec'
     }
 
-    @Unroll('#description')
-    def "Filter order is correct"() {
+    @Property(name = "disable.all.rules", value = StringUtils.TRUE)
+    def 'No rules'() {
         given:
-        SecurityFilter filter = new SecurityFilter(rules, reactiveRules, List.of(), Stub(SecurityConfiguration.class))
+        HttpRequest request = HttpRequest.GET('/securityFilter')
 
-        HttpRequest request = Stub(HttpRequest.class) {
-            getPath() >> new URI('/')
-            getMethod() >> HttpMethod.GET
-            getAttributes() >> Stub(MutableConvertibleValues.class)
-        }
+        when:
+        client.exchange(request, String)
 
-        ServerFilterChain chain = Stub(ServerFilterChain.class) {
-            proceed(request) >> {allowed != null ? Flowable.just(HttpResponse.ok()) : Flowable.empty()}
-        }
+        then:
+        HttpClientResponseException e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.UNAUTHORIZED
+    }
 
-        RouteMatch<?> routeMatch = Stub(RouteMatch.class)
-        Authentication authentication = Stub(Authentication.class)
+    @Property(name = "disable.all.rules", value = StringUtils.FALSE)
+    def 'With rules - authorized'() {
+        given:
+        HttpRequest request = HttpRequest.GET('/securityFilter')
 
-        TestSubscriber<HttpResponse<?>> testSubscriber = new TestSubscriber<>()
+        when:
+        Rule1.result = ruleValues[0]
+        Rule2.result = ruleValues[1]
+        Rule3.result = ruleValues[2]
 
-        expect:
-        filter.checkRules(request, chain, routeMatch, authentication).subscribe(testSubscriber)
-        testSubscriber.await()
+        Rule1.delayMs = delayValue
 
-        if (allowed) {
-            testSubscriber.completions() == 1
-            !testSubscriber.timeout
-            testSubscriber.errorCount() == 0
-            testSubscriber.valueCount() == 1
-            testSubscriber.values() == [HttpResponse.ok()]
-        } else {
-            testSubscriber.completions() == 0
-            !testSubscriber.timeout
-            testSubscriber.errorCount() == 1
-            testSubscriber.errors().get(0).class == AuthorizationException.class
-            testSubscriber.valueCount() == 0
-        }
+        HttpResponse<String> response = client.exchange(request, String)
+
+        then:
+        response != null
+        response.getStatus() == HttpStatus.OK
+        response.body() != null
+        response.body() == magicString
 
         where:
-        rules                       | reactiveRules                           | allowed | description
-        []                          | []                                      | false   | 'No rules'
-        [securityRule(0, ALLOWED)]  | []                                      | true    | 'One SecurityRule - allowed'
-        [securityRule(0, REJECTED)] | []                                      | false   | 'One SecurityRule - rejected'
-        [securityRule(0, UNKNOWN)]  | []                                      | false   | 'One SecurityRule - unknown'
-        []                          | [reactiveSecurityRule(0, ALLOWED, 0)]   | true    | 'One ReactiveSecurityRule - allowed'
-        []                          | [reactiveSecurityRule(0, REJECTED, 0)]  | false   | 'One ReactiveSecurityRule - rejected'
-        []                          | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'One ReactiveSecurityRule - unknown'
-
-        // Non-reactive first
-        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, ALLOWED, 0)]   | true    | 'Mixed - rule unknown => reactive allowed, no delay'
-        [securityRule(0, ALLOWED)]  | [reactiveSecurityRule(1, REJECTED, 0)]  | true    | 'Mixed - rule allowed => reactive rejected, no delay'
-        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, REJECTED, 0)]  | false   | 'Mixed - rule unknown => reactive rejected, no delay'
-        [securityRule(0, REJECTED)] | [reactiveSecurityRule(1, ALLOWED, 0)]   | false   | 'Mixed - rule rejected => reactive allowed, no delay'
-        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, UNKNOWN, 0)]   | false   | 'Mixed - rule unknown => reactive unknown, no delay'
-
-        // Reactive first
-        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, UNKNOWN, 0)]   | true    | 'Mixed - reactive unknown => rule allowed, no delay'
-        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, ALLOWED, 0)]   | true    | 'Mixed - reactive allowed => rule rejected, no delay'
-        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'Mixed - reactive unknown => rule rejected, no delay'
-        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, REJECTED, 0)]  | false   | 'Mixed - reactive rejected => rule allowed, no delay'
-        [securityRule(1, UNKNOWN)]  | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'Mixed - reactive unknown => rule unknown, no delay'
+        ruleValues                    | delayValue | description
+        [ALLOWED, REJECTED, REJECTED] | 0          | 'first rule - allowed'
+        [UNKNOWN, ALLOWED, REJECTED]  | 0          | 'second rule - allowed'
+        [UNKNOWN, UNKNOWN, ALLOWED]   | 0          | 'third rule - allowed'
 
         // With delays (cause the reactive to evaluate async and slowly, ensure still correct response)
-        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, ALLOWED, 100)]  | true   | 'Mixed - reactive allowed => rule rejected, 100ms delay'
-        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, REJECTED, 100)] | false  | 'Mixed - reactive rejected => rule allowed, 100ms delay'
+        [ALLOWED, REJECTED, REJECTED] | 100        | 'first allowed after 100ms delay'
 
-        // Multiple of same type, injection sort order incorrect
-        [securityRule(1, REJECTED), securityRule(0, ALLOWED)]  | [] | true  | 'Multiple - rule 0 rejected => rule 1 allowed, no delay'
-        [] | [reactiveSecurityRule(1, REJECTED, 0), reactiveSecurityRule(0, ALLOWED, 0)] | true  | 'Multiple - reactive 0 rejected => reactive 1 allowed, no delay'
     }
 
-    SecurityRule securityRule(int order, SecurityRuleResult result) {
-        Stub(SecurityRule.class) {
-            check(_ as HttpRequest, _ as RouteMatch, _ as Map) >> result
-            getOrder() >> order
+    @Property(name = "disable.all.rules", value = StringUtils.FALSE)
+    def 'With rules - unauthorized'() {
+        given:
+        HttpRequest request = HttpRequest.GET('/securityFilter')
+
+        when:
+        Rule1.result = ruleValues[0]
+        Rule2.result = ruleValues[1]
+        Rule3.result = ruleValues[2]
+
+        Rule1.delayMs = delayValue
+
+        client.exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.UNAUTHORIZED
+
+        where:
+        ruleValues                            | delayValue | description
+        [UNKNOWN, UNKNOWN, UNKNOWN]  | 0      | 'all unknown'
+        [REJECTED, ALLOWED, UNKNOWN] | 0      | 'first rule - rejected'
+        [UNKNOWN, REJECTED, ALLOWED] | 0      | 'second rule - rejected'
+        [UNKNOWN, UNKNOWN, REJECTED] | 0      | 'third rule - rejected'
+
+        // With delays (cause the reactive to evaluate async and slowly, ensure still correct response)
+        [REJECTED, ALLOWED, ALLOWED] | 100    | 'first rejected after 100ms delay'
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = 'SecurityFilterSpec')
+    @Requires(property = "disable.all.rules", notEquals = StringUtils.TRUE)
+    static class Rule1 implements ReactiveSecurityRule {
+        static SecurityRuleResult result = UNKNOWN
+        static int delayMs = 0
+
+        @Override
+        Publisher<SecurityRuleResult> check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims) {
+            return Flowable.timer(delayMs, TimeUnit.MILLISECONDS)
+                    .subscribeOn(Schedulers.io())
+                    .flatMap((l) -> Flowable.just(result))
+        }
+
+        @Override
+        int getOrder() {
+            return HIGHEST_PRECEDENCE
         }
     }
 
-    ReactiveSecurityRule reactiveSecurityRule(int order, SecurityRuleResult result, long delayMs) {
-        Stub(ReactiveSecurityRule.class) {
-            check(_ as HttpRequest, _ as RouteMatch, _ as Map) >>
-                    Flowable.timer(delayMs, TimeUnit.MILLISECONDS)
-                            .subscribeOn(Schedulers.io())
-                            .flatMap((l) -> Flowable.just(result))
-            getOrder() >> order
+    @Singleton
+    @Requires(property = "spec.name", value = 'SecurityFilterSpec')
+    @Requires(property = "disable.all.rules", notEquals = StringUtils.TRUE)
+    static class Rule2 implements SecurityRule {
+        static SecurityRuleResult result = UNKNOWN
+
+        @Override
+        SecurityRuleResult check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims) {
+            return result
+        }
+
+        @Override
+        int getOrder() {
+            return HIGHEST_PRECEDENCE + 1
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = 'SecurityFilterSpec')
+    @Requires(property = "disable.all.rules", notEquals = StringUtils.TRUE)
+    static class Rule3 implements ReactiveSecurityRule {
+        static SecurityRuleResult result = UNKNOWN
+
+        @Override
+        Publisher<SecurityRuleResult> check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims) {
+            return Flowable.just(result)
+        }
+
+        @Override
+        int getOrder() {
+            return HIGHEST_PRECEDENCE + 2
+        }
+    }
+
+    @Requires(property = "spec.name", value = 'SecurityFilterSpec')
+    @Controller('/securityFilter')
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    static class TestController {
+        @Get
+        String get() {
+            return magicString
         }
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/filters/SecurityFilterSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/filters/SecurityFilterSpec.groovy
@@ -1,0 +1,121 @@
+package io.micronaut.security.filters
+
+import io.micronaut.core.convert.value.MutableConvertibleValues
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.security.EmbeddedServerSpecification
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.authentication.AuthorizationException
+import io.micronaut.security.config.SecurityConfiguration
+import io.micronaut.security.rules.ReactiveSecurityRule
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.security.rules.SecurityRuleResult
+import io.micronaut.web.router.RouteMatch
+import io.reactivex.Flowable
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subscribers.TestSubscriber
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+import static io.micronaut.security.rules.SecurityRuleResult.ALLOWED
+import static io.micronaut.security.rules.SecurityRuleResult.REJECTED
+import static io.micronaut.security.rules.SecurityRuleResult.UNKNOWN
+
+class SecurityFilterSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'SecurityFilterSpec'
+    }
+
+    @Unroll('#description')
+    def "Filter order is correct"() {
+        given:
+        SecurityFilter filter = new SecurityFilter(rules, reactiveRules, List.of(), Stub(SecurityConfiguration.class))
+
+        HttpRequest request = Stub(HttpRequest.class) {
+            getPath() >> new URI('/')
+            getMethod() >> HttpMethod.GET
+            getAttributes() >> Stub(MutableConvertibleValues.class)
+        }
+
+        ServerFilterChain chain = Stub(ServerFilterChain.class) {
+            proceed(request) >> {allowed != null ? Flowable.just(HttpResponse.ok()) : Flowable.empty()}
+        }
+
+        RouteMatch<?> routeMatch = Stub(RouteMatch.class)
+        Authentication authentication = Stub(Authentication.class)
+
+        TestSubscriber<HttpResponse<?>> testSubscriber = new TestSubscriber<>()
+
+        expect:
+        filter.checkRules(request, chain, routeMatch, authentication).subscribe(testSubscriber)
+        testSubscriber.await()
+
+        if (allowed) {
+            testSubscriber.completions() == 1
+            !testSubscriber.timeout
+            testSubscriber.errorCount() == 0
+            testSubscriber.valueCount() == 1
+            testSubscriber.values() == [HttpResponse.ok()]
+        } else {
+            testSubscriber.completions() == 0
+            !testSubscriber.timeout
+            testSubscriber.errorCount() == 1
+            testSubscriber.errors().get(0).class == AuthorizationException.class
+            testSubscriber.valueCount() == 0
+        }
+
+        where:
+        rules                       | reactiveRules                           | allowed | description
+        []                          | []                                      | false   | 'No rules'
+        [securityRule(0, ALLOWED)]  | []                                      | true    | 'One SecurityRule - allowed'
+        [securityRule(0, REJECTED)] | []                                      | false   | 'One SecurityRule - rejected'
+        [securityRule(0, UNKNOWN)]  | []                                      | false   | 'One SecurityRule - unknown'
+        []                          | [reactiveSecurityRule(0, ALLOWED, 0)]   | true    | 'One ReactiveSecurityRule - allowed'
+        []                          | [reactiveSecurityRule(0, REJECTED, 0)]  | false   | 'One ReactiveSecurityRule - rejected'
+        []                          | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'One ReactiveSecurityRule - unknown'
+
+        // Non-reactive first
+        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, ALLOWED, 0)]   | true    | 'Mixed - rule unknown => reactive allowed, no delay'
+        [securityRule(0, ALLOWED)]  | [reactiveSecurityRule(1, REJECTED, 0)]  | true    | 'Mixed - rule allowed => reactive rejected, no delay'
+        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, REJECTED, 0)]  | false   | 'Mixed - rule unknown => reactive rejected, no delay'
+        [securityRule(0, REJECTED)] | [reactiveSecurityRule(1, ALLOWED, 0)]   | false   | 'Mixed - rule rejected => reactive allowed, no delay'
+        [securityRule(0, UNKNOWN)]  | [reactiveSecurityRule(1, UNKNOWN, 0)]   | false   | 'Mixed - rule unknown => reactive unknown, no delay'
+
+        // Reactive first
+        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, UNKNOWN, 0)]   | true    | 'Mixed - reactive unknown => rule allowed, no delay'
+        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, ALLOWED, 0)]   | true    | 'Mixed - reactive allowed => rule rejected, no delay'
+        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'Mixed - reactive unknown => rule rejected, no delay'
+        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, REJECTED, 0)]  | false   | 'Mixed - reactive rejected => rule allowed, no delay'
+        [securityRule(1, UNKNOWN)]  | [reactiveSecurityRule(0, UNKNOWN, 0)]   | false   | 'Mixed - reactive unknown => rule unknown, no delay'
+
+        // With delays (cause the reactive to evaluate async and slowly, ensure still correct response)
+        [securityRule(1, REJECTED)] | [reactiveSecurityRule(0, ALLOWED, 100)]  | true   | 'Mixed - reactive allowed => rule rejected, 100ms delay'
+        [securityRule(1, ALLOWED)]  | [reactiveSecurityRule(0, REJECTED, 100)] | false  | 'Mixed - reactive rejected => rule allowed, 100ms delay'
+
+        // Multiple of same type, injection sort order incorrect
+        [securityRule(1, REJECTED), securityRule(0, ALLOWED)]  | [] | true  | 'Multiple - rule 0 rejected => rule 1 allowed, no delay'
+        [] | [reactiveSecurityRule(1, REJECTED, 0), reactiveSecurityRule(0, ALLOWED, 0)] | true  | 'Multiple - reactive 0 rejected => reactive 1 allowed, no delay'
+    }
+
+    SecurityRule securityRule(int order, SecurityRuleResult result) {
+        Stub(SecurityRule.class) {
+            check(_ as HttpRequest, _ as RouteMatch, _ as Map) >> result
+            getOrder() >> order
+        }
+    }
+
+    ReactiveSecurityRule reactiveSecurityRule(int order, SecurityRuleResult result, long delayMs) {
+        Stub(ReactiveSecurityRule.class) {
+            check(_ as HttpRequest, _ as RouteMatch, _ as Map) >>
+                    Flowable.timer(delayMs, TimeUnit.MILLISECONDS)
+                            .subscribeOn(Schedulers.io())
+                            .flatMap((l) -> Flowable.just(result))
+            getOrder() >> order
+        }
+    }
+}

--- a/src/main/docs/guide/securityRule.adoc
+++ b/src/main/docs/guide/securityRule.adoc
@@ -1,10 +1,10 @@
 The decision to allow access to a particular endpoint to anonymous or authenticated users is determined by a collection of
 Security Rules. Micronaut ships with several built-in security rules. If they don't fulfil your needs,
-you can implement your own link:{api}/io/micronaut/security/rules/SecurityRule.html[SecurityRule].
+you can implement your own link:{api}/io/micronaut/security/rules/SecurityRule.html[SecurityRule] or link:{api}/io/micronaut/security/rules/ReactiveSecurityRule.tml[ReactiveSecurityRule]. You should use the Reactive variant and subscribe on another thread pool if you need to do any blocking work in order to not block the netty event loop.
 
 Security rules implement the ordered interface and they are executed in order. All of the existing rules have a static variable `ORDER` that stores the order of that rule. You can use those variables to place your own rule before or after any of the existing rules.
 
-Security rules return a api:security.rules.SecurityRuleResult[]. See the following table for a description of each result.
+Security rules return a api:security.rules.SecurityRuleResult[] while Reactive security rules return a publisher of api:security.rules.SecurityRuleResult[]. See the following table for a description of each result.
 
 |===
 |Result |Description


### PR DESCRIPTION
Adds a `ReactiveSecurityRule` and updates the `SecurityFilter` to sort and interleave reactive and normal `SecurityRule` objects in order to enable blocking work without blocking the netty event loop.

Solution based on the proposed solution offered up by @jameskleeh on Gitter.

Starting this off as a draft to get some early feedback (and tips on the reactive stuff, still learning it, might be wrong) before I start on tests and documentation.

Edit: Just wanted to note that we have been successfully running this version in our codebase now for almost two days via `@Replaces`