### PR TITLE
javadoc: SecurityFilter should mention SecurityFilter instead of JWT

### DIFF
--- a/security/src/main/java/io/micronaut/security/rules/SecurityRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SecurityRule.java
@@ -19,11 +19,12 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.filters.SecurityFilter;
 import io.micronaut.web.router.RouteMatch;
 import org.reactivestreams.Publisher;
 
 /**
- * Informs the JWT filter what to do with the given request.
+ * Informs the {@link SecurityFilter} filter what to do with the given request.
  *
  * @author James Kleeh
  * @since 1.0


### PR DESCRIPTION
I believe now Micronaut supports many authentication methods and not only JWT.
So SecurityRule must mention SecurityFilter instead.