### PR TITLE
Make public access to getCookies methods in CookieLoginHandler class.

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/CookieLoginHandler.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/CookieLoginHandler.java
@@ -108,9 +108,9 @@ public abstract class CookieLoginHandler implements RedirectingLoginHandler {
         this.priorToLoginPersistence = null;
     }
 
-    protected abstract List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request);
+    public abstract List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request);
 
-    protected abstract List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request);
+    public abstract List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request);
 
     @Override
     public MutableHttpResponse<?> loginSuccess(UserDetails userDetails, HttpRequest<?> request) {

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieLoginHandler.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/cookie/JwtCookieLoginHandler.java
@@ -146,7 +146,7 @@ public class JwtCookieLoginHandler extends CookieLoginHandler {
     }
 
     @Override
-    protected List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request) {
+    public List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request) {
         AccessRefreshToken accessRefreshToken = accessRefreshTokenGenerator.generate(userDetails)
                 .orElseThrow(() -> new OauthErrorResponseException(ObtainingAuthorizationErrorCode.SERVER_ERROR, "Cannot obtain an access token", null));
 
@@ -154,7 +154,7 @@ public class JwtCookieLoginHandler extends CookieLoginHandler {
     }
 
     @Override
-    protected List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request) {
+    public List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request) {
         AccessRefreshToken accessRefreshToken = accessRefreshTokenGenerator.generate(refreshToken, userDetails)
                 .orElseThrow(() -> new OauthErrorResponseException(ObtainingAuthorizationErrorCode.SERVER_ERROR, "Cannot obtain an access token", null));
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/IdTokenLoginHandler.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/IdTokenLoginHandler.java
@@ -75,7 +75,7 @@ public class IdTokenLoginHandler extends CookieLoginHandler {
     }
 
     @Override
-    protected List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request) {
+    public List<Cookie> getCookies(UserDetails userDetails, HttpRequest<?> request) {
         List<Cookie> cookies = new ArrayList<>(1);
         String accessToken = parseIdToken(userDetails).orElseThrow(() -> new OauthErrorResponseException(ObtainingAuthorizationErrorCode.SERVER_ERROR, "Cannot obtain an access token", null));
 
@@ -87,7 +87,7 @@ public class IdTokenLoginHandler extends CookieLoginHandler {
     }
 
     @Override
-    protected List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request) {
+    public List<Cookie> getCookies(UserDetails userDetails, String refreshToken, HttpRequest<?> request) {
         throw new OauthErrorResponseException(ObtainingAuthorizationErrorCode.INVALID_REQUEST, "Cannot refresh a provider token through the oauth endpoint. The token must be refreshed directly with the provider", null);
     }
 


### PR DESCRIPTION
I'm using this module with GraphQL login implementation where I need to call some classes directly, and instead of copy-paste the whole method to generate cookies from `UserDetails` object it will be better to open access to these methods. This will help to reuse these methods after upgrade to the new version.

This is an example of how I use this code in GraphQL endpoints: https://github.com/expatiat/dumper/blob/main/dumper-api/src/main/java/com/zhokhov/dumper/api/graphql/mutation/UserLoginServerMutation.java

This method is mostly copy-pasted from `JwtCookieLoginHandler` class:
`private Optional<Cookie> accessTokenCookie(UserDetails userDetails, HttpRequest<?> request)`
