### PR TITLE
Audience client_id validation

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
@@ -49,20 +49,18 @@ public class AudienceClaimValidator implements OpenIdClaimsValidator {
         List<String> audienceList = claims.getAudience();
 
         //The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience.
-        boolean condition = audienceList.stream().anyMatch(audience -> audience.equals(clientConfiguration.getClientId()));
-        if (!condition && LOG.isTraceEnabled()) {
+        boolean clientIdIsValid = audienceList.stream().anyMatch(audience -> audience.equals(clientConfiguration.getClientId()));
+        if (!clientIdIsValid && LOG.isTraceEnabled()) {
             LOG.trace("JWT validation failed for provider [{}]. Audience claims does not contain [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
         }
 
         //If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
-        if (audienceList.size() > 1) {
-            condition = claims.getAuthorizedParty() != null;
-            if (!condition && LOG.isTraceEnabled()) {
-                LOG.trace("JWT validation failed for provider [{}]. Multiple audience claims present but no authorized party", clientConfiguration.getName());
-            }
+        boolean azpClaimIsValid = audienceList.size() <= 1 || claims.getAuthorizedParty() != null;
+        if (!azpClaimIsValid && LOG.isTraceEnabled()) {
+            LOG.trace("JWT validation failed for provider [{}]. Multiple audience claims present but no authorized party", clientConfiguration.getName());
         }
 
-        return condition;
+        return clientIdIsValid && azpClaimIsValid;
     }
 
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidatorSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidatorSpec.groovy
@@ -30,13 +30,14 @@ class AudienceClaimValidatorSpec extends ApplicationContextSpecification {
         expected == validator.validate(openIdClaims, oauthClientConfiguration, openIdProviderMetadata)
 
         where:
-        clientId   | audience            | authorizedParty || expected
-        'CLIENTID' | []                  | null            || false
-        'CLIENTID' | ['FOO']             | null            || false
-        'CLIENTID' | ['CLIENTID']        | null            || true
-        'CLIENTID' | ['CLIENTID', 'FOO'] | null            || false
-        'CLIENTID' | ['CLIENTID', 'FOO'] | 'YYY'           || true
+        clientId   | audience                   | authorizedParty || expected
+        'CLIENTID' | []                         | null            || false
+        'CLIENTID' | ['FOO']                    | null            || false
+        'CLIENTID' | ['CLIENTID']               | null            || true
+        'CLIENTID' | ['CLIENTID', 'FOO']        | null            || false
+        'CLIENTID' | ['CLIENTID', 'FOO']        | 'YYY'           || true
+        'CLIENTID' | ['ANOTHERCLIENTID', 'FOO'] | 'YYY'           || false
 
-        description = audience.size() > 1 ? (authorizedParty ? "for multiple audiences, azp claim must be present." : "for multiple audiencies claim if azp is not present validation should fail") : (!audience ? 'if audience is empty validation fails' : (clientId != audience.first() ? 'if audience claim does not match client id validation must fail' : 'if audience claim must match client id'))
+        description = audience.size() > 1 ? (authorizedParty ? "for multiple audiences, azp claim must be present." : "for multiple audiences claim if azp is not present validation should fail") : (!audience ? 'if audience is empty validation fails' : (clientId != audience.first() ? 'if audience claim does not match client id validation must fail' : 'if audience claim must match client id'))
     }
 }


### PR DESCRIPTION
Current version of the validator returns `true` when:
- audience claim contains multiple values, and 
- `azp` claim is present

regardless whether `client_id` is present in audience or not.

This PR suggest a test covering this case and also fix for it.