### PR TITLE
Support for Keycloak v17+ in AuthorizationServer::infer

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/AuthorizationServer.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/AuthorizationServer.java
@@ -32,7 +32,7 @@ public enum AuthorizationServer {
     private static final String ISSUER_PART_OKTA = "okta";
     private static final String ISSUER_PART_COGNITO = "cognito";
     private static final String ISSUER_PART_AUTH0 = "auth0";
-    private static final String ISSUER_PART_KEYCLOAK = "/auth/realms/";
+    private static final String ISSUER_PART_KEYCLOAK = "/realms/";
 
     /**
      * @param issuer Issuer url

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/endsession/request/AuthorizationServerSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/endsession/request/AuthorizationServerSpec.groovy
@@ -13,6 +13,7 @@ class AuthorizationServerSpec extends Specification {
         where:
         issuer                                                || authorizationServer
         "http://localhost:8180/auth/realms/master"            || AuthorizationServer.KEYCLOAK
+        "http://localhost:8180/realms/master"                 || AuthorizationServer.KEYCLOAK
         "https://dev-XXXXX.oktapreview.com/oauth2/default"    || AuthorizationServer.OKTA
         "https://cognito-idp.us-east-1.amazonaws.com/12345}/" || AuthorizationServer.COGNITO
         "https://micronautguides.eu.auth0.com"                || AuthorizationServer.AUTH0


### PR DESCRIPTION
Keycloak 17+ doesn't have the `/auth/` fragment in its pre-set URLs, therefore the original logic in `AuthorizationServer` is outdated, and it's not possible to infer the right type of newer Keycloak instances based on the URL of the issuer. The biggest consequence of this is that `EndSessionEndpointResolver` is not able to register the right end session endpoint for Keycloak.