### PR TITLE
docs: improve documentation about SensitiveEndpointRule replacement

### DIFF
--- a/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
@@ -15,15 +15,25 @@
  */
 package io.micronaut.security.rules;
 
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.management.endpoint.EndpointSensitivityProcessor;
+import io.micronaut.management.endpoint.beans.BeansEndpoint;
+import io.micronaut.management.endpoint.env.EnvironmentEndpoint;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.endpoint.info.InfoEndpoint;
+import io.micronaut.management.endpoint.loggers.LoggersEndpoint;
+import io.micronaut.management.endpoint.refresh.RefreshEndpoint;
+import io.micronaut.management.endpoint.routes.RoutesEndpoint;
+import io.micronaut.management.endpoint.stop.ServerStopEndpoint;
+import io.micronaut.management.endpoint.threads.ThreadDumpEndpoint;
 import io.micronaut.web.router.MethodBasedRouteMatch;
 import io.micronaut.web.router.RouteMatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micronaut.core.annotation.Nullable;
 import javax.inject.Singleton;
 import java.util.Map;
 
@@ -42,7 +52,16 @@ public class SensitiveEndpointRule implements SecurityRule {
      */
     public static final Integer ORDER = 0;
 
-    private static final Logger LOG = LoggerFactory.getLogger(InterceptUrlMapRule.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SensitiveEndpointRule.class);
+    private static final String ENDPOINTS_BEANS = "beans";
+    private static final String ENDPOINTS_INFO = "info";
+    private static final String ENDPOINTS_HEALTH = "health";
+    private static final String ENDPOINTS_REFRESH = "refresh";
+    private static final String ENDPOINTS_ROUTES = "routes";
+    private static final String ENDPOINTS_LOGGERS = "loggers";
+    private static final String ENDPOINTS_SERVER_STOP = "serverStop";
+    private static final String ENDPOINTS_ENVIRONMENT = "environment";
+    private static final String ENDPOINTS_THREAD_DUMP = "threadDump";
 
     /**
      * A map where the key represents the method of an endpoint
@@ -64,28 +83,115 @@ public class SensitiveEndpointRule implements SecurityRule {
     @Override
     public SecurityRuleResult check(HttpRequest<?> request, @Nullable RouteMatch<?> routeMatch, @Nullable Map<String, Object> claims) {
         if (routeMatch instanceof MethodBasedRouteMatch) {
-            ExecutableMethod method = ((MethodBasedRouteMatch) routeMatch).getExecutableMethod();
-
+            ExecutableMethod<?, ?> method = ((MethodBasedRouteMatch<?, ?>) routeMatch).getExecutableMethod();
             if (endpointMethods.containsKey(method)) {
-                Boolean sensitive = endpointMethods.get(method);
-                if (claims == null && sensitive) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("The endpoint method [{}] is sensitive and no authentication was found. Rejecting the request", method);
-                    }
-                    return SecurityRuleResult.REJECTED;
-                } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("The endpoint method [{}] is not sensitive or the request was authenticated. Allowing the request", method);
-                    }
-                    return SecurityRuleResult.ALLOWED;
-                }
+                return check(request, claims, method);
             }
         }
         return SecurityRuleResult.UNKNOWN;
     }
 
+    /**
+     * Evaluate the Endpoint's method.
+     * @param request HTTP Request
+     * @param claims Claims of authenticated user. null if the user is not authenticated
+     * @param method Route method
+     * @return The Result
+     */
+    @NonNull
+    protected SecurityRuleResult check(@NonNull HttpRequest<?> request,
+                                       @Nullable Map<String, Object> claims,
+                                       @NonNull ExecutableMethod<?, ?> method) {
+        Boolean sensitive = endpointMethods.get(method);
+        if (sensitive) {
+            if (claims == null) {
+                return checkSensitiveAnonymous(request, method);
+            }
+            return checkSensitiveAuthenticated(request, claims, method);
+        }
+        return checkNotSensitive(request, claims, method);
+    }
+
     @Override
     public int getOrder() {
         return ORDER;
+    }
+
+    /**
+     * Evaluates a sensitive endpoint for an authenticated user.
+     * @param request HTTP Request
+     * @param claims Claims of authenticated user.
+     * @param method Endpoint's method
+     * @return The Result
+     */
+    @NonNull
+    protected SecurityRuleResult checkSensitiveAuthenticated(@NonNull HttpRequest<?> request,
+                                                             @NonNull Map<String, Object> claims,
+                                                             @NonNull ExecutableMethod<?, ?> method) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("authentication was found for sensitive {} endpoint. Allowing the request.", endpointName(method));
+        }
+        return SecurityRuleResult.ALLOWED;
+    }
+
+    /**
+     * Evaluates a sensitive endpoint for an anonymous user.
+     * @param request HTTP Request
+     * @param method Endpoint's method
+     * @return The Result
+     */
+    @NonNull
+    protected SecurityRuleResult checkSensitiveAnonymous(@NonNull HttpRequest<?> request,
+                                                         @NonNull ExecutableMethod<?, ?> method) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} endpoint is sensitive and no authentication was found. Rejecting the request.", endpointName(method));
+        }
+        return SecurityRuleResult.REJECTED;
+    }
+
+    /**
+     * Evaluates a non sensitive endpoint.
+     * @param request HTTP Request
+     * @param claims Claims of authenticated user. null if the user is not authenticated.
+     * @param method Endpoint's method
+     * @return The Result
+     */
+    @NonNull
+    protected SecurityRuleResult checkNotSensitive(@NonNull HttpRequest<?> request,
+                                                   @Nullable Map<String, Object> claims,
+                                                   @NonNull ExecutableMethod<?, ?> method) {
+        if (LOG.isTraceEnabled()) {
+            LOG.debug("{} endpoint is not sensitive. Allowing the request.", endpointName(method));
+        }
+        return SecurityRuleResult.ALLOWED;
+    }
+
+    /**
+     * @param method Endpoint's method
+     * @return A string identifying the Endpoint
+     */
+    @NonNull
+    protected String endpointName(@NonNull ExecutableMethod<?, ?> method) {
+        Class<?> endpointClass = method.getDeclaringType();
+        if (endpointClass == BeansEndpoint.class) {
+            return ENDPOINTS_BEANS;
+        } else if (endpointClass == InfoEndpoint.class) {
+            return ENDPOINTS_INFO;
+        } else if (endpointClass == HealthEndpoint.class) {
+            return ENDPOINTS_HEALTH;
+        } else if (endpointClass == RefreshEndpoint.class) {
+            return ENDPOINTS_REFRESH;
+        } else if (endpointClass == RoutesEndpoint.class) {
+            return ENDPOINTS_ROUTES;
+        } else if (endpointClass == LoggersEndpoint.class) {
+            return ENDPOINTS_LOGGERS;
+        } else if (endpointClass == ServerStopEndpoint.class) {
+            return ENDPOINTS_SERVER_STOP;
+        } else if (endpointClass == EnvironmentEndpoint.class) {
+            return ENDPOINTS_ENVIRONMENT;
+        } else if (endpointClass == ThreadDumpEndpoint.class) {
+            return ENDPOINTS_THREAD_DUMP;
+        }
+        return method.getDeclaringType().getSimpleName();
     }
 }

