### PR TITLE
feat: builder of DefaultOpenIdProviderMetadata

### DIFF
--- a/security-aot/src/main/java/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGenerator.java
+++ b/security-aot/src/main/java/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGenerator.java
@@ -16,7 +16,6 @@
 package io.micronaut.security.aot;
 
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;

--- a/security-aot/src/main/java/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGenerator.java
+++ b/security-aot/src/main/java/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGenerator.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.aot;
 
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -57,7 +58,7 @@ public class OpenIdProviderMetadataFetcherCodeGenerator extends AbstractCodeGene
     public static final String SECURITY_AOT_OPENID_CONFIGURATION_MODULE_ID = "micronaut.security.openid-configuration";
     private static final Logger LOG = LoggerFactory.getLogger(OpenIdProviderMetadataFetcherCodeGenerator.class);
     private static final ParameterizedTypeName SUPPLIER_OF_METADATA = ParameterizedTypeName.get(Supplier.class, DefaultOpenIdProviderMetadata.class);
-    private static final String METADATA = "metadata.";
+    private static final String BUILDER = "builder.";
 
     @Override
     public void generate(@NonNull AOTContext context) {
@@ -116,55 +117,55 @@ public class OpenIdProviderMetadataFetcherCodeGenerator extends AbstractCodeGene
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("create")
                 .returns(DefaultOpenIdProviderMetadata.class)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addStatement("$T metadata = new $T()", DefaultOpenIdProviderMetadata.class, DefaultOpenIdProviderMetadata.class);
-        addStringSetterStatement(methodBuilder, "setUserinfoEndpoint", defaultOpenIdProviderMetadata.getUserinfoEndpoint());
-        addBooleanSetterStatement(methodBuilder, "setRequireRequestUriRegistration", defaultOpenIdProviderMetadata.getRequireRequestUriRegistration());
-        addStringSetterStatement(methodBuilder, "setAuthorizationEndpoint", defaultOpenIdProviderMetadata.getAuthorizationEndpoint());
-        addListStringSetterStatement(methodBuilder, "userinfoEncryptionEncValuesSupported", "setUserinfoEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getUserinfoEncryptionEncValuesSupported());
-        addListStringSetterStatement(methodBuilder, "idTokenEncryptionEncValuesSupported", "setIdTokenEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getIdTokenEncryptionEncValuesSupported());
-        addListStringSetterStatement(methodBuilder, "userinfoEncryptionAlgValuesSupported", "setUserinfoEncryptionAlgValuesSupported", defaultOpenIdProviderMetadata.getUserInfoEncryptionAlgValuesSupported());
-        addListStringSetterStatement(methodBuilder, "idTokenSigningAlgValuesSupported", "setIdTokenSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getIdTokenSigningAlgValuesSupported());
-        addStringSetterStatement(methodBuilder, "setIssuer", defaultOpenIdProviderMetadata.getIssuer());
-        addStringSetterStatement(methodBuilder, "setJwksUri", defaultOpenIdProviderMetadata.getJwksUri());
-        addListStringSetterStatement(methodBuilder, "responseTypesSupported", "setResponseTypesSupported", defaultOpenIdProviderMetadata.getResponseTypesSupported());
-        addListStringSetterStatement(methodBuilder, "scopesSupported", "setScopesSupported", defaultOpenIdProviderMetadata.getScopesSupported());
-        addListStringSetterStatement(methodBuilder, "subjectTypesSupported", "setSubjectTypesSupported", defaultOpenIdProviderMetadata.getSubjectTypesSupported());
-        addStringSetterStatement(methodBuilder, "setTokenEndpoint", defaultOpenIdProviderMetadata.getTokenEndpoint());
-        addListStringSetterStatement(methodBuilder, "tokenEndpointAuthSigningAlgValuesSupported", "setTokenEndpointAuthSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getTokenEndpointAuthSigningAlgValuesSupported());
-        addListStringSetterStatement(methodBuilder, "displayValuesSupported", "setDisplayValuesSupported", defaultOpenIdProviderMetadata.getDisplayValuesSupported());
-        addListStringSetterStatement(methodBuilder, "claimTypesSupported", "setClaimTypesSupported", defaultOpenIdProviderMetadata.getClaimTypesSupported());
-        addListStringSetterStatement(methodBuilder, "tokenEndpointAuthMethodsSupported", "setTokenEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getTokenEndpointAuthMethodsSupported());
-        addListStringSetterStatement(methodBuilder, "responseModesSupported", "setResponseModesSupported", defaultOpenIdProviderMetadata.getResponseModesSupported());
-        addListStringSetterStatement(methodBuilder, "acrValuesSupported", "setAcrValuesSupported", defaultOpenIdProviderMetadata.getAcrValuesSupported());
-        addListStringSetterStatement(methodBuilder, "grantTypesSupported", "setGrantTypesSupported", defaultOpenIdProviderMetadata.getGrantTypesSupported());
-        addStringSetterStatement(methodBuilder, "setRegistrationEndpoint", defaultOpenIdProviderMetadata.getRegistrationEndpoint());
-        addStringSetterStatement(methodBuilder, "setServiceDocumentation", defaultOpenIdProviderMetadata.getServiceDocumentation());
-        addListStringSetterStatement(methodBuilder, "claimsLocalesSupported", "setClaimsLocalesSupported", defaultOpenIdProviderMetadata.getClaimsLocalesSupported());
-        addListStringSetterStatement(methodBuilder, "uriLocalesSupported", "setUriLocalesSupported", defaultOpenIdProviderMetadata.getUriLocalesSupported());
-        addBooleanSetterStatement(methodBuilder, "setClaimsParameterSupported", defaultOpenIdProviderMetadata.getClaimsParameterSupported());
-        addListStringSetterStatement(methodBuilder, "claimsSupported", "setClaimsSupported", defaultOpenIdProviderMetadata.getClaimsSupported());
-        addListStringSetterStatement(methodBuilder, "codeChallengeMethodsSupported", "setCodeChallengeMethodsSupported", defaultOpenIdProviderMetadata.getCodeChallengeMethodsSupported());
-        addStringSetterStatement(methodBuilder, "setIntrospectionEndpoint", defaultOpenIdProviderMetadata.getIntrospectionEndpoint());
-        addListStringSetterStatement(methodBuilder, "introspectionEndpointAuthMethodsSupported", "setIntrospectionEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getIntrospectionEndpointAuthMethodsSupported());
-        addStringSetterStatement(methodBuilder, "setRevocationEndpoint", defaultOpenIdProviderMetadata.getRevocationEndpoint());
-        addListStringSetterStatement(methodBuilder, "revocationEndpointAuthMethodsSupported", "setRevocationEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getRevocationEndpointAuthMethodsSupported());
-        addStringSetterStatement(methodBuilder, "setCheckSessionIframe", defaultOpenIdProviderMetadata.getCheckSessionIframe());
-        addStringSetterStatement(methodBuilder, "setEndSessionEndpoint", defaultOpenIdProviderMetadata.getEndSessionEndpoint());
-        addBooleanSetterStatement(methodBuilder, "setRequestUriParameterSupported", defaultOpenIdProviderMetadata.getRequestUriParameterSupported());
-        addStringSetterStatement(methodBuilder, "setOpPolicyUri", defaultOpenIdProviderMetadata.getOpPolicyUri());
-        addStringSetterStatement(methodBuilder, "setOpTosUri", defaultOpenIdProviderMetadata.getOpTosUri());
-        addBooleanSetterStatement(methodBuilder, "setRequestParameterSupported", defaultOpenIdProviderMetadata.getRequestParameterSupported());
-        addListStringSetterStatement(methodBuilder, "requestObjectEncryptionAlgValuesSupported", "setRequestObjectEncryptionAlgValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectEncryptionAlgValuesSupported());
-        addListStringSetterStatement(methodBuilder, "requestObjectEncryptionEncValuesSupported", "setRequestObjectEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectEncryptionEncValuesSupported());
-        addListStringSetterStatement(methodBuilder, "requestObjectSigningAlgValuesSupported", "setRequestObjectSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectSigningAlgValuesSupported());
-        return methodBuilder.addStatement("return metadata").build();
+                .addStatement("$T builder = $T.builder()", DefaultOpenIdProviderMetadata.Builder.class, DefaultOpenIdProviderMetadata.class);
+        addStringSetterStatement(methodBuilder, "userinfoEndpoint", defaultOpenIdProviderMetadata.getUserinfoEndpoint());
+        addBooleanSetterStatement(methodBuilder, "requireRequestUriRegistration", defaultOpenIdProviderMetadata.getRequireRequestUriRegistration());
+        addStringSetterStatement(methodBuilder, "authorizationEndpoint", defaultOpenIdProviderMetadata.getAuthorizationEndpoint());
+        addListStringSetterStatement(methodBuilder, "userinfoEncryptionEncValuesSupported", "userinfoEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getUserinfoEncryptionEncValuesSupported());
+        addListStringSetterStatement(methodBuilder, "idTokenEncryptionEncValuesSupported", "idTokenEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getIdTokenEncryptionEncValuesSupported());
+        addListStringSetterStatement(methodBuilder, "userinfoEncryptionAlgValuesSupported", "userinfoEncryptionAlgValuesSupported", defaultOpenIdProviderMetadata.getUserInfoEncryptionAlgValuesSupported());
+        addListStringSetterStatement(methodBuilder, "idTokenSigningAlgValuesSupported", "idTokenSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getIdTokenSigningAlgValuesSupported());
+        addStringSetterStatement(methodBuilder, "issuer", defaultOpenIdProviderMetadata.getIssuer());
+        addStringSetterStatement(methodBuilder, "jwksUri", defaultOpenIdProviderMetadata.getJwksUri());
+        addListStringSetterStatement(methodBuilder, "responseTypesSupported", "responseTypesSupported", defaultOpenIdProviderMetadata.getResponseTypesSupported());
+        addListStringSetterStatement(methodBuilder, "scopesSupported", "scopesSupported", defaultOpenIdProviderMetadata.getScopesSupported());
+        addListStringSetterStatement(methodBuilder, "subjectTypesSupported", "subjectTypesSupported", defaultOpenIdProviderMetadata.getSubjectTypesSupported());
+        addStringSetterStatement(methodBuilder, "tokenEndpoint", defaultOpenIdProviderMetadata.getTokenEndpoint());
+        addListStringSetterStatement(methodBuilder, "tokenEndpointAuthSigningAlgValuesSupported", "tokenEndpointAuthSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getTokenEndpointAuthSigningAlgValuesSupported());
+        addListStringSetterStatement(methodBuilder, "displayValuesSupported", "displayValuesSupported", defaultOpenIdProviderMetadata.getDisplayValuesSupported());
+        addListStringSetterStatement(methodBuilder, "claimTypesSupported", "claimTypesSupported", defaultOpenIdProviderMetadata.getClaimTypesSupported());
+        addListStringSetterStatement(methodBuilder, "tokenEndpointAuthMethodsSupported", "tokenEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getTokenEndpointAuthMethodsSupported());
+        addListStringSetterStatement(methodBuilder, "responseModesSupported", "responseModesSupported", defaultOpenIdProviderMetadata.getResponseModesSupported());
+        addListStringSetterStatement(methodBuilder, "acrValuesSupported", "acrValuesSupported", defaultOpenIdProviderMetadata.getAcrValuesSupported());
+        addListStringSetterStatement(methodBuilder, "grantTypesSupported", "grantTypesSupported", defaultOpenIdProviderMetadata.getGrantTypesSupported());
+        addStringSetterStatement(methodBuilder, "registrationEndpoint", defaultOpenIdProviderMetadata.getRegistrationEndpoint());
+        addStringSetterStatement(methodBuilder, "serviceDocumentation", defaultOpenIdProviderMetadata.getServiceDocumentation());
+        addListStringSetterStatement(methodBuilder, "claimsLocalesSupported", "claimsLocalesSupported", defaultOpenIdProviderMetadata.getClaimsLocalesSupported());
+        addListStringSetterStatement(methodBuilder, "uriLocalesSupported", "uriLocalesSupported", defaultOpenIdProviderMetadata.getUriLocalesSupported());
+        addBooleanSetterStatement(methodBuilder, "claimsParameterSupported", defaultOpenIdProviderMetadata.getClaimsParameterSupported());
+        addListStringSetterStatement(methodBuilder, "claimsSupported", "claimsSupported", defaultOpenIdProviderMetadata.getClaimsSupported());
+        addListStringSetterStatement(methodBuilder, "codeChallengeMethodsSupported", "codeChallengeMethodsSupported", defaultOpenIdProviderMetadata.getCodeChallengeMethodsSupported());
+        addStringSetterStatement(methodBuilder, "introspectionEndpoint", defaultOpenIdProviderMetadata.getIntrospectionEndpoint());
+        addListStringSetterStatement(methodBuilder, "introspectionEndpointAuthMethodsSupported", "introspectionEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getIntrospectionEndpointAuthMethodsSupported());
+        addStringSetterStatement(methodBuilder, "revocationEndpoint", defaultOpenIdProviderMetadata.getRevocationEndpoint());
+        addListStringSetterStatement(methodBuilder, "revocationEndpointAuthMethodsSupported", "revocationEndpointAuthMethodsSupported", defaultOpenIdProviderMetadata.getRevocationEndpointAuthMethodsSupported());
+        addStringSetterStatement(methodBuilder, "checkSessionIframe", defaultOpenIdProviderMetadata.getCheckSessionIframe());
+        addStringSetterStatement(methodBuilder, "endSessionEndpoint", defaultOpenIdProviderMetadata.getEndSessionEndpoint());
+        addBooleanSetterStatement(methodBuilder, "requestUriParameterSupported", defaultOpenIdProviderMetadata.getRequestUriParameterSupported());
+        addStringSetterStatement(methodBuilder, "opPolicyUri", defaultOpenIdProviderMetadata.getOpPolicyUri());
+        addStringSetterStatement(methodBuilder, "opTosUri", defaultOpenIdProviderMetadata.getOpTosUri());
+        addBooleanSetterStatement(methodBuilder, "requestParameterSupported", defaultOpenIdProviderMetadata.getRequestParameterSupported());
+        addListStringSetterStatement(methodBuilder, "requestObjectEncryptionAlgValuesSupported", "requestObjectEncryptionAlgValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectEncryptionAlgValuesSupported());
+        addListStringSetterStatement(methodBuilder, "requestObjectEncryptionEncValuesSupported", "requestObjectEncryptionEncValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectEncryptionEncValuesSupported());
+        addListStringSetterStatement(methodBuilder, "requestObjectSigningAlgValuesSupported", "requestObjectSigningAlgValuesSupported", defaultOpenIdProviderMetadata.getRequestObjectSigningAlgValuesSupported());
+        return methodBuilder.addStatement("return builder.build()").build();
     }
 
     private void addStringSetterStatement(@NonNull MethodSpec.Builder methodBuilder,
                                           @NonNull String setter,
                                           @Nullable String value) {
         if (value != null) {
-            methodBuilder.addStatement(METADATA + setter + "($S)", value);
+            methodBuilder.addStatement(BUILDER + setter + "($S)", value);
         }
     }
 
@@ -172,7 +173,7 @@ public class OpenIdProviderMetadataFetcherCodeGenerator extends AbstractCodeGene
                                            @NonNull String setter,
                                            @Nullable Boolean value) {
         if (value != null) {
-            methodBuilder.addStatement(METADATA + setter + "($L)", value);
+            methodBuilder.addStatement(BUILDER + setter + "($L)", value);
         }
     }
 
@@ -185,7 +186,7 @@ public class OpenIdProviderMetadataFetcherCodeGenerator extends AbstractCodeGene
             for (String value : values) {
                 methodBuilder.addStatement(listVariableName + ".add($S)", value);
             }
-            methodBuilder.addStatement(METADATA + setter + "(" + listVariableName + ")");
+            methodBuilder.addStatement(BUILDER + setter + "(" + listVariableName + ")");
         }
     }
 }

--- a/security-aot/src/test/groovy/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGeneratorSpec.groovy
+++ b/security-aot/src/test/groovy/io/micronaut/security/aot/OpenIdProviderMetadataFetcherCodeGeneratorSpec.groovy
@@ -80,34 +80,34 @@ import java.util.List;
 
 public class AotOpenIdProviderMetadataFetcherCognito {
   public static DefaultOpenIdProviderMetadata create() {
-    DefaultOpenIdProviderMetadata metadata = new DefaultOpenIdProviderMetadata();
-    metadata.setUserinfoEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/userInfo");
-    metadata.setAuthorizationEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/authorize");
+    DefaultOpenIdProviderMetadata.Builder builder = DefaultOpenIdProviderMetadata.builder();
+    builder.userinfoEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/userInfo");
+    builder.authorizationEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/authorize");
     List<String> idTokenSigningAlgValuesSupported = new ArrayList<>();
     idTokenSigningAlgValuesSupported.add("RS256");
-    metadata.setIdTokenSigningAlgValuesSupported(idTokenSigningAlgValuesSupported);
-    metadata.setIssuer("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_4OqDoWVrZ");
-    metadata.setJwksUri("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_4OqDoWVrZ/.well-known/jwks.json");
+    builder.idTokenSigningAlgValuesSupported(idTokenSigningAlgValuesSupported);
+    builder.issuer("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_4OqDoWVrZ");
+    builder.jwksUri("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_4OqDoWVrZ/.well-known/jwks.json");
     List<String> responseTypesSupported = new ArrayList<>();
     responseTypesSupported.add("code");
     responseTypesSupported.add("token");
-    metadata.setResponseTypesSupported(responseTypesSupported);
+    builder.responseTypesSupported(responseTypesSupported);
     List<String> scopesSupported = new ArrayList<>();
     scopesSupported.add("openid");
     scopesSupported.add("email");
     scopesSupported.add("phone");
     scopesSupported.add("profile");
-    metadata.setScopesSupported(scopesSupported);
+    builder.scopesSupported(scopesSupported);
     List<String> subjectTypesSupported = new ArrayList<>();
     subjectTypesSupported.add("public");
-    metadata.setSubjectTypesSupported(subjectTypesSupported);
-    metadata.setTokenEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/token");
+    builder.subjectTypesSupported(subjectTypesSupported);
+    builder.tokenEndpoint("https://auth-groovycalamari.auth.us-east-1.amazoncognito.com/oauth2/token");
     List<String> tokenEndpointAuthMethodsSupported = new ArrayList<>();
     tokenEndpointAuthMethodsSupported.add("client_secret_basic");
     tokenEndpointAuthMethodsSupported.add("client_secret_post");
-    metadata.setTokenEndpointAuthMethodsSupported(tokenEndpointAuthMethodsSupported);
-    metadata.setClaimsParameterSupported(false);
-    return metadata;
+    builder.tokenEndpointAuthMethodsSupported(tokenEndpointAuthMethodsSupported);
+    builder.claimsParameterSupported(false);
+    return builder.build();
   }
 }"""
                 compiles()

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/DefaultOpenIdProviderMetadata.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/DefaultOpenIdProviderMetadata.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @see <a href="https://openid.net/specs/openid-connect-discovery-1_0.html">OpenID connect Discovery Spec</a>
@@ -862,5 +863,603 @@ public class DefaultOpenIdProviderMetadata implements OpenIdProviderMetadata {
         result = 31 * result + (requestObjectEncryptionEncValuesSupported != null ? requestObjectEncryptionEncValuesSupported.hashCode() : 0);
         result = 31 * result + (checkSessionIframe != null ? checkSessionIframe.hashCode() : 0);
         return result;
+    }
+
+
+    /**
+     *
+     * @return Creates a Builder.
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder.
+     */
+    public static class Builder {
+        @Nullable
+        private String authorizationEndpoint;
+
+        @NonNull
+        private List<String> idTokenSigningAlgValuesSupported;
+
+        @NonNull
+        private String issuer;
+        @NonNull
+        private String jwksUri;
+
+        @Nullable
+        private List<String> acrValuesSupported;
+        @Nullable
+        private List<String> responseTypesSupported;
+        @Nullable
+        private List<String> responseModesSupported;
+        @Nullable
+        private List<String> scopesSupported;
+
+        @Nullable
+        private List<String> grantTypesSupported;
+
+        @NonNull
+        private List<String> subjectTypesSupported;
+        @NonNull
+        private String tokenEndpoint;
+
+        @Nullable
+        private List<String> tokenEndpointAuthMethodsSupported;
+
+        @Nullable
+        private String userinfoEndpoint;
+
+        @Nullable
+        private String registrationEndpoint;
+        @Nullable private List<String> claimsSupported;
+        @Nullable
+        private List<String> codeChallengeMethodsSupported;
+        @Nullable
+        private String introspectionEndpoint;
+        @Nullable
+        private List<String> introspectionEndpointAuthMethodsSupported;
+        @Nullable
+        private String revocationEndpoint;
+        @Nullable
+        private List<String> revocationEndpointAuthMethodsSupported;
+        @Nullable
+        private String endSessionEndpoint;
+        @Nullable
+        private Boolean requestParameterSupported;
+        @Nullable
+        private Boolean requestUriParameterSupported;
+        @Nullable
+        private Boolean requireRequestUriRegistration;
+        @Nullable
+        private List<String> requestObjectSigningAlgValuesSupported;
+        @Nullable
+        private String serviceDocumentation;
+        @Nullable
+        private List<String> idTokenEncryptionEncValuesSupported;
+        @Nullable
+        private List<String> displayValuesSupported;
+        @Nullable
+        private List<String> claimTypesSupported;
+
+        @NonNull
+        private Boolean claimsParameterSupported = Boolean.FALSE;
+
+        @Nullable
+        private String opTosUri;
+        @Nullable
+        private String opPolicyUri;
+        @Nullable
+        private List<String> uriLocalesSupported;
+        @Nullable
+        private List<String> claimsLocalesSupported;
+        @Nullable
+        private List<String> userinfoEncryptionAlgValuesSupported;
+        @Nullable
+        private List<String> userinfoEncryptionEncValuesSupported;
+        @Nullable
+        private List<String> tokenEndpointAuthSigningAlgValuesSupported;
+        @Nullable
+        private List<String> requestObjectEncryptionAlgValuesSupported;
+        @Nullable
+        private List<String> requestObjectEncryptionEncValuesSupported;
+        @Nullable
+        private String checkSessionIframe;
+
+        /**
+         *
+         * @param authorizationEndpoint URL of the Open ID Provider's OAuth 2.0 Authorization Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder authorizationEndpoint(@Nullable String authorizationEndpoint) {
+            this.authorizationEndpoint = authorizationEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param idTokenSigningAlgValuesSupported List of the JWS signing algorithms (alg values) supported by the OP for the ID Token to encode the Claims in a JWT [JWT].
+         * @return The Builder
+         */
+        @NonNull
+        public Builder idTokenSigningAlgValuesSupported(@NonNull List<String> idTokenSigningAlgValuesSupported) {
+            this.idTokenSigningAlgValuesSupported = idTokenSigningAlgValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param issuer URL using the https scheme with no query or fragment component that the Open ID Provider asserts as its Issuer Identifier.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder issuer(@NonNull String issuer) {
+            this.issuer = issuer;
+            return this;
+        }
+
+        /**
+         *
+         * @param jwksUri URL of the Open ID Provider's JSON Web Key Set
+         * @return The Builder
+         */
+        @NonNull
+        public Builder jwksUri(@NonNull String jwksUri) {
+            this.jwksUri = jwksUri;
+            return this;
+        }
+
+        /**
+         *
+         * @param acrValuesSupported List of the Authentication Context Class References that this OP supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder acrValuesSupported(@NonNull List<String> acrValuesSupported) {
+            this.acrValuesSupported = acrValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param responseTypesSupported List of the OAuth 2.0 response_type values that this Open ID Provider supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder responseTypesSupported(@Nullable List<String> responseTypesSupported) {
+            this.responseTypesSupported = responseTypesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param responseModesSupported List of the OAuth 2.0 response_mode values that this Open ID Provider supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder responseModesSupported(@Nullable List<String> responseModesSupported) {
+            this.responseModesSupported = responseModesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param scopesSupported List of the OAuth 2.0 [RFC6749] scope values that this server supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder scopesSupported(@Nullable List<String> scopesSupported) {
+            this.scopesSupported = scopesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param grantTypesSupported List of the OAuth 2.0 Grant Type values that this Open ID Provider supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder grantTypesSupported(@Nullable List<String> grantTypesSupported) {
+            this.grantTypesSupported = grantTypesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param subjectTypesSupported List of the Subject Identifier types that this OP supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder subjectTypesSupported(@NonNull List<String> subjectTypesSupported) {
+            this.subjectTypesSupported = subjectTypesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param tokenEndpoint URL of the Open ID Provider's OAuth 2.0 Token Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder tokenEndpoint(@NonNull String tokenEndpoint) {
+            this.tokenEndpoint = tokenEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param tokenEndpointAuthMethodsSupported List of Client Authentication methods supported by this Token Endpoint.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder tokenEndpointAuthMethodsSupported(@Nullable List<String> tokenEndpointAuthMethodsSupported) {
+            this.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param userinfoEndpoint URL of the Open ID Provider's UserInfo Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder userinfoEndpoint(@Nullable String userinfoEndpoint) {
+            this.userinfoEndpoint = userinfoEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param registrationEndpoint URL of the Open ID Provider's Dynamic Client Registration Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder registrationEndpoint(@Nullable String registrationEndpoint) {
+            this.registrationEndpoint = registrationEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param claimsSupported List of the Claim Names of the Claims that the OpenID Provider MAY be able to supply values for.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder claimsSupported(@Nullable List<String> claimsSupported) {
+            this.claimsSupported = claimsSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param codeChallengeMethodsSupported List of the supported transformation methods by the authorisation code verifier for Proof Key for Code Exchange (PKCE).
+         * @return The Builder
+         */
+        @NonNull
+        public Builder codeChallengeMethodsSupported(@Nullable List<String> codeChallengeMethodsSupported) {
+            this.codeChallengeMethodsSupported = codeChallengeMethodsSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param introspectionEndpoint The fully qualified URL of the server's introspection endpoint defined by OAuth Token Introspection [RFC7662]
+         * @return The Builder
+         */
+        @NonNull
+        public Builder introspectionEndpoint(@Nullable String introspectionEndpoint) {
+            this.introspectionEndpoint = introspectionEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param introspectionEndpointAuthMethodsSupported List of Client Authentication methods supported by Introspection Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder introspectionEndpointAuthMethodsSupported(@Nullable List<String> introspectionEndpointAuthMethodsSupported) {
+            this.introspectionEndpointAuthMethodsSupported = introspectionEndpointAuthMethodsSupported;
+            return this;
+        }
+
+
+        /**
+         *
+         * @param revocationEndpoint The fully qualified URL of the server's revocation endpoint defined by Oauth Token Revocation.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder revocationEndpoint(@Nullable String revocationEndpoint) {
+            this.revocationEndpoint = revocationEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param revocationEndpointAuthMethodsSupported List of Client Authentication methods supported by Revocation Endpoint
+         * @return The Builder
+         */
+        @NonNull
+        public Builder revocationEndpointAuthMethodsSupported(@Nullable List<String> revocationEndpointAuthMethodsSupported) {
+            this.revocationEndpointAuthMethodsSupported = revocationEndpointAuthMethodsSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param endSessionEndpoint URL at the OP to which an RP can perform a redirect to request that the End-User be logged out at the OP.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder endSessionEndpoint(@Nullable String endSessionEndpoint) {
+            this.endSessionEndpoint = endSessionEndpoint;
+            return this;
+        }
+
+        /**
+         *
+         * @param requestParameterSupported Boolean value specifying whether the OP supports use of the request parameter, with true indicating support.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requestParameterSupported(@Nullable Boolean requestParameterSupported) {
+            this.requestParameterSupported = requestParameterSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param requestUriParameterSupported Boolean value specifying whether the OP supports use of the request_uri parameter, with true indicating support.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requestUriParameterSupported(@Nullable Boolean requestUriParameterSupported) {
+            this.requestUriParameterSupported = requestUriParameterSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param requireRequestUriRegistration Boolean value specifying whether the OP requires any request_uri values used to be pre-registered using the request_uris registration parameter. Pre-registration is REQUIRED when the value is true. If omitted, the default value is false.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requireRequestUriRegistration(@Nullable Boolean requireRequestUriRegistration) {
+            this.requireRequestUriRegistration = requireRequestUriRegistration;
+            return this;
+        }
+
+        /**
+         *
+         * @param requestObjectSigningAlgValuesSupported List of the JWS signing algorithms (alg values) supported by the OP for Request Objects.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requestObjectSigningAlgValuesSupported(@Nullable List<String> requestObjectSigningAlgValuesSupported) {
+            this.requestObjectSigningAlgValuesSupported = requestObjectSigningAlgValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param serviceDocumentation URL of a page containing human-readable information that developers might want or need to know when using the OpenID Provider.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder serviceDocumentation(@Nullable String serviceDocumentation) {
+            this.serviceDocumentation = serviceDocumentation;
+            return this;
+        }
+
+        /**
+         *
+         * @param idTokenEncryptionEncValuesSupported List of the JWE encryption algorithms (enc values) supported by the OP for the ID Token to encode the Claims in a JWT [JWT].
+         * @return The Builder
+         */
+        @NonNull
+        public Builder idTokenEncryptionEncValuesSupported(@Nullable List<String> idTokenEncryptionEncValuesSupported) {
+            this.idTokenEncryptionEncValuesSupported = idTokenEncryptionEncValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param displayValuesSupported List of the display parameter values that the OpenID Provider supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder displayValuesSupported(@Nullable List<String> displayValuesSupported) {
+            this.displayValuesSupported = displayValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param claimTypesSupported List of the Claim Types that the OpenID Provider supports.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder claimTypesSupported(@Nullable List<String> claimTypesSupported) {
+            this.claimTypesSupported = claimTypesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param claimsParameterSupported Boolean value specifying whether the OP supports use of the claims parameter.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder claimsParameterSupported(@NonNull Boolean claimsParameterSupported) {
+            this.claimsParameterSupported = claimsParameterSupported;
+            return this;
+        }
+
+
+
+        /**
+         *
+         * @param opTosUri URL that the OpenID Provider provides to the person registering the Client to read about OpenID Provider's terms of service.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder opTosUri(@Nullable String opTosUri) {
+            this.opTosUri = opTosUri;
+            return this;
+        }
+
+        /**
+         *
+         * @param opPolicyUri URL that the OpenID Provider provides to the person registering the Client to read about the OP's requirements on how the Relying Party can use the data provided by the OP.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder opPolicyUri(@Nullable String opPolicyUri) {
+            this.opPolicyUri = opPolicyUri;
+            return this;
+        }
+
+        /**
+         *
+         * @param uriLocalesSupported Languages and scripts supported for the user interface
+         * @return The Builder
+         */
+        @NonNull
+        public Builder uriLocalesSupported(@Nullable List<String> uriLocalesSupported) {
+            this.uriLocalesSupported = uriLocalesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param claimsLocalesSupported Languages and scripts supported for values in Claims
+         * @return The Builder
+         */
+        @NonNull
+        public Builder claimsLocalesSupported(@Nullable List<String> claimsLocalesSupported) {
+            this.claimsLocalesSupported = claimsLocalesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param userinfoEncryptionAlgValuesSupported List of the JWE [JWE] encryption algorithms (alg values) [JWA] supported by the UserInfo Endpoint to encode the Claims in a JWT [JWT].
+         * @return The Builder
+         */
+        @NonNull
+        public Builder userinfoEncryptionAlgValuesSupported(@Nullable List<String> userinfoEncryptionAlgValuesSupported) {
+            this.userinfoEncryptionAlgValuesSupported = userinfoEncryptionAlgValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param userinfoEncryptionEncValuesSupported List of the JWE encryption algorithms (enc values) [JWA] supported by the UserInfo Endpoint to encode the Claims in a JWT [JWT].
+         * @return The Builder
+         */
+        @NonNull
+        public Builder userinfoEncryptionEncValuesSupported(@Nullable List<String> userinfoEncryptionEncValuesSupported) {
+            this.userinfoEncryptionEncValuesSupported = userinfoEncryptionEncValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param tokenEndpointAuthSigningAlgValuesSupported List of the JWS signing algorithms (alg values) supported by the Token Endpoint.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder tokenEndpointAuthSigningAlgValuesSupported(@Nullable List<String> tokenEndpointAuthSigningAlgValuesSupported) {
+            this.tokenEndpointAuthSigningAlgValuesSupported = tokenEndpointAuthSigningAlgValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param requestObjectEncryptionAlgValuesSupported list of the JWE encryption algorithms (alg values) supported by the OP for Request Objects.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requestObjectEncryptionAlgValuesSupported(@Nullable List<String> requestObjectEncryptionAlgValuesSupported) {
+            this.requestObjectEncryptionAlgValuesSupported = requestObjectEncryptionAlgValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param requestObjectEncryptionEncValuesSupported List of the JWE encryption algorithms (enc values) supported by the OP for Request Objects.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder requestObjectEncryptionEncValuesSupported(@Nullable List<String> requestObjectEncryptionEncValuesSupported) {
+            this.requestObjectEncryptionEncValuesSupported = requestObjectEncryptionEncValuesSupported;
+            return this;
+        }
+
+        /**
+         *
+         * @param checkSessionIframe URL of an OP iframe that supports cross-origin communications for session state information with the RP Client, using the HTML5 postMessage API.
+         * @return The Builder
+         */
+        @NonNull
+        public Builder checkSessionIframe(@Nullable String checkSessionIframe) {
+            this.checkSessionIframe = checkSessionIframe;
+            return this;
+        }
+
+        /**
+         *
+         * @return a {@link DefaultOpenIdProviderMetadata} instance.
+         */
+        @NonNull
+        public DefaultOpenIdProviderMetadata build() {
+            DefaultOpenIdProviderMetadata metadata = new DefaultOpenIdProviderMetadata();
+            metadata.setAuthorizationEndpoint(Objects.requireNonNull(authorizationEndpoint));
+            metadata.setIdTokenSigningAlgValuesSupported(idTokenSigningAlgValuesSupported);
+            metadata.setIssuer(issuer);
+            metadata.setJwksUri(jwksUri);
+            metadata.setAcrValuesSupported(acrValuesSupported);
+            metadata.setResponseTypesSupported(responseTypesSupported);
+            metadata.setResponseModesSupported(responseModesSupported);
+            metadata.setScopesSupported(scopesSupported);
+            metadata.setGrantTypesSupported(grantTypesSupported);
+            metadata.setSubjectTypesSupported(subjectTypesSupported);
+            metadata.setTokenEndpoint(tokenEndpoint);
+            metadata.setTokenEndpointAuthMethodsSupported(tokenEndpointAuthMethodsSupported);
+            metadata.setUserinfoEndpoint(userinfoEndpoint);
+            metadata.setRegistrationEndpoint(registrationEndpoint);
+            metadata.setClaimsSupported(claimsSupported);
+            metadata.setCodeChallengeMethodsSupported(codeChallengeMethodsSupported);
+            metadata.setIntrospectionEndpoint(introspectionEndpoint);
+            metadata.setIntrospectionEndpointAuthMethodsSupported(introspectionEndpointAuthMethodsSupported);
+            metadata.setRevocationEndpoint(revocationEndpoint);
+            metadata.setRevocationEndpointAuthMethodsSupported(revocationEndpointAuthMethodsSupported);
+            metadata.setEndSessionEndpoint(endSessionEndpoint);
+            metadata.setRequestParameterSupported(requestParameterSupported);
+            metadata.setRequestUriParameterSupported(requestUriParameterSupported);
+            metadata.setRequireRequestUriRegistration(requireRequestUriRegistration);
+            metadata.setRequestObjectSigningAlgValuesSupported(requestObjectSigningAlgValuesSupported);
+            metadata.setServiceDocumentation(serviceDocumentation);
+            metadata.setIdTokenEncryptionEncValuesSupported(idTokenEncryptionEncValuesSupported);
+            metadata.setDisplayValuesSupported(displayValuesSupported);
+            metadata.setClaimTypesSupported(claimTypesSupported);
+            metadata.setClaimsParameterSupported(claimsParameterSupported);
+            metadata.setOpTosUri(opTosUri);
+            metadata.setOpPolicyUri(opPolicyUri);
+            metadata.setUriLocalesSupported(uriLocalesSupported);
+            metadata.setClaimsLocalesSupported(claimsLocalesSupported);
+            metadata.setUserinfoEncryptionAlgValuesSupported(userinfoEncryptionAlgValuesSupported);
+            metadata.setUserinfoEncryptionEncValuesSupported(userinfoEncryptionEncValuesSupported);
+            metadata.setTokenEndpointAuthSigningAlgValuesSupported(tokenEndpointAuthSigningAlgValuesSupported);
+            metadata.setRequestObjectEncryptionAlgValuesSupported(requestObjectEncryptionAlgValuesSupported);
+            metadata.setRequestObjectEncryptionEncValuesSupported(requestObjectEncryptionEncValuesSupported);
+            metadata.setCheckSessionIframe(checkSessionIframe);
+            return metadata;
+        }
     }
 }

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/DefaultOpenIdProviderMetadataSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/DefaultOpenIdProviderMetadataSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.security.oauth2.client
 
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.annotation.ReflectiveAccess
 import spock.lang.Specification
 
@@ -7,5 +9,135 @@ class DefaultOpenIdProviderMetadataSpec extends Specification {
     void "DefaultOpenIdProviderMetadata is annotated with ReflectiveAccess"() {
         expect:
         DefaultOpenIdProviderMetadata.class.isAnnotationPresent(ReflectiveAccess)
+    }
+
+    void "DefaultOpenIdProviderMetadata offers a builder"() {
+        given:
+        String authorizationEndpoint = "authorizationEndpoint"
+        List<String> idTokenSigningAlgValuesSupported = ["idTokenSigningAlgValuesSupported"]
+        String issuer = "issuer"
+        String jwksUri = "jwksUri"
+        List<String> acrValuesSupported = ["acrValuesSupported"]
+        List<String> responseTypesSupported = ["responseTypesSupported"]
+        List<String> responseModesSupported = ["responseModesSupported"]
+        List<String> scopesSupported = ["scopesSupported"]
+        List<String> grantTypesSupported = ["grantTypesSupported"]
+        List<String> subjectTypesSupported = ["subjectTypesSupported"]
+        String tokenEndpoint = "tokenEndpoint"
+        List<String> tokenEndpointAuthMethodsSupported = ["tokenEndpointAuthMethodsSupported"]
+        String userinfoEndpoint = "userinfoEndpoint"
+        String registrationEndpoint = "registrationEndpoint"
+        List<String> claimsSupported = ["claimsSupported"]
+        List<String> codeChallengeMethodsSupported = ["codeChallengeMethodsSupported"]
+        String introspectionEndpoint = "introspectionEndpoint"
+        List<String> introspectionEndpointAuthMethodsSupported = ["introspectionEndpointAuthMethodsSupported"]
+        String revocationEndpoint = "revocationEndpoint"
+        List<String> revocationEndpointAuthMethodsSupported = ["revocationEndpointAuthMethodsSupported"]
+        String endSessionEndpoint = "endSessionEndpoint"
+        Boolean requestParameterSupported = Boolean.TRUE
+        Boolean requestUriParameterSupported = Boolean.TRUE
+        Boolean requireRequestUriRegistration = Boolean.TRUE
+        List<String> requestObjectSigningAlgValuesSupported = ["requestObjectSigningAlgValuesSupported"]
+        String serviceDocumentation ="serviceDocumentation"
+        List<String> idTokenEncryptionEncValuesSupported = ["idTokenEncryptionEncValuesSupported"]
+        List<String> displayValuesSupported = ["displayValuesSupported"]
+        List<String> claimTypesSupported = ["claimTypesSupported"]
+        Boolean claimsParameterSupported = Boolean.TRUE
+        String opTosUri = "opTosUri"
+        String opPolicyUri = "opPolicyUri"
+        List<String> uriLocalesSupported = ["uriLocalesSupported"]
+        List<String> claimsLocalesSupported = ["claimsLocalesSupported"]
+        List<String> userinfoEncryptionAlgValuesSupported = ["userinfoEncryptionAlgValuesSupported"]
+        List<String> userinfoEncryptionEncValuesSupported = ["userinfoEncryptionEncValuesSupported"]
+        List<String> tokenEndpointAuthSigningAlgValuesSupported = ["tokenEndpointAuthSigningAlgValuesSupported"]
+        List<String> requestObjectEncryptionAlgValuesSupported = ["requestObjectEncryptionAlgValuesSupported"]
+        List<String> requestObjectEncryptionEncValuesSupported = ["requestObjectEncryptionEncValuesSupported"]
+        String checkSessionIframe = "checkSessionIframe"
+
+        when:
+        DefaultOpenIdProviderMetadata metadata = DefaultOpenIdProviderMetadata.builder()
+                .authorizationEndpoint(authorizationEndpoint)
+                .idTokenSigningAlgValuesSupported(idTokenSigningAlgValuesSupported)
+                .issuer(issuer)
+                .jwksUri(jwksUri)
+                .acrValuesSupported(acrValuesSupported)
+                .responseTypesSupported(responseTypesSupported)
+                .responseModesSupported(responseModesSupported)
+                .scopesSupported(scopesSupported)
+                .grantTypesSupported(grantTypesSupported)
+                .subjectTypesSupported(subjectTypesSupported)
+                .tokenEndpoint(tokenEndpoint)
+                .tokenEndpointAuthMethodsSupported(tokenEndpointAuthMethodsSupported)
+                .userinfoEndpoint(userinfoEndpoint)
+                .registrationEndpoint(registrationEndpoint)
+                .claimsSupported(claimsSupported)
+                .codeChallengeMethodsSupported(codeChallengeMethodsSupported)
+                .introspectionEndpoint(introspectionEndpoint)
+                .introspectionEndpointAuthMethodsSupported(introspectionEndpointAuthMethodsSupported)
+                .revocationEndpoint(revocationEndpoint)
+                .revocationEndpointAuthMethodsSupported(revocationEndpointAuthMethodsSupported)
+                .endSessionEndpoint(endSessionEndpoint)
+                .requestParameterSupported(requestParameterSupported)
+                .requestUriParameterSupported(requestUriParameterSupported)
+                .requireRequestUriRegistration(requireRequestUriRegistration)
+                .requestObjectSigningAlgValuesSupported(requestObjectSigningAlgValuesSupported)
+                .serviceDocumentation(serviceDocumentation)
+                .idTokenEncryptionEncValuesSupported(idTokenEncryptionEncValuesSupported)
+                .displayValuesSupported(displayValuesSupported)
+                .claimTypesSupported(claimTypesSupported)
+                .claimsParameterSupported(claimsParameterSupported)
+                .opTosUri(opTosUri)
+                .opPolicyUri(opPolicyUri)
+                .uriLocalesSupported(uriLocalesSupported)
+                .claimsLocalesSupported(claimsLocalesSupported)
+                .userinfoEncryptionAlgValuesSupported(userinfoEncryptionAlgValuesSupported)
+                .userinfoEncryptionEncValuesSupported(userinfoEncryptionEncValuesSupported)
+                .tokenEndpointAuthSigningAlgValuesSupported(tokenEndpointAuthSigningAlgValuesSupported)
+                .requestObjectEncryptionAlgValuesSupported(requestObjectEncryptionAlgValuesSupported)
+                .requestObjectEncryptionEncValuesSupported(requestObjectEncryptionEncValuesSupported)
+                .checkSessionIframe(checkSessionIframe)
+                .build()
+
+        then:
+        metadata.authorizationEndpoint == authorizationEndpoint
+        metadata.idTokenSigningAlgValuesSupported == idTokenSigningAlgValuesSupported
+        metadata.issuer == issuer
+        metadata.jwksUri == jwksUri
+        metadata.acrValuesSupported == acrValuesSupported
+        metadata.responseTypesSupported == responseTypesSupported
+        metadata.responseModesSupported == responseModesSupported
+        metadata.scopesSupported == scopesSupported
+        metadata.grantTypesSupported == grantTypesSupported
+        metadata.subjectTypesSupported == subjectTypesSupported
+        metadata.tokenEndpoint == tokenEndpoint
+        metadata.tokenEndpointAuthMethodsSupported == tokenEndpointAuthMethodsSupported
+        metadata.userinfoEndpoint == userinfoEndpoint
+        metadata.registrationEndpoint == registrationEndpoint
+        metadata.claimsSupported == claimsSupported
+        metadata.codeChallengeMethodsSupported == codeChallengeMethodsSupported
+        metadata.introspectionEndpoint == introspectionEndpoint
+        metadata.introspectionEndpointAuthMethodsSupported == introspectionEndpointAuthMethodsSupported
+        metadata.revocationEndpoint == revocationEndpoint
+        metadata.revocationEndpointAuthMethodsSupported == revocationEndpointAuthMethodsSupported
+        metadata.endSessionEndpoint == endSessionEndpoint
+        metadata.requestParameterSupported == requestParameterSupported
+        metadata.requestUriParameterSupported == requestUriParameterSupported
+        metadata.requireRequestUriRegistration == requireRequestUriRegistration
+        metadata.requestObjectSigningAlgValuesSupported == requestObjectSigningAlgValuesSupported
+        metadata.serviceDocumentation == serviceDocumentation
+        metadata.idTokenEncryptionEncValuesSupported == idTokenEncryptionEncValuesSupported
+        metadata.displayValuesSupported == displayValuesSupported
+        metadata.claimTypesSupported == claimTypesSupported
+        metadata.claimsParameterSupported == claimsParameterSupported
+        metadata.opTosUri == opTosUri
+        metadata.opPolicyUri == opPolicyUri
+        metadata.uriLocalesSupported == uriLocalesSupported
+        metadata.claimsLocalesSupported == claimsLocalesSupported
+        metadata.userInfoEncryptionAlgValuesSupported == userinfoEncryptionAlgValuesSupported
+        metadata.userinfoEncryptionEncValuesSupported == userinfoEncryptionEncValuesSupported
+        metadata.tokenEndpointAuthSigningAlgValuesSupported == tokenEndpointAuthSigningAlgValuesSupported
+        metadata.requestObjectEncryptionAlgValuesSupported == requestObjectEncryptionAlgValuesSupported
+        metadata.requestObjectEncryptionEncValuesSupported == requestObjectEncryptionEncValuesSupported
+        metadata.checkSessionIframe == checkSessionIframe
     }
 }


### PR DESCRIPTION
This PR adds a builder for `DefaultOpenIdProviderMetadata` and uses the builder in the AOT code generation.

In Micronaut Security 4.0, I want to remove the setters from DefaultOpenIdProviderMetadata, and the builder is helpful in avoiding calling a constructor with too many parameters from the AOT code.