### PR TITLE
test: Keycloak to v16 and fix tests for M1 apple hardware

### DIFF
--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/e2e/LoginPage.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/e2e/LoginPage.groovy
@@ -4,7 +4,7 @@ import geb.Page
 
 class LoginPage extends Page {
 
-    static at = { title == 'Log in to Keycloak' }
+    static at = { title == 'Sign in to Keycloak' }
 
     static content = {
         usernameInput { $('#username') }

--- a/test-suite-utils/src/main/groovy/io/micronaut/security/testutils/Keycloak.groovy
+++ b/test-suite-utils/src/main/groovy/io/micronaut/security/testutils/Keycloak.groovy
@@ -28,7 +28,7 @@ import java.time.Duration
 class Keycloak {
     static final String SYS_TESTCONTAINERS = "testcontainers"
     static final String CLIENT_ID = "myclient"
-    private static String clientSecret
+    private static String clientSecret = UUID.randomUUID()
     private static String issuer
     static GenericContainer keycloak
 
@@ -56,7 +56,7 @@ class Keycloak {
             if (OperatingSystem.current.macOs && System.getProperty("os.arch") == 'aarch64') {
                 keycloak = new GenericContainer(new ImageFromDockerfile("keycloak-m1", false).withFileFromClasspath("Dockerfile", "/Dockerfile.keycloak"))
             } else {
-                keycloak = new GenericContainer("jboss/keycloak:8.0.0")
+                keycloak = new GenericContainer("jboss/keycloak:16.1.1")
             }
 
             keycloak = keycloak.withExposedPorts(8080)
@@ -68,11 +68,7 @@ class Keycloak {
                     .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Deployed \"keycloak-server.war\".*").withStartupTimeout(Duration.ofMinutes(5)))
             keycloak.start()
             keycloak.execInContainer("/opt/jboss/keycloak/bin/kcreg.sh config credentials --server http://localhost:8080/auth --realm master --user user --password password".split(" "))
-            keycloak.execInContainer("/opt/jboss/keycloak/bin/kcreg.sh create -s clientId=$CLIENT_ID -s redirectUris=[\"http://${getRedirectUriHost()}*\"]".split(" "))
-            Container.ExecResult result = keycloak.execInContainer("/opt/jboss/keycloak/bin/kcreg.sh get $CLIENT_ID".split(" "))
-            Map map = new ObjectMapper()
-                    .readValue(result.getStdout(), Map.class)
-            clientSecret = map.get("secret")
+            keycloak.execInContainer("/opt/jboss/keycloak/bin/kcreg.sh create -s clientId=$CLIENT_ID -s redirectUris=[\"http://${getRedirectUriHost()}*\"] -s secret=$clientSecret".split(" "))
             int port = keycloak.getMappedPort(8080)
             Testcontainers.exposeHostPorts(port)
             issuer = "http://" + getHost() + ":" + port  + "/auth/realms/master"

--- a/test-suite-utils/src/main/resources/Dockerfile.keycloak
+++ b/test-suite-utils/src/main/resources/Dockerfile.keycloak
@@ -1,0 +1,45 @@
+# Grab the x86 version of keycloak for the tools
+FROM jboss/keycloak:8.0.0 as keycloak
+
+FROM ubuntu:latest
+
+# Taken from https://github.com/keycloak/keycloak-containers/blob/main/server/Dockerfile (check history for version changes)
+ENV KEYCLOAK_VERSION 8.0.0
+ENV JDBC_POSTGRES_VERSION 42.2.5
+ENV JDBC_MYSQL_VERSION 8.0.22
+ENV JDBC_MARIADB_VERSION 2.5.4
+ENV JDBC_MSSQL_VERSION 8.2.2.jre11
+
+ENV LAUNCH_JBOSS_IN_BACKGROUND 1
+ENV PROXY_ADDRESS_FORWARDING false
+ENV JBOSS_HOME /opt/jboss/keycloak
+ENV LANG en_US.UTF-8
+
+ARG GIT_REPO
+ARG GIT_BRANCH
+
+# Pre v11
+ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+
+# Post v11
+# ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+
+
+USER root
+
+RUN apt update
+RUN apt --assume-yes install curl gzip hostname openssl tar
+RUN apt --assume-yes install openjdk-11-jdk-headless
+
+COPY --from=keycloak /opt/jboss/tools /opt/jboss/tools
+
+RUN /opt/jboss/tools/build-keycloak.sh
+
+USER 1000
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENTRYPOINT [ "/opt/jboss/tools/docker-entrypoint.sh" ]
+
+CMD ["-b", "0.0.0.0"]

--- a/test-suite-utils/src/main/resources/Dockerfile.keycloak
+++ b/test-suite-utils/src/main/resources/Dockerfile.keycloak
@@ -1,10 +1,14 @@
+ARG KEYCLOAK_VERSION=16.1.1
+
 # Grab the x86 version of keycloak for the tools
-FROM jboss/keycloak:16.1.1 as keycloak
+FROM jboss/keycloak:$KEYCLOAK_VERSION as keycloak
 
 FROM ubuntu:latest
 
+ARG KEYCLOAK_VERSION
+
 # Taken from https://github.com/keycloak/keycloak-containers/blob/main/server/Dockerfile (check history for version changes)
-ENV KEYCLOAK_VERSION 16.1.1
+ENV KEYCLOAK_VERSION $KEYCLOAK_VERSION
 ENV JDBC_POSTGRES_VERSION 42.2.5
 ENV JDBC_MYSQL_VERSION 8.0.22
 ENV JDBC_MARIADB_VERSION 2.5.4
@@ -18,12 +22,7 @@ ENV LANG en_US.UTF-8
 ARG GIT_REPO
 ARG GIT_BRANCH
 
-# Pre v11
-# ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
-
-# Post v11
 ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
-
 
 USER root
 

--- a/test-suite-utils/src/main/resources/Dockerfile.keycloak
+++ b/test-suite-utils/src/main/resources/Dockerfile.keycloak
@@ -1,10 +1,10 @@
 # Grab the x86 version of keycloak for the tools
-FROM jboss/keycloak:8.0.0 as keycloak
+FROM jboss/keycloak:16.1.1 as keycloak
 
 FROM ubuntu:latest
 
 # Taken from https://github.com/keycloak/keycloak-containers/blob/main/server/Dockerfile (check history for version changes)
-ENV KEYCLOAK_VERSION 8.0.0
+ENV KEYCLOAK_VERSION 16.1.1
 ENV JDBC_POSTGRES_VERSION 42.2.5
 ENV JDBC_MYSQL_VERSION 8.0.22
 ENV JDBC_MARIADB_VERSION 2.5.4
@@ -19,10 +19,10 @@ ARG GIT_REPO
 ARG GIT_BRANCH
 
 # Pre v11
-ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+# ARG KEYCLOAK_DIST=https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
 
 # Post v11
-# ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
 
 
 USER root


### PR DESCRIPTION
On an Apple M1 computer, the x86 Keycloak image runs too slowly and the tests fail.

This change updates Keycloak to the latest version, and builds an ARM version when run
on M1 hardware so the tests pass when run locally.