--- a/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
@@ -57,7 +57,7 @@ public class SensitiveEndpointRule implements SecurityRule {
      *
      * @param endpointSensitivityProcessor The endpoint configurations
      */
-    SensitiveEndpointRule(EndpointSensitivityProcessor endpointSensitivityProcessor) {
+    public SensitiveEndpointRule(EndpointSensitivityProcessor endpointSensitivityProcessor) {
         this.endpointMethods = endpointSensitivityProcessor.getEndpointMethods();
     }
 

--- a/src/main/docs/guide/securityRule/builtInEndpointsAccess.adoc
+++ b/src/main/docs/guide/securityRule/builtInEndpointsAccess.adoc
@@ -7,3 +7,7 @@ include::{testssecurity}/security/securityRule/builtinendpoints/BuiltInEndpoints
 
 <1> `/beans` endpoint is secured
 <2> `/info` endpoint is open for unauthenticated access.
+
+By default, authenticated users are allowed to access sensitive endpoints. To change that behaviour, replace the default implementation api:security.rules.SensitiveEndpointRule[] with your own. For example, you may want to restrict access to users with a specific role:
+
+snippet::io.micronaut.security.oauth2.docs.managementendpoints.SensitiveEndpointRuleReplacement[tags="imports,clazz"]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggerSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggerSpec.groovy
@@ -1,0 +1,94 @@
+package io.micronaut.security.oauth2.docs.managementendpoints
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.security.authentication.*
+import io.micronaut.security.oauth2.docs.EmbeddedServerSpecification
+import io.reactivex.Maybe
+import org.reactivestreams.Publisher
+import javax.inject.Singleton
+
+class LoggersSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'LoggersSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+            'endpoints.loggers.enabled': true,
+            'endpoints.loggers.sensitive': true,
+            'endpoints.health.enabled': true,
+            'endpoints.health.sensitive': false,
+        ]
+    }
+
+    void "/health endpoint is not secured"() {
+        when:
+        HttpResponse<?> response = client.exchange(HttpRequest.GET('/health'))
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+    }
+
+    void "/loggers endpoint is secured"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNAUTHORIZED
+    }
+
+    void "/loggers endpoint is accessible for users with role ROLE_SYSTEM"() {
+        given:
+        HttpRequest<?> request = HttpRequest.GET('/loggers').basicAuth('system', 'password')
+
+        when:
+        HttpResponse<Map> response = client.exchange(request, Map)
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+
+        when:
+        Map m = response.body()
+
+        then:
+        m.containsKey('levels')
+        m.containsKey('loggers')
+    }
+
+    void "/loggers endpoint is not accessible for users without role ROLE_SYSTEM"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers').basicAuth('user', 'password'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.FORBIDDEN
+    }
+
+    @Requires(property = 'spec.name', value = 'LoggersSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            return Maybe.<AuthenticationResponse>create(emitter -> {
+                if (authenticationRequest.identity == "user" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("user", []))
+                } else if (authenticationRequest.identity == "system" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("admin", ['ROLE_SYSTEM']))
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+            }).toFlowable()
+        }
+    }
+}

