### PR TITLE
test: annotate LoginForm with @Introspected

### DIFF
--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/LoginForm.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/LoginForm.groovy
@@ -1,5 +1,8 @@
 package io.micronaut.security.token.jwt.cookie
 
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
 class LoginForm {
     String username
     String password


### PR DESCRIPTION
>  io.micronaut.core.beans.exceptions.IntrospectionException: No bean introspection available for type [class io.micronaut.security.token.jwt.cookie.LoginForm]. Ensure the class is annotated with io.micronaut.core.annotation.Introspected