### PR TITLE
remove unuecessary repository block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,18 +9,6 @@ buildscript {
 
 subprojects { Project subproject ->
     group "io.micronaut.security"
-
-    repositories {
-        maven { url "https://dl.bintray.com/micronaut/core-releases-local" }
-        jcenter()
-        maven {
-            url "https://oss.jfrog.org/oss-snapshot-local"
-            content {
-                includeVersionByRegex('.*', '.*', '.*SNAPSHOT')
-            }
-        }
-    }
-
     apply plugin: "io.micronaut.build.internal.common"
 
     if (subproject.parent.name == "examples" || subproject.name == "examples") {


### PR DESCRIPTION
[Project template](https://github.com/micronaut-projects/micronaut-project-template) no longer contains a repositories block for root `build.gradle`