--- a/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.security.oauth2.docs.managementendpoints
+
+//tag::imports[]
+import javax.inject.Singleton
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpRequest
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.management.endpoint.EndpointSensitivityProcessor
+import io.micronaut.security.rules.SecurityRuleResult
+import io.micronaut.security.rules.SensitiveEndpointRule
+import io.micronaut.security.token.MapClaims
+import io.micronaut.security.token.RolesFinder
+//end::imports[]
+
+@Requires(property = "spec.name", value = "LoggersSpec")
+//tag::clazz[]
+@Replaces(SensitiveEndpointRule.class)
+@Singleton
+class SensitiveEndpointRuleReplacement extends SensitiveEndpointRule {
+    private final RolesFinder rolesFinder;
+
+    SensitiveEndpointRuleReplacement(EndpointSensitivityProcessor endpointSensitivityProcessor,
+                                            RolesFinder rolesFinder) {
+        super(endpointSensitivityProcessor)
+        this.rolesFinder = rolesFinder
+    }
+
+    @Override
+    @NonNull
+    protected SecurityRuleResult checkSensitiveAuthenticated(@NonNull HttpRequest<?> request,
+                                                             @NonNull Map<String, Object> claims,
+                                                             @NonNull ExecutableMethod<?, ?> method) {
+        rolesFinder.hasAnyRequiredRoles(["ROLE_SYSTEM"], new MapClaims(claims))
+                ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED
+    }
+}
+//end::clazz[]

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,8 +1,10 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.4.32"
+    id("org.jetbrains.kotlin.kapt") version "1.4.32"
 }
 
 dependencies {
+    kaptTest "io.micronaut:micronaut-inject-java:$micronautVersion"
     testImplementation "io.micronaut:micronaut-http-server-netty"
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation project(":security-jwt")

--- a/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/ConfigurationFixture.groovy
+++ b/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/ConfigurationFixture.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.security.oauth2.docs
+
+trait ConfigurationFixture {
+    Map<String, Object> getConfiguration() {
+        Map<String, Object> m = [:]
+        if (specName) {
+            m['spec.name'] = specName
+        }
+        m += loginHandlerCookieConfiguration
+        m += oauth2ClientConfiguration
+        m
+    }
+
+    String getOpenIdClientName() {
+        'github'
+    }
+
+    String getSpecName() {
+        null
+    }
+
+    String getIssuer() {
+        null
+    }
+
+    Map<String, Object> getLoginHandlerCookieConfiguration() {
+        ['micronaut.security.authentication': 'cookie'] as Map<String, Object>
+    }
+
+    Map<String, Object> getOauth2ClientConfiguration() {
+        Map m = [
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-id".toString()): 'XXXX',
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-secret".toString()): 'YYYY',
+        ]
+        if (issuer != null) {
+            m[("micronaut.security.oauth2.clients.${openIdClientName}.openid.issuer".toString())] = issuer
+        }
+        m
+    }
+}

--- a/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/EmbeddedServerSpecification.groovy
+++ b/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/EmbeddedServerSpecification.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.security.oauth2.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class EmbeddedServerSpecification extends Specification implements ConfigurationFixture {
+
+    @AutoCleanup
+    @Shared
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, configuration)
+
+    @Shared
+    ApplicationContext applicationContext = embeddedServer.applicationContext
+
+    @Shared
+    HttpClient httpClient = applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    @Shared
+    BlockingHttpClient client = httpClient.toBlocking()
+}

