### PR TITLE
fix: basic auth must allow password with :

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthUtils.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthUtils.java
@@ -21,7 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Base64;
+import java.util.Optional;
 
 /**
  * Utility class for Basic Auth.
@@ -29,6 +30,7 @@ import java.util.*;
 public class BasicAuthUtils {
     private static final Logger LOG = LoggerFactory.getLogger(BasicAuthUtils.class);
     private static final String PREFIX = HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC + " ";
+    private static final String DELIMITER = ":";
 
     /**
      *
@@ -55,15 +57,14 @@ public class BasicAuthUtils {
         }
 
         String token = new String(decoded, StandardCharsets.UTF_8);
-
-        ArrayList<String> parts = new ArrayList<>(Arrays.asList(token.split(":")));
-        if (parts.size() < 2) {
+        int index = token.indexOf(DELIMITER);
+        if (index == -1) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Bad format of the basic auth header - Delimiter : not found");
             }
             return Optional.empty();
         }
-
-        return Optional.of(new UsernamePasswordCredentials(parts.remove(0), String.join(":", parts)));
+        return Optional.of(new UsernamePasswordCredentials(token.substring(0, index),
+                token.substring(index + DELIMITER.length())));
     }
 }

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthUtils.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthUtils.java
@@ -21,8 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Utility class for Basic Auth.
@@ -57,14 +56,14 @@ public class BasicAuthUtils {
 
         String token = new String(decoded, StandardCharsets.UTF_8);
 
-        String[] parts = token.split(":");
-        if (parts.length < 2) {
+        ArrayList<String> parts = new ArrayList<>(Arrays.asList(token.split(":")));
+        if (parts.size() < 2) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Bad format of the basic auth header - Delimiter : not found");
             }
             return Optional.empty();
         }
 
-        return Optional.of(new UsernamePasswordCredentials(parts[0], parts[1]));
+        return Optional.of(new UsernamePasswordCredentials(parts.remove(0), String.join(":", parts)));
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/authentication/BasicAuthUtilsSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/BasicAuthUtilsSpec.groovy
@@ -15,6 +15,16 @@ class BasicAuthUtilsSpec extends Specification {
         creds.get().secret == 'password'
     }
 
+    void "BasicAuthAuthenticationFetcher::parseCredentials must handle : on password"() {
+        when:
+        Optional<UsernamePasswordCredentials> creds = BasicAuthUtils.parseCredentials('Basic dXNlcjpwYXNzOndvcmQ=')
+
+        then:
+        creds.isPresent()
+        creds.get().identity == 'user'
+        creds.get().secret == 'pass:word'
+    }
+
     @Unroll("BasicAuthUtils::parseCredentials returns an empty optional if HTTP Authorization header value ( #value ) does not start with `Basic `")
     void "For HTTP Header Authroziation value which do not start with Basic BasicAuthAuthenticationFetcher::parseCredentials returns an empty optional"(String value) {
         when:


### PR DESCRIPTION
relate to https://github.com/tchiotludo/akhq/issues/939

see https://dev.to/ethanarrowood/what-characters-should-be-allowed-in-http-basic-authentication-userid-and-password-48f0

> Based on this RFC2617 Specification, HTTP Basic Authentication userid can contain any TEXT excluding the symbol :. The password can contain any TEXT. Are these the only rules for Basic Authentication usernames and passwords?

