### PR TITLE
add logic for roles endpoints sentitive (exclude health). issue https://github.com/micronaut-projects/micronaut-security/issues/606

### DIFF
--- a/security/src/main/java/io/micronaut/security/rules/RoleEndpointSensitiveRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/RoleEndpointSensitiveRule.java
@@ -1,0 +1,55 @@
+package io.micronaut.security.rules;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.management.endpoint.EndpointSensitivityProcessor;
+import io.micronaut.security.token.RolesFinder;
+import io.micronaut.web.router.MethodBasedRouteMatch;
+import io.micronaut.web.router.RouteMatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+import java.util.*;
+
+@Singleton
+public class RoleEndpointSensitiveRule extends AbstractSecurityRule {
+    private static final Logger LOG = LoggerFactory.getLogger(InterceptUrlMapRule.class);
+
+    protected final Map<ExecutableMethod, Boolean> endpointMethods;
+    protected final RolesFinder rolesFinder;
+    protected final String EXCLUDE_METHOD = "getHealth";
+    protected final String PROPERTY_ROLES = "endpoints.roles";
+    protected final ArrayList<String> requiredRoles;
+
+    RoleEndpointSensitiveRule(
+            EndpointSensitivityProcessor endpointSensitivityProcessor,
+            RolesFinder rolesFinder,
+            PropertyResolver propertyResolver
+    ) {
+        super(rolesFinder);
+        this.endpointMethods = endpointSensitivityProcessor.getEndpointMethods();
+        this.rolesFinder = rolesFinder;
+        this.requiredRoles = new ArrayList(Arrays.asList(propertyResolver.get(PROPERTY_ROLES, String[].class).orElse(new String[0])));
+        this.requiredRoles.removeAll(Collections.singleton(""));
+    }
+
+    @Override
+    public SecurityRuleResult check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims) {
+        if (routeMatch instanceof MethodBasedRouteMatch) {
+            ExecutableMethod method = ((MethodBasedRouteMatch) routeMatch).getExecutableMethod();
+
+            if (endpointMethods.containsKey(method) && !method.getMethodName().equals(EXCLUDE_METHOD)) {
+                if (!this.requiredRoles.isEmpty()) return super.compareRoles(this.requiredRoles, super.getRoles(claims));
+            }
+        }
+        return SecurityRuleResult.UNKNOWN;
+    }
+
+    @Override
+    public int getOrder() {
+        return SensitiveEndpointRule.ORDER - 1;
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/rules/sensitive/RoleEmptyEndpointSensitiveRuleSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rules/sensitive/RoleEmptyEndpointSensitiveRuleSpec.groovy
@@ -1,0 +1,24 @@
+package io.micronaut.security.rules.sensitive
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.security.EmbeddedServerSpecification
+
+class RoleEmptyEndpointSensitiveRuleSpec extends EmbeddedServerSpecification {
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'endpoints.env.sensitive': false,
+                'endpoints.roles': "",
+
+        ]
+    }
+
+    void "if endpoint has roles empty is set via configuration property"() {
+        when:
+        HttpResponse<String> response = client.exchange(HttpRequest.GET("/env"), String)
+
+        then:
+        response.body() != null
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/rules/sensitive/RoleNotEmptyEndpointSensitiveRuleSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rules/sensitive/RoleNotEmptyEndpointSensitiveRuleSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.security.rules.sensitive
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.security.EmbeddedServerSpecification
+
+class RoleNotEmptyEndpointSensitiveRuleSpec extends EmbeddedServerSpecification {
+    @Override
+    String getSpecName() {
+        'EndpointWithRoleAndSensitivityOverrideSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'endpoints.env.sensitive': false,
+                'endpoints.roles': "admin,guest",
+
+        ]
+    }
+
+    void "if endpoint has roles is set via configuration property, it overrides default list empty"() {
+        when:
+        HttpResponse<String> response = client.exchange(HttpRequest.GET("/env"), String)
+
+        then:
+        HttpClientResponseException e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.UNAUTHORIZED
+    }
+}
+


### PR DESCRIPTION
This logic helps for configure roles in properties and send response UNAUTHORIZED when not apply roles (only when you configure that properties endpoints.roles), Only apply for endpoints sensitive minus health. 

This PR improves security because any logged in user can see all the specific sensitive routes 