### PR TITLE
Log on missing JWT configs in validation

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/validator/JwtValidator.java
@@ -200,6 +200,11 @@ public final class JwtValidator {
                 return Optional.empty();
             }
         }
+
+        if (LOG.isDebugEnabled() && encryptions.isEmpty()) {
+            LOG.debug("JWT is encrypted and no encryption configurations -> not verified");
+        }
+
         return Optional.empty();
     }
 
@@ -229,6 +234,11 @@ public final class JwtValidator {
                 }
             }
         }
+
+        if (LOG.isDebugEnabled() && signatures.isEmpty()) {
+            LOG.debug("JWT is signed and no signature configurations -> not verified");
+        }
+
         return Optional.empty();
     }
 


### PR DESCRIPTION
Add logging when validating encrypted or signed JWTs and there is no config.