### PR TITLE
fix: id token validation fails if aud contains multiple values, aud does not contain client_id and azp claim is present

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
@@ -50,19 +50,21 @@ public class AudienceClaimValidator implements OpenIdClaimsValidator {
 
         //The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience.
         boolean condition = audienceList.stream().anyMatch(audience -> audience.equals(clientConfiguration.getClientId()));
-        if (!condition && LOG.isTraceEnabled()) {
-            LOG.trace("JWT validation failed for provider [{}]. Audience claims does not contain [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
+        if (!condition) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("JWT validation failed for provider [{}]. Audience claims does not contain [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
+            }
+            return false;
         }
 
         //If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
-        if (audienceList.size() > 1) {
-            condition = claims.getAuthorizedParty() != null;
-            if (!condition && LOG.isTraceEnabled()) {
+        if (audienceList.size() > 1 && claims.getAuthorizedParty() == null) {
+            if (LOG.isTraceEnabled()) {
                 LOG.trace("JWT validation failed for provider [{}]. Multiple audience claims present but no authorized party", clientConfiguration.getName());
             }
+            return false;
         }
-
-        return condition;
+        return true;
     }
 
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/IdTokenValidatorSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/token/response/validation/IdTokenValidatorSpec.groovy
@@ -1,0 +1,59 @@
+package io.micronaut.security.oauth2.endpoint.token.response.validation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.security.oauth2.client.IdTokenClaimsValidator
+import io.micronaut.security.oauth2.client.OpenIdProviderMetadata
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration
+import io.micronaut.security.oauth2.endpoint.token.response.OpenIdClaims
+import spock.lang.See
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IdTokenValidatorSpec extends Specification {
+
+    @See("https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation")
+    @Unroll("#description")
+    void 'ID Token Claims validation'(String clientId,
+                                       String claimIssuer,
+                                       String issuer,
+                                       String azp,
+                                       boolean expected,
+                                       String description) {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run()
+        List<OpenIdClaimsValidator> validators = applicationContext.getBeansOfType(OpenIdClaimsValidator)
+
+        expect:
+        validators
+
+        when:
+        OauthClientConfiguration oauthClientConfiguration = Stub(OauthClientConfiguration) {
+            getClientId() >> clientId
+        }
+        OpenIdProviderMetadata openIdProviderMetadata = Stub(OpenIdProviderMetadata) {
+            getIssuer() >> issuer
+        }
+        OpenIdClaims claims = Stub(OpenIdClaims) {
+            getIssuer() >> claimIssuer
+            getAudience() >> aud
+            getAuthorizedParty() >> azp
+        }
+        then:
+        expected == validators.stream()
+                .allMatch(it -> it.validate(claims, oauthClientConfiguration, openIdProviderMetadata))
+
+        cleanup:
+        applicationContext.close()
+
+        where:
+        clientId | claimIssuer | aud             | issuer           | azp   |  expected | description
+        'xxx'    | 'iss'       | ['xxx']         | 'iss'            | null  | true      | 'id token valid with null azp'
+        'xxx'    | 'iss'       | ['xxx', 'foo']  | 'iss'            | 'xxx' | true      | 'id token valid'
+        'xxx'    | 'iss'       | ['xxx', 'foo']  | 'iss'            | null  | false     | 'If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.'
+        'xxx'    | 'iss'       | ['ooo', 'foo']  | 'iss'            | 'xxx' | false     | 'The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience'
+        'xxx'    | null        | ['xxx', 'foo']  | 'iss'            | 'xxx' | false     | 'issuer claim not found'
+        'xxx'    | 'foo'       | ['xxx', 'foo']  | 'iss'            | 'xxx' | false     | 'The Issuer Identifier for the OpenID Provider MUST exactly match the value of the iss (issuer) Claim'
+        'xxx'    | 'iss'       | ['xxx', 'foo']  | 'iss'            | 'ooo' | false     | 'If an azp Claim is present, the Client SHOULD verify that its client_id is the Claim Value'
+    }
+}


### PR DESCRIPTION
See: https://github.com/micronaut-projects/micronaut-security/pull/899