--- a/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggersSpec.groovy
+++ b/test-suite-kotlin/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggersSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.security.oauth2.docs.managementendpoints
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.security.authentication.*
+import io.micronaut.security.oauth2.docs.EmbeddedServerSpecification
+import io.reactivex.Maybe
+import org.reactivestreams.Publisher
+
+import javax.inject.Singleton
+
+class LoggersSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'LoggersSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'endpoints.loggers.enabled': true,
+                'endpoints.loggers.sensitive': true,
+                'endpoints.health.enabled': true,
+                'endpoints.health.sensitive': false,
+        ]
+    }
+
+    void "/health endpoint is not secured"() {
+        when:
+        HttpResponse<?> response = client.exchange(HttpRequest.GET('/health'))
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+    }
+
+    void "/loggers endpoint is secured"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNAUTHORIZED
+    }
+
+    void "/loggers endpoint is accessible for users with role ROLE_SYSTEM"() {
+        given:
+        HttpRequest<?> request = HttpRequest.GET('/loggers').basicAuth('system', 'password')
+
+        when:
+        HttpResponse<Map> response = client.exchange(request, Map)
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+
+        when:
+        Map m = response.body()
+
+        then:
+        m.containsKey('levels')
+        m.containsKey('loggers')
+    }
+
+    void "/loggers endpoint is not accessible for users without role ROLE_SYSTEM"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers').basicAuth('user', 'password'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.FORBIDDEN
+    }
+
+    @Requires(property = 'spec.name', value = 'LoggersSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            return Maybe.<AuthenticationResponse>create(emitter -> {
+                if (authenticationRequest.identity == "user" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("user", []))
+                } else if (authenticationRequest.identity == "system" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("admin", ['ROLE_SYSTEM']))
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+            }).toFlowable()
+        }
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.kt
@@ -1,0 +1,30 @@
+package io.micronaut.security.oauth2.docs.managementendpoints
+
+//tag::imports[]
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.http.HttpRequest
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.management.endpoint.EndpointSensitivityProcessor
+import io.micronaut.security.rules.SecurityRuleResult
+import io.micronaut.security.rules.SensitiveEndpointRule
+import io.micronaut.security.token.MapClaims
+import io.micronaut.security.token.RolesFinder
+import javax.inject.Singleton
+//end::imports[]
+
+@Requires(property = "spec.name", value = "LoggersSpec")
+//tag::clazz[]
+@Replaces(SensitiveEndpointRule::class)
+@Singleton
+class SensitiveEndpointRuleReplacement(endpointSensitivityProcessor: EndpointSensitivityProcessor,
+                                       private val rolesFinder: RolesFinder) : SensitiveEndpointRule(endpointSensitivityProcessor) {
+    @NonNull
+    override fun checkSensitiveAuthenticated(@NonNull request: HttpRequest<*>,
+                                             @NonNull claims: Map<String, Any>,
+                                             @NonNull method: ExecutableMethod<*, *>): SecurityRuleResult {
+        return if (rolesFinder.hasAnyRequiredRoles(listOf("ROLE_SYSTEM"), MapClaims(claims))) SecurityRuleResult.ALLOWED else SecurityRuleResult.REJECTED
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/ConfigurationFixture.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/ConfigurationFixture.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.security.oauth2.docs
+
+trait ConfigurationFixture {
+    Map<String, Object> getConfiguration() {
+        Map<String, Object> m = [:]
+        if (specName) {
+            m['spec.name'] = specName
+        }
+        m += loginHandlerCookieConfiguration
+        m += oauth2ClientConfiguration
+        m
+    }
+
+    String getOpenIdClientName() {
+        'github'
+    }
+
+    String getSpecName() {
+        null
+    }
+
+    String getIssuer() {
+        null
+    }
+
+    Map<String, Object> getLoginHandlerCookieConfiguration() {
+        ['micronaut.security.authentication': 'cookie'] as Map<String, Object>
+    }
+
+    Map<String, Object> getOauth2ClientConfiguration() {
+        Map m = [
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-id".toString()): 'XXXX',
+                ("micronaut.security.oauth2.clients.${openIdClientName}.client-secret".toString()): 'YYYY',
+        ]
+        if (issuer != null) {
+            m[("micronaut.security.oauth2.clients.${openIdClientName}.openid.issuer".toString())] = issuer
+        }
+        m
+    }
+}

--- a/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/EmbeddedServerSpecification.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/EmbeddedServerSpecification.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.security.oauth2.docs
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+abstract class EmbeddedServerSpecification extends Specification implements ConfigurationFixture {
+
+    @AutoCleanup
+    @Shared
+    EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, configuration)
+
+    @Shared
+    ApplicationContext applicationContext = embeddedServer.applicationContext
+
+    @Shared
+    HttpClient httpClient = applicationContext.createBean(HttpClient, embeddedServer.URL)
+
+    @Shared
+    BlockingHttpClient client = httpClient.toBlocking()
+}

--- a/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggersSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/security/oauth2/docs/managementendpoints/LoggersSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.security.oauth2.docs.managementendpoints
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.security.authentication.*
+import io.micronaut.security.oauth2.docs.EmbeddedServerSpecification
+import io.reactivex.Maybe
+import org.reactivestreams.Publisher
+
+import javax.inject.Singleton
+
+class LoggersSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'LoggersSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'endpoints.loggers.enabled': true,
+                'endpoints.loggers.sensitive': true,
+                'endpoints.health.enabled': true,
+                'endpoints.health.sensitive': false,
+        ]
+    }
+
+    void "/health endpoint is not secured"() {
+        when:
+        HttpResponse<?> response = client.exchange(HttpRequest.GET('/health'))
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+    }
+
+    void "/loggers endpoint is secured"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNAUTHORIZED
+    }
+
+    void "/loggers endpoint is accessible for users with role ROLE_SYSTEM"() {
+        given:
+        HttpRequest<?> request = HttpRequest.GET('/loggers').basicAuth('system', 'password')
+
+        when:
+        HttpResponse<Map> response = client.exchange(request, Map)
+
+        then:
+        noExceptionThrown()
+        response.status() == HttpStatus.OK
+
+        when:
+        Map m = response.body()
+
+        then:
+        m.containsKey('levels')
+        m.containsKey('loggers')
+    }
+
+    void "/loggers endpoint is not accessible for users without role ROLE_SYSTEM"() {
+        when:
+        client.exchange(HttpRequest.GET('/loggers').basicAuth('user', 'password'))
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.FORBIDDEN
+    }
+
+    @Requires(property = 'spec.name', value = 'LoggersSpec')
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider {
+
+        @Override
+        Publisher<AuthenticationResponse> authenticate(HttpRequest<?> httpRequest, AuthenticationRequest<?, ?> authenticationRequest) {
+            return Maybe.<AuthenticationResponse>create(emitter -> {
+                if (authenticationRequest.identity == "user" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("user", []))
+                } else if (authenticationRequest.identity == "system" && authenticationRequest.secret == "password") {
+                    emitter.onSuccess(new UserDetails("admin", ['ROLE_SYSTEM']))
+                } else {
+                    emitter.onError(new AuthenticationException(new AuthenticationFailed()))
+                }
+            }).toFlowable()
+        }
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.java
+++ b/test-suite/src/test/java/io/micronaut/security/oauth2/docs/managementendpoints/SensitiveEndpointRuleReplacement.java
@@ -1,0 +1,41 @@
+package io.micronaut.security.oauth2.docs.managementendpoints;
+
+//tag::imports[]
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.management.endpoint.EndpointSensitivityProcessor;
+import io.micronaut.security.rules.SecurityRuleResult;
+import io.micronaut.security.rules.SensitiveEndpointRule;
+import io.micronaut.security.token.MapClaims;
+import io.micronaut.security.token.RolesFinder;
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.Map;
+//end::imports[]
+
+@Requires(property = "spec.name", value = "LoggersSpec")
+//tag::clazz[]
+@Replaces(SensitiveEndpointRule.class)
+@Singleton
+public class SensitiveEndpointRuleReplacement extends SensitiveEndpointRule {
+    private final RolesFinder rolesFinder;
+
+    public SensitiveEndpointRuleReplacement(EndpointSensitivityProcessor endpointSensitivityProcessor,
+                                            RolesFinder rolesFinder) {
+        super(endpointSensitivityProcessor);
+        this.rolesFinder = rolesFinder;
+    }
+
+    @Override
+    @NonNull
+    protected SecurityRuleResult checkSensitiveAuthenticated(@NonNull HttpRequest<?> request,
+                                                             @NonNull Map<String, Object> claims,
+                                                             @NonNull ExecutableMethod<?, ?> method) {
+        return rolesFinder.hasAnyRequiredRoles(Collections.singletonList("ROLE_SYSTEM"), new MapClaims(claims))
+                    ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED;
+    }
+}
+//end::clazz[]


### PR DESCRIPTION
close: https://github.com/micronaut-projects/micronaut-security/issues/606
close: https://github.com/micronaut-projects/micronaut-security/pull/589

@oscarcitoz this PR refactors `SensitiveEndpointRule` to ease replacement. Moreover, it documents how to restrict management endpoints for a particular role.