### PR TITLE
Fix session serialization of ServerAuthentication

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
@@ -16,9 +16,9 @@
 package io.micronaut.security.authentication;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.security.token.config.TokenConfiguration;
 
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author James Kleeh
  * @since 3.0.0
  */
-@ReflectiveAccess
+@Introspected
 public class ServerAuthentication implements Authentication {
 
     private static final String JSON_KEY_NAME = "name";

--- a/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
@@ -18,6 +18,7 @@ package io.micronaut.security.authentication;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.ReflectiveAccess;
 import io.micronaut.security.token.config.TokenConfiguration;
 
 import java.util.ArrayList;
@@ -34,6 +35,7 @@ import java.util.Map;
  * @author James Kleeh
  * @since 3.0.0
  */
+@ReflectiveAccess
 public class ServerAuthentication implements Authentication {
 
     private static final String JSON_KEY_NAME = "name";


### PR DESCRIPTION
Without reflection configuration, using Redis session authentication throws following exception:

> 17:09:48.362 ERROR RouteExecutor [io-executor-thread-1] Unexpected error occurred: Error serializing object to JSON: No serializer found for class io.micronaut.security.authentication.ServerAuthentication and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
> io.micronaut.core.serialize.exceptions.SerializationException: Error serializing object to JSON: No serializer found for class io.micronaut.security.authentication.ServerAuthentication and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
>         at io.micronaut.json.JsonObjectSerializer.serialize(JsonObjectSerializer.java:52)
>         at io.micronaut.configuration.lettuce.session.RedisSessionStore$RedisSession.convertAttribute(RedisSessionStore.java:712)
>         at io.micronaut.configuration.lettuce.session.RedisSessionStore$RedisSession.delta(RedisSessionStore.java:675)
>         at io.micronaut.configuration.lettuce.session.RedisSessionStore.save(RedisSessionStore.java:301)
>         at io.micronaut.configuration.lettuce.session.RedisSessionStore.save(RedisSessionStore.java:94)
>         at io.micronaut.session.http.HttpSessionFilter.lambda$null$4(HttpSessionFilter.java:135)

I think this might be solution, because locally the problem was fixed by adding:

```kotlin
@TypeHint(ServerAuthentication::class, accessType = [ALL_PUBLIC])
```
