### PR TITLE
fix: openid-urls in github-example

### DIFF
--- a/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
@@ -19,11 +19,12 @@ micronaut:
           scopes: // <4>
             - user:email
             - read:user
-          authorization:
-            url: https://github.com/login/oauth/authorize // <5>
-          token:
-            url: https://github.com/login/oauth/access_token // <6>
-            auth-method: client-secret-post // <7>
+          openid:
+            authorization:
+              url: https://github.com/login/oauth/authorize // <5>
+            token:
+              url: https://github.com/login/oauth/access_token // <6>
+              auth-method: client-secret-post // <7>
 ----
 
 <1> Configure a client. The name here is arbitrary


### PR DESCRIPTION
This fixes the documentation on a OAuth2/OpenID Example with GitHub, where the urls (token & authentication) are placed in the wrong spot, according to the correct Type-Definition of `AuthorizationEndpointConfigurationProperties`.