### PR TITLE
Inject "additional-request-params" into the SecureGrantMap produced by  ClientCredentialsTokenRequestContext::getGrant

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfiguration.java
@@ -21,6 +21,7 @@ import io.micronaut.http.util.OutgointRequestProcessorMatcher;
 import io.micronaut.security.oauth2.client.clientcredentials.propagation.ClientCredentialsHeaderTokenPropagatorConfiguration;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -48,4 +49,7 @@ public interface ClientCredentialsConfiguration extends Toggleable, OutgointRequ
 
     @NonNull
     Optional<ClientCredentialsHeaderTokenPropagatorConfiguration> getHeaderPropagation();
+
+    @NonNull
+    Map<String, String> getAdditionalRequestParams();
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -441,12 +441,20 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
 
         }
 
+        /**
+         *
+         * @return a Map of additional request parameters
+         */
         @Override
         @NonNull
         public Map<String, String> getAdditionalRequestParams() {
             return additonalRequestParams;
         }
 
+        /**
+         * Additional parameters included in the client-credentials flow
+         * @param additionalRequestParams Map of additional request parameters to include in client-credentials flow
+         */
         public void setAdditionalRequestParams(@MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, String> additionalRequestParams) {
             this.additonalRequestParams = additionalRequestParams;
         }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.http.MediaType;
 import io.micronaut.security.oauth2.client.clientcredentials.ClientCredentialsConfiguration;
 import io.micronaut.security.oauth2.client.clientcredentials.propagation.ClientCredentialsHeaderTokenPropagatorConfiguration;
@@ -35,7 +36,9 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -277,6 +280,8 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
 
         private HeaderTokenPropagatorConfigurationProperties headerPropagation;
 
+        private Map<String, String> additonalRequestParams = Collections.emptyMap();
+
         @NonNull
         @Override
         public Duration getAdvancedExpiration() {
@@ -434,6 +439,16 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
                 return this.headerName;
             }
 
+        }
+
+        @Override
+        @NonNull
+        public Map<String, String> getAdditionalRequestParams() {
+            return additonalRequestParams;
+        }
+
+        public void setAdditionalRequestParams(@MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, String> additionalRequestParams) {
+            this.additonalRequestParams = additionalRequestParams;
         }
     }
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -383,6 +383,24 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         }
 
         /**
+         *
+         * @return a Map of additional request parameters
+         */
+        @Override
+        @NonNull
+        public Map<String, String> getAdditionalRequestParams() {
+            return additonalRequestParams;
+        }
+
+        /**
+         * Additional parameters included in the client-credentials flow.
+         * @param additionalRequestParams Map of additional request parameters to include in client-credentials flow
+         */
+        public void setAdditionalRequestParams(@MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, String> additionalRequestParams) {
+            this.additonalRequestParams = additionalRequestParams;
+        }
+
+        /**
          * Client credentials http header token propagation configuration.
          */
         @ConfigurationProperties("header-propagation")
@@ -439,24 +457,6 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
                 return this.headerName;
             }
 
-        }
-
-        /**
-         *
-         * @return a Map of additional request parameters
-         */
-        @Override
-        @NonNull
-        public Map<String, String> getAdditionalRequestParams() {
-            return additonalRequestParams;
-        }
-
-        /**
-         * Additional parameters included in the client-credentials flow
-         * @param additionalRequestParams Map of additional request parameters to include in client-credentials flow
-         */
-        public void setAdditionalRequestParams(@MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, String> additionalRequestParams) {
-            this.additonalRequestParams = additionalRequestParams;
         }
     }
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/context/ClientCredentialsTokenRequestContext.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/context/ClientCredentialsTokenRequestContext.java
@@ -23,6 +23,7 @@ import io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse;
 import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
 import io.micronaut.security.oauth2.grants.ClientCredentialsGrant;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -33,6 +34,7 @@ import java.util.Map;
  */
 public class ClientCredentialsTokenRequestContext extends AbstractTokenRequestContext<Map<String, String>, TokenResponse> {
     private final ClientCredentialsGrant grant;
+    private final Map<String, String> additionalRequestParams;
 
     /**
      * @param scope requested scopes
@@ -46,6 +48,7 @@ public class ClientCredentialsTokenRequestContext extends AbstractTokenRequestCo
         ClientCredentialsGrant grant = new ClientCredentialsGrant();
         grant.setScope(scope);
         this.grant = grant;
+        this.additionalRequestParams = clientConfiguration.getClientCredentials().map(configuration -> configuration.getAdditionalRequestParams()).orElseGet(Collections::emptyMap);
     }
 
     /**
@@ -54,6 +57,7 @@ public class ClientCredentialsTokenRequestContext extends AbstractTokenRequestCo
     public ClientCredentialsTokenRequestContext(OauthClientConfiguration clientConfiguration) {
         super(MediaType.APPLICATION_FORM_URLENCODED_TYPE, clientConfiguration.getTokenEndpoint(), clientConfiguration);
         this.grant = new ClientCredentialsGrant();
+        this.additionalRequestParams = clientConfiguration.getClientCredentials().map(configuration -> configuration.getAdditionalRequestParams()).orElseGet(Collections::emptyMap);
     }
 
     /**
@@ -64,11 +68,14 @@ public class ClientCredentialsTokenRequestContext extends AbstractTokenRequestCo
         super(MediaType.APPLICATION_FORM_URLENCODED_TYPE, clientConfiguration.getTokenEndpoint(), clientConfiguration);
         this.grant = new ClientCredentialsGrant();
         this.grant.setScope(scope);
+        this.additionalRequestParams = clientConfiguration.getClientCredentials().map(configuration -> configuration.getAdditionalRequestParams()).orElseGet(Collections::emptyMap);
     }
 
     @Override
     public Map<String, String> getGrant() {
-        return grant.toMap();
+        Map<String, String> grantMap = grant.toMap();
+        grantMap.putAll(additionalRequestParams);
+        return grantMap;
     }
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfigurationSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfigurationSpec.groovy
@@ -72,7 +72,7 @@ class ClientCredentialsConfigurationSpec extends Specification {
         noExceptionThrown()
 
         expect:
-        configuration.getClientCredentials().get().getAdditionalRequestParams().get("audience") == "test"
+        "test" == configuration.getClientCredentials().get().getAdditionalRequestParams().get("audience")
 
         cleanup:
         applicationContext.close()

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfigurationSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/clientcredentials/ClientCredentialsConfigurationSpec.groovy
@@ -54,4 +54,27 @@ class ClientCredentialsConfigurationSpec extends Specification {
         cleanup:
         applicationContext.close()
     }
+
+    void "is is possible to set additionalRequestParams with client-credentials.additional-request-params"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run([
+                'micronaut.security.oauth2.clients.authservermanual.token.url': "http://foo.bar/token",
+                'micronaut.security.oauth2.clients.authservermanual.client-id': 'XXX',
+                'micronaut.security.oauth2.clients.authservermanual.client-secret': 'YYY',
+                'micronaut.security.oauth2.clients.authservermanual.client-credentials.advanced-expiration': '0s',
+                'micronaut.security.oauth2.clients.authservermanual.client-credentials.additional-request-params.audience': 'test',
+        ])
+
+        when:
+        OauthClientConfiguration configuration = applicationContext.getBean(OauthClientConfiguration, Qualifiers.byName("authservermanual"))
+
+        then:
+        noExceptionThrown()
+
+        expect:
+        configuration.getClientCredentials().get().getAdditionalRequestParams().get("audience") == "test"
+
+        cleanup:
+        applicationContext.close()
+    }
 }


### PR DESCRIPTION
- Added `getAdditionalRequestParams` into the `ClientCredentialsConfiguration` interface
- Added `additionalRequestParams` to the `ClientCredentialsConfigurationProperties`, including getter and setter.
- Added `additionalRequestParams` to `ClientCredentialsTokenRequestContext` 
- In `ClientCredentialsTokenRequestContext`, inject extra parameters when the `ClientCredentialsGrant` is converted to a map
- Added a test to verify that the binding of the added configuration properties are valid

Todo(?)
- [ ]  Update documentation regarding `additional-request-params` on client credentials grant oauth flow

closes #751