### PR TITLE
Feat: Support for explicitly typed attributes in Authentication (#308)

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/Authentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/Authentication.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.NonNull;
 import java.io.Serializable;
 import java.security.Principal;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents the state of an authentication.
@@ -40,4 +41,18 @@ public interface Authentication extends Principal, Serializable {
      */
     @NonNull
     Map<String, Object> getAttributes();
+
+    /**
+     * Retrieves an explicitly typed attribute value.
+     *
+     * @param name the name of the attribute
+     * @param clazz the expected class of the attribute
+     * @param <T> the expected type of the attribute
+     * @return the typed attribute or null if it doesn't exist or the type is not correct
+     */
+    default <T> Optional<T> getAttribute(String name, @NonNull Class<T> clazz) {
+        return Optional.ofNullable(getAttributes().get(name))
+            .filter(clazz::isInstance)
+            .map(clazz::cast);
+    }
 }

--- a/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.security.authentication
+
+import groovy.transform.AutoImplement
+import spock.lang.Specification
+
+class AuthenticationSpec extends Specification {
+
+    @AutoImplement
+    static class TestAuthentication implements Authentication {
+
+        @Override
+        Map<String, Object> getAttributes() {
+            return Map.of("string", "string", "int", 0, "boolean", true)
+        }
+    }
+
+    def "getAttribute returns the desired explicitly typed optional"() {
+        expect:
+        new TestAuthentication().getAttribute("string", String.class) == Optional.of("string")
+        new TestAuthentication().getAttribute("int", Integer.class) == Optional.of(0)
+        new TestAuthentication().getAttribute("boolean", Boolean.class) == Optional.of(true)
+    }
+
+    def "getAttribute returns empty optional when type is incorrect"() {
+        expect:
+        new TestAuthentication().getAttribute("string", Void.class) == Optional.empty()
+        new TestAuthentication().getAttribute("int", Void.class) == Optional.empty()
+        new TestAuthentication().getAttribute("boolean", Void.class) == Optional.empty()
+    }
+}


### PR DESCRIPTION
Adds support for explicitly typed attributes in Authentication like @p1729 suggested.