### PR TITLE
Enable build scans

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,14 @@
-plugins {
-  id "com.gradle.enterprise" version "3.3.1"
-}
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
     }
 }
+
+plugins {
+    id 'io.micronaut.build.shared.settings' version '4.1.4'
+}
+
 rootProject.name = 'micronaut-security'
 
 include "security"


### PR DESCRIPTION
Replaces the old configuration with the standard Micronaut publication
to ge.micronaut.io