### PR TITLE
Avoid initializing logging at build time for GraalVM

### DIFF
--- a/test-suite-graal/build.gradle
+++ b/test-suite-graal/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(project(":security"))
+    testImplementation(project(":security-jwt"))
     testImplementation(mnTest.micronaut.test.junit5)
 }
 


### PR DESCRIPTION
Custom conditions are encoding into the AnnotationMetadata which is initialized at build time, for this reason conditions can never use logging safely otherwise they will initialize the log infrastructure. This PR moves  the logging in `AuthenticationModeCondition` to a static inner class which avoids initializing the logging when the class is initialized.