### PR TITLE
reverts changes to RefreshTokenPersistence

### DIFF
--- a/security/src/main/java/io/micronaut/security/token/refresh/RefreshTokenPersistence.java
+++ b/security/src/main/java/io/micronaut/security/token/refresh/RefreshTokenPersistence.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.token.refresh;
 
 import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.runtime.event.annotation.EventListener;
 import io.micronaut.security.authentication.UserDetails;
 import io.micronaut.security.token.event.RefreshTokenGeneratedEvent;
 import org.reactivestreams.Publisher;
@@ -27,23 +28,19 @@ import org.reactivestreams.Publisher;
  * @author James Kleeh
  * @since 2.0.0
  */
-public interface RefreshTokenPersistence extends ApplicationEventListener<RefreshTokenGeneratedEvent> {
+public interface RefreshTokenPersistence {
 
     /**
      * Persist the refresh token.
      *
      * @param event The refresh token generated event
      */
+    @EventListener
     void persistToken(RefreshTokenGeneratedEvent event);
-
-    default void onApplicationEvent(RefreshTokenGeneratedEvent event) {
-        persistToken(event);
-    }
 
     /**
      * @param refreshToken The refresh token
      * @return The user details associated with the refresh token
      */
     Publisher<UserDetails> getUserDetails(String refreshToken);
-
 }

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -4,8 +4,6 @@ This section will document breaking changes that may happen during milestone or 
 
 === What's New
 
-- `RefreshTokenPersistence` extends `ApplicationEventListener<RefreshTokenGeneratedEvent>`.
-
 The following properties' default value has been removed in Micronaut Security 3.0.0:
 
 - `micronaut.security.oauth2.openid.nonce.cookie.cookie-secure`


### PR DESCRIPTION
To keep the API as in 2.5.x https://github.com/micronaut-projects/micronaut-security/blob/2.5.x/security/src/main/java/io/micronaut/security/token/refresh/RefreshTokenPersistence.java