### PR TITLE
Fix dependency scope

### DIFF
--- a/security-oauth2/build.gradle
+++ b/security-oauth2/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     testImplementation project(":security-jwt")
     testImplementation project(":test-suite-utils")
     testImplementation project(":test-suite-utils-security")
-    implementation(project(":test-suite-keycloak-16"))
+    testImplementation(project(":test-suite-keycloak-16"))
 }


### PR DESCRIPTION
The `oauth2` module depends on a test suite, which is wrong.