### PR TITLE
BREAKING CHANGE: del createAuthenticationResponse

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/DefaultOpenIdUserDetailsMapper.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/DefaultOpenIdUserDetailsMapper.java
@@ -72,21 +72,13 @@ public class DefaultOpenIdUserDetailsMapper implements OpenIdUserDetailsMapper {
     public DefaultOpenIdUserDetailsMapper(OpenIdAdditionalClaimsConfiguration openIdAdditionalClaimsConfiguration) {
         this(openIdAdditionalClaimsConfiguration, null);
     }
-
     @NonNull
     @Override
-    @Deprecated
-    public UserDetails createUserDetails(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims) {
+    public AuthenticationResponse createAuthenticationResponse(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims, @Nullable State state) {
         Map<String, Object> claims = buildAttributes(providerName, tokenResponse, openIdClaims);
         List<String> roles = getRoles(providerName, tokenResponse, openIdClaims);
         String username = getUsername(providerName, tokenResponse, openIdClaims);
         return new UserDetails(username, roles, claims);
-    }
-
-    @NonNull
-    @Override
-    public AuthenticationResponse createAuthenticationResponse(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims, @Nullable State state) {
-        return createUserDetails(providerName, tokenResponse, openIdClaims);
     }
 
     /**

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/OpenIdUserDetailsMapper.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/OpenIdUserDetailsMapper.java
@@ -18,14 +18,12 @@ package io.micronaut.security.oauth2.endpoint.token.response;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.security.authentication.AuthenticationResponse;
-import io.micronaut.security.authentication.UserDetails;
 import io.micronaut.security.oauth2.endpoint.authorization.state.State;
-
 import io.micronaut.core.annotation.NonNull;
 
 /**
  * Responsible for converting an OpenID token response to
- * a {@link UserDetails} representing the authenticated user.
+ * a {@link AuthenticationResponse} representing the authenticated user.
  *
  * @author James Kleeh
  * @since 1.2.0
@@ -39,28 +37,12 @@ public interface OpenIdUserDetailsMapper {
      * @param providerName The OpenID provider name
      * @param tokenResponse The token response
      * @param openIdClaims The OpenID claims
-     * @return A user details object
-     * @deprecated Use {@link #createAuthenticationResponse(String, OpenIdTokenResponse, OpenIdClaims, State)} instead.
-     * This method will only be called if the new method is not implemented.
-     */
-    @Deprecated
-    @NonNull
-    UserDetails createUserDetails(String providerName,
-                                  OpenIdTokenResponse tokenResponse,
-                                  OpenIdClaims openIdClaims);
-
-    /**
-     * @param providerName The OpenID provider name
-     * @param tokenResponse The token response
-     * @param openIdClaims The OpenID claims
      * @param state        The state of the response
      * @return An authentication response
      */
     @NonNull
-    default AuthenticationResponse createAuthenticationResponse(String providerName,
-                                                                OpenIdTokenResponse tokenResponse,
-                                                                OpenIdClaims openIdClaims,
-                                                                @Nullable State state) {
-        return createUserDetails(providerName, tokenResponse, openIdClaims);
-    }
+    AuthenticationResponse createAuthenticationResponse(String providerName,
+                                                        OpenIdTokenResponse tokenResponse,
+                                                        OpenIdClaims openIdClaims,
+                                                        @Nullable State state);
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.groovy
@@ -23,18 +23,10 @@ import javax.inject.Singleton
 //tag::clazz[]
 class GlobalOpenIdUserDetailsMapper implements OpenIdUserDetailsMapper {
 
-    //This method is deprecated and will only be called if the createAuthenticationResponse is not implemented
-    @Override
-    UserDetails createUserDetails(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims) {
-        throw new UnsupportedOperationException()
-    }
-
     @Override
     @NonNull
     AuthenticationResponse createAuthenticationResponse(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims, @Nullable State state) {
         new UserDetails("name", [])
     }
-
-
 }
 //end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.kt
@@ -17,11 +17,6 @@ import javax.inject.Singleton
 @Replaces(DefaultOpenIdUserDetailsMapper::class)
 class GlobalOpenIdUserDetailsMapper : OpenIdUserDetailsMapper {
 
-    //This method is deprecated and will only be called if the createAuthenticationResponse is not implemented
-    override fun createUserDetails(providerName: String?, tokenResponse: OpenIdTokenResponse?, openIdClaims: OpenIdClaims?): UserDetails {
-        throw UnsupportedOperationException()
-    }
-
     override fun createAuthenticationResponse(providerName: String, tokenResponse: OpenIdTokenResponse, openIdClaims: OpenIdClaims, state: State?): AuthenticationResponse {
         return UserDetails("name", emptyList())
     }

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/openid/OktaUserDetailsMapper.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/security/oauth2/docs/openid/OktaUserDetailsMapper.kt
@@ -16,11 +16,6 @@ import javax.inject.Singleton
 @Named("okta") // <1>
 class OktaUserDetailsMapper : OpenIdUserDetailsMapper {
 
-    //This method is deprecated and will only be called if the createAuthenticationResponse is not implemented
-    override fun createUserDetails(providerName: String?, tokenResponse: OpenIdTokenResponse?, openIdClaims: OpenIdClaims?): UserDetails {
-        throw UnsupportedOperationException()
-    }
-
     override fun createAuthenticationResponse(providerName: String, // <2>
                                               tokenResponse: OpenIdTokenResponse, // <3>
                                               openIdClaims: OpenIdClaims, // <4>

--- a/test-suite/src/test/java/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.java
+++ b/test-suite/src/test/java/io/micronaut/security/oauth2/docs/openid/GlobalOpenIdUserDetailsMapper.java
@@ -19,14 +19,7 @@ import java.util.Collections;
 @Singleton
 @Replaces(DefaultOpenIdUserDetailsMapper.class)
 public class GlobalOpenIdUserDetailsMapper implements OpenIdUserDetailsMapper {
-
-    //This method is deprecated and will only be called if the createAuthenticationResponse is not implemented
-    @NonNull
-    @Override
-    public UserDetails createUserDetails(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims) {
-        throw new UnsupportedOperationException();
-    }
-
+    
     @Override
     @NonNull
     public AuthenticationResponse createAuthenticationResponse(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims, @Nullable State state) {

--- a/test-suite/src/test/java/io/micronaut/security/oauth2/docs/openid/OktaUserDetailsMapper.java
+++ b/test-suite/src/test/java/io/micronaut/security/oauth2/docs/openid/OktaUserDetailsMapper.java
@@ -17,14 +17,7 @@ import java.util.Collections;
 @Singleton
 @Named("okta") // <1>
 public class OktaUserDetailsMapper implements OpenIdUserDetailsMapper {
-
-    //This method is deprecated and will only be called if the createAuthenticationResponse is not implemented
-    @NonNull
-    @Override
-    public UserDetails createUserDetails(String providerName, OpenIdTokenResponse tokenResponse, OpenIdClaims openIdClaims) {
-        throw new UnsupportedOperationException();
-    }
-
+    
     @Override
     @NonNull
     public AuthenticationResponse createAuthenticationResponse(String providerName, // <2>


### PR DESCRIPTION
delete deprecated method OpenIdUserDetailsMapper:createAuthenticationResponse(String, OpenIdTokenResponse, OpenIdClaims)