### PR TITLE
test: use ARM builds of selenium container on M1 macs

### DIFF
--- a/test-suite-utils/src/main/resources/GebConfig.groovy
+++ b/test-suite-utils/src/main/resources/GebConfig.groovy
@@ -1,9 +1,19 @@
 import org.openqa.selenium.firefox.FirefoxOptions
 import org.testcontainers.containers.BrowserWebDriverContainer
+import org.testcontainers.utility.DockerImageName
+import spock.util.environment.OperatingSystem
 
 driver = {
-    def container = new BrowserWebDriverContainer()
-            .withCapabilities(new FirefoxOptions())
+    def isM1Mac = OperatingSystem.current.macOs && System.getProperty("os.arch") == 'aarch64'
+    def rawContainer = isM1Mac ?
+            new BrowserWebDriverContainer(DockerImageName
+                    .parse("seleniarm/standalone-firefox")
+                    .asCompatibleSubstituteFor("selenium/standalone-firefox")
+            ) :
+            new BrowserWebDriverContainer()
+
+    def container = rawContainer.withCapabilities(new FirefoxOptions())
+
     container.start()
     container.webDriver
 }


### PR DESCRIPTION
The x86 container fails to start or run quick enough for the tests
to pass on an m1 mac

This replaces

    selenium/standalone-firefox

with

    seleniarm/standalone-firefox

Which is an ARM based fork of the selenium docker project

https://hub.docker.com/u/seleniarm
https://github.com/seleniarm/docker-selenium