### PR TITLE
For PriorToLogin if there is no cookie configuration, default the path to root

### DIFF
--- a/security/src/main/java/io/micronaut/security/errors/CookiePriorToLoginPersistence.java
+++ b/security/src/main/java/io/micronaut/security/errors/CookiePriorToLoginPersistence.java
@@ -80,6 +80,7 @@ public class CookiePriorToLoginPersistence implements PriorToLoginPersistence {
             cookie.configure(cookieConfiguration, request.isSecure());
         } else {
             cookie.secure(request.isSecure()).httpOnly(true);
+            cookie.path("/");
         }
     }
 }


### PR DESCRIPTION
Please feel free to correct me if my approach is wrong to any of this. 

From my testing, I've found that Chrome will refuse to include cookies in requests where their path does not match the browser URI path exactly or is a superdirectory of the browser path. Most auth providers will redirect back to a path or subfolder that does not match the path of the ORIGINAL_URI.

For example:
Cookie ORIGINAL_URI: `/abc/123`
Config callback-uri: `/google/etc/`

The path for ORIGINAL_URI will be `/abc` which Chrome will not send to `/google`. Debugging the application I've found that it is not finding a cookie config so it is defaulting to null which seems to have the effect of defaulting to path of the URI where the cookie is set.

By defaulting the path to root, this should avoid this in most use cases.