### PR TITLE
Fixed serialization of ServerAuthentication when running in a native image

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
+++ b/security/src/main/java/io/micronaut/security/authentication/ServerAuthentication.java
@@ -18,6 +18,7 @@ package io.micronaut.security.authentication;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.security.token.config.TokenConfiguration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,7 @@ import java.util.Map;
  * @author James Kleeh
  * @since 3.0.0
  */
+@TypeHint(value = {ServerAuthentication.class}, accessType = {TypeHint.AccessType.ALL_PUBLIC})
 public class ServerAuthentication implements Authentication {
 
     private static final String JSON_KEY_NAME = "name";


### PR DESCRIPTION
In the authentication process, the `io.micronaut.security.session.SessionLoginHandler` saves an authentication to a session. When Redis is used as a session storage, the authentication is serialized before sent to Redis. The serialization of ServerAuthentication doesn't work as expected when running in a native image (the serialized result doesn't contain any value from ServerAuthentication instance). The test project can be found here: https://github.com/msupic/server-auth/blob/main/src/main/java/server/auth/HomeController.java. Adding
```
@TypeHint(value = {ServerAuthentication.class}, accessType = {TypeHint.AccessType.ALL_PUBLIC})
```
solves the serialization issue when running in a native image