### PR TITLE
refactor: extract AbstractPrincipalArgumentBinder

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/AbstractPrincipalArgumentBinder.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AbstractPrincipalArgumentBinder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
+import io.micronaut.security.filters.SecurityFilter;
+import java.security.Principal;
+import java.util.Optional;
+
+/**
+ * Binds the authentication object to a route argument.
+ *
+ * @param <A> the {@link Principal} type
+ * @author Burt Beckwith
+ * @since 3.2
+ */
+public abstract class AbstractPrincipalArgumentBinder<A extends Principal> implements TypedRequestArgumentBinder<A> {
+
+    private final Class<A> authenticationClass;
+    private final Argument<A> argumentType;
+
+    protected AbstractPrincipalArgumentBinder(Class<A> authenticationClass) {
+        this.authenticationClass = authenticationClass;
+        argumentType = Argument.of(authenticationClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public BindingResult<A> bind(ArgumentConversionContext<A> context,
+                                 HttpRequest<?> source) {
+
+        if (!source.getAttributes().contains(SecurityFilter.KEY)) {
+            return BindingResult.UNSATISFIED;
+        }
+
+        final Optional<A> existing = source.getUserPrincipal(authenticationClass);
+        return existing.isPresent() ? (() -> existing) : BindingResult.EMPTY;
+    }
+
+    @Override
+    public Argument<A> argumentType() {
+        return argumentType;
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationArgumentBinder.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationArgumentBinder.java
@@ -15,40 +15,18 @@
  */
 package io.micronaut.security.authentication;
 
-import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.type.Argument;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
-import io.micronaut.security.filters.SecurityFilter;
-
 import jakarta.inject.Singleton;
-import java.util.Optional;
 
 /**
- * Responsible for binding the authentication object to a route argument.
+ * Binds the authentication object to a route argument.
  *
  * @author James Kleeh
  * @since 1.0
  */
 @Singleton
-public class AuthenticationArgumentBinder implements TypedRequestArgumentBinder<Authentication> {
+public class AuthenticationArgumentBinder extends AbstractPrincipalArgumentBinder<Authentication> {
 
-    @Override
-    public Argument<Authentication> argumentType() {
-        return Argument.of(Authentication.class);
-    }
-
-    @Override
-    public BindingResult<Authentication> bind(ArgumentConversionContext<Authentication> context, HttpRequest<?> source) {
-        if (source.getAttributes().contains(SecurityFilter.KEY)) {
-            final Optional<Authentication> existing = source.getUserPrincipal(Authentication.class);
-            if (existing.isPresent()) {
-                return () -> existing;
-            } else {
-                return BindingResult.EMPTY;
-            }
-        } else {
-            return BindingResult.UNSATISFIED;
-        }
+    public AuthenticationArgumentBinder() {
+        super(Authentication.class);
     }
 }

--- a/security/src/main/java/io/micronaut/security/authentication/PrincipalArgumentBinder.java
+++ b/security/src/main/java/io/micronaut/security/authentication/PrincipalArgumentBinder.java
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 package io.micronaut.security.authentication;
-
-import io.micronaut.core.convert.ArgumentConversionContext;
-import io.micronaut.core.type.Argument;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
-import io.micronaut.security.filters.SecurityFilter;
-
 import jakarta.inject.Singleton;
 import java.security.Principal;
-import java.util.Optional;
 
 /**
  * Responsible for binding a {@link Principal} to a route argument.
@@ -32,24 +24,8 @@ import java.util.Optional;
  * @since 1.0
  */
 @Singleton
-public class PrincipalArgumentBinder implements TypedRequestArgumentBinder<Principal> {
-
-    @Override
-    public Argument<Principal> argumentType() {
-        return Argument.of(Principal.class);
-    }
-
-    @Override
-    public BindingResult<Principal> bind(ArgumentConversionContext<Principal> context, HttpRequest<?> source) {
-        if (source.getAttributes().contains(SecurityFilter.KEY)) {
-            final Optional<Principal> existing = source.getUserPrincipal();
-            if (existing.isPresent()) {
-                return () -> existing;
-            } else {
-                return BindingResult.EMPTY;
-            }
-        } else {
-            return BindingResult.UNSATISFIED;
-        }
+public class PrincipalArgumentBinder extends AbstractPrincipalArgumentBinder<Principal> {
+    public PrincipalArgumentBinder() {
+        super(Principal.class);
     }
 }


### PR DESCRIPTION
@burtbeckwith  I've extracted this improvement into its own PR and use it also for `PrincipalArgumentBinder`