### PR TITLE
Fix deserialization of Authentication without attributes

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/ClientAuthentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/ClientAuthentication.java
@@ -50,7 +50,7 @@ public class ClientAuthentication implements Authentication {
     public ClientAuthentication(@JsonProperty("name") String name,
                                 @JsonProperty("attributes") Map<String, Object> attributes) {
         this.name = name;
-        this.attributes = attributes;
+        this.attributes = attributes == null ? Collections.emptyMap() : attributes;
     }
 
     @Override

--- a/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSerializationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/AuthenticationSerializationSpec.groovy
@@ -5,6 +5,8 @@ import io.micronaut.core.serialize.JdkSerializer
 import io.micronaut.jackson.serialize.JacksonObjectSerializer
 import spock.lang.Specification
 
+import java.nio.charset.StandardCharsets
+
 class AuthenticationSerializationSpec extends Specification {
 
     void "test authentication is serializable"() {
@@ -41,5 +43,17 @@ class AuthenticationSerializationSpec extends Specification {
         deserialized.roles.size() == 2
         deserialized.roles.contains("X")
         deserialized.roles.contains("Y")
+    }
+
+    void "deserialization without attributes"() {
+        ObjectMapper objectMapper = new ObjectMapper()
+        JacksonObjectSerializer serializer = new JacksonObjectSerializer(objectMapper)
+
+        when:
+        Authentication deserialized = serializer.deserialize('{\"name\":\"foo\"}'.getBytes(StandardCharsets.UTF_8), Authentication).get()
+
+        then:
+        deserialized.name == "foo"
+        deserialized.attributes.isEmpty()
     }
 }


### PR DESCRIPTION
Handle missing attributes for ClientAuthentication deserialization the same way as the ServerAuthentication constructor, i.e. by using an empty attribute map.
Fixes #1038