### PR TITLE
Add jakarta security annotation mapping

### DIFF
--- a/security-annotations/src/main/java/io/micronaut/security/annotation/DenyAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/DenyAllAnnotationMapper.java
@@ -17,10 +17,10 @@ package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import javax.annotation.security.DenyAll;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,14 +31,14 @@ import java.util.List;
  * @since 1.0
  */
 @Internal
-public class DenyAllAnnotationMapper implements TypedAnnotationMapper<DenyAll> {
+public class DenyAllAnnotationMapper implements NamedAnnotationMapper {
     @Override
-    public Class<DenyAll> annotationType() {
-        return DenyAll.class;
+    public String getName() {
+        return "javax.annotation.security.DenyAll";
     }
 
     @Override
-    public List<AnnotationValue<?>> map(AnnotationValue<DenyAll> annotation, VisitorContext visitorContext) {
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         List<AnnotationValue<?>> annotationValues = new ArrayList<>(1);
         annotationValues.add(
                 AnnotationValue.builder(Secured.class)

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaDenyAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaDenyAllAnnotationMapper.java
@@ -1,0 +1,16 @@
+package io.micronaut.security.annotation;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Allows using the {@link jakarta.annotation.security.DenyAll} annotation in Micronaut.
+ *
+ * @author Fredrik Hov
+ */
+@Internal
+public class JakartaDenyAllAnnotationMapper extends DenyAllAnnotationMapper {
+    @Override
+    public String getName() {
+        return "jakarta.annotation.security.DenyAll";
+    }
+}

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaDenyAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaDenyAllAnnotationMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.Internal;

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaPermitAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaPermitAllAnnotationMapper.java
@@ -1,0 +1,16 @@
+package io.micronaut.security.annotation;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Allows using the {@link jakarta.annotation.security.PermitAll} annotation in Micronaut.
+ *
+ * @author Fredrik Hov
+ */
+@Internal
+public class JakartaPermitAllAnnotationMapper extends PermitAllAnnotationMapper {
+    @Override
+    public String getName() {
+        return "jakarta.annotation.security.PermitAll";
+    }
+}

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaPermitAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaPermitAllAnnotationMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.Internal;

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaRolesAllowedAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaRolesAllowedAnnotationMapper.java
@@ -1,0 +1,16 @@
+package io.micronaut.security.annotation;
+
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Allows using the {@link jakarta.annotation.security.RolesAllowed} annotation in Micronaut.
+ *
+ * @author Fredrik Hov
+ */
+@Internal
+public class JakartaRolesAllowedAnnotationMapper extends RolesAllowedAnnotationMapper {
+    @Override
+    public String getName() {
+        return "jakarta.annotation.security.RolesAllowed";
+    }
+}

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaRolesAllowedAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/JakartaRolesAllowedAnnotationMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.Internal;

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/PermitAllAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/PermitAllAnnotationMapper.java
@@ -17,10 +17,10 @@ package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import javax.annotation.security.PermitAll;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,14 +32,14 @@ import java.util.List;
  */
 // tag::clazz[]
 @Internal
-public class PermitAllAnnotationMapper implements TypedAnnotationMapper<PermitAll> { // <1>
+public class PermitAllAnnotationMapper implements NamedAnnotationMapper { // <1>
     @Override
-    public Class<PermitAll> annotationType() {
-        return PermitAll.class;
+    public String getName() {
+        return "javax.annotation.security.PermitAll";
     }
 
     @Override
-    public List<AnnotationValue<?>> map(AnnotationValue<PermitAll> annotation, VisitorContext visitorContext) { // <2>
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) { // <2>
         List<AnnotationValue<?>> annotationValues = new ArrayList<>(1);
         annotationValues.add(
                 AnnotationValue.builder(Secured.class) // <3>

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/RolesAllowedAnnotationMapper.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/RolesAllowedAnnotationMapper.java
@@ -17,10 +17,10 @@ package io.micronaut.security.annotation;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.inject.annotation.TypedAnnotationMapper;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import javax.annotation.security.RolesAllowed;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,14 +31,14 @@ import java.util.List;
  * @since 1.0
  */
 @Internal
-public class RolesAllowedAnnotationMapper implements TypedAnnotationMapper<RolesAllowed> {
+public class RolesAllowedAnnotationMapper implements NamedAnnotationMapper {
     @Override
-    public Class<RolesAllowed> annotationType() {
-        return RolesAllowed.class;
+    public String getName() {
+        return "javax.annotation.security.RolesAllowed";
     }
 
     @Override
-    public List<AnnotationValue<?>> map(AnnotationValue<RolesAllowed> annotation, VisitorContext visitorContext) {
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         String[] values = annotation.get("value", String[].class).orElse(new String[0]);
 
         List<AnnotationValue<?>> annotationValues = new ArrayList<>(1);
@@ -50,3 +50,4 @@ public class RolesAllowedAnnotationMapper implements TypedAnnotationMapper<Roles
         return annotationValues;
     }
 }
+

--- a/security-annotations/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/security-annotations/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,3 +1,6 @@
 io.micronaut.security.annotation.PermitAllAnnotationMapper
+io.micronaut.security.annotation.JakartaPermitAllAnnotationMapper
 io.micronaut.security.annotation.RolesAllowedAnnotationMapper
+io.micronaut.security.annotation.JakartaRolesAllowedAnnotationMapper
 io.micronaut.security.annotation.DenyAllAnnotationMapper
+io.micronaut.security.annotation.JakartaDenyAllAnnotationMapper

--- a/security/src/test/groovy/io/micronaut/security/denyall/JakartaDenyAllSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/denyall/JakartaDenyAllSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.security.denyall
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+
+import jakarta.annotation.security.DenyAll
+
+class JakartaDenyAllSpec extends DenyAllSpec {
+
+    @Requires(env = Environment.TEST)
+    @Requires(property = 'spec.name', value = "DenyAllSpec")
+    @Replaces(DenyAllSpec.BookController.class)
+    @Controller(DenyAllSpec.controllerPath)
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    static class BookController {
+
+        @DenyAll
+        @Get("/denied")
+        String denied() {
+            "You will not see this"
+        }
+
+        @Get("/index")
+        String index() {
+            "You will not see this"
+        }
+
+        @Secured(SecurityRule.DENY_ALL)
+        @Get("/secureddenied")
+        String securedDenyAll() {
+            "You will not see this"
+        }
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/permitall/JakartaPermitAllSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/permitall/JakartaPermitAllSpec.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.security.permitall
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+import jakarta.annotation.security.PermitAll
+
+class JakartaPermitAllSpec extends PermitAllSpec {
+
+    @Requires(env = Environment.TEST)
+    @Requires(property = 'spec.name', value = 'PermitAllSpec')
+    @Replaces(PermitAllSpec.BookController.class)
+    @Controller(PermitAllSpec.controllerPath)
+    static class BookController {
+
+        @PermitAll
+        @Get("/books")
+        Map<String, Object> list() {
+            [books: ['Building Microservice', 'Release it']]
+        }
+    }
+
+    @Requires(env = Environment.TEST)
+    @Requires(property = 'spec.name', value = 'PermitAllSpec')
+    @Replaces(PermitAllSpec.LanguagesController.class)
+    @Controller(PermitAllSpec.controllerPath)
+    @PermitAll
+    static class LanguagesController {
+
+        @Get("/languages")
+        Map<String, Object> list() {
+            [languages: ['Groovy', 'Java']]
+        }
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/rolesallowed/JakartaRolesAllowedSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rolesallowed/JakartaRolesAllowedSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.security.rolesallowed
+
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+
+import jakarta.annotation.security.RolesAllowed
+
+class JakartaRolesAllowedSpec extends RolesAllowedSpec {
+
+    @Requires(env = Environment.TEST)
+    @Requires(property = 'spec.name', value = 'RolesAllowedSpec')
+    @Replaces(RolesAllowedSpec.BookController.class)
+    @RolesAllowed(['ROLE_USER'])
+    @Controller(RolesAllowedSpec.controllerPath)
+    static class BookController {
+
+        @RolesAllowed(['ROLE_USER', 'ROLE_ADMIN'])
+        @Get("/books")
+        Map<String, Object> list() {
+            [books: ['Building Microservice', 'Release it']]
+        }
+
+        @Get("/classlevel")
+        Map<String, Object> classlevel() {
+            [books: ['Building Microservice', 'Release it']]
+        }
+
+        @RolesAllowed(['ROLE_ADMIN', 'ROLE_MANAGER'])
+        @Get("/forbidenbooks")
+        Map<String, Object> forbiddenList() {
+            [books: ['Building Microservice', 'Release it']]
+        }
+    }
+
+
+}

--- a/src/main/docs/guide/securityRule/secured.adoc
+++ b/src/main/docs/guide/securityRule/secured.adoc
@@ -15,6 +15,9 @@ Alternatively, you can use https://jcp.org/en/jsr/detail?id=250[JSR_250] annotat
 * `javax.annotation.security.PermitAll`
 * `javax.annotation.security.RolesAllowed`
 * `javax.annotation.security.DenyAll`
+* `jakarta.annotation.security.PermitAll`
+* `jakarta.annotation.security.RolesAllowed`
+* `jakarta.annotation.security.DenyAll`
 
 [source, java]
 ----


### PR DESCRIPTION
Switched over the AnnotationMappers for javax security annotations to NamedAnnotationMapper as discussed in #774.
Added the Jakarta equaivalent mappers by extending the javax ones and overriding the namespace.

closes #774 