### PR TITLE
test: move deprecated config to micronaut.server.ssl

### DIFF
--- a/security/src/test/groovy/io/micronaut/docs/security/authorization/X509AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/authorization/X509AuthorizationSpec.groovy
@@ -46,7 +46,7 @@ class X509AuthorizationSpec extends Specification {
                 'spec.name': X509AuthorizationSpec.simpleName,
                 'micronaut.ssl.enabled': true,
                 'micronaut.server.ssl.port': -1,
-                'micronaut.ssl.build-self-signed': false,
+                'micronaut.server.ssl.build-self-signed': false,
                 'micronaut.ssl.client-authentication': "need",
                 'micronaut.ssl.key-store.path': 'file://' + keyStorePath.toString(),
                 'micronaut.ssl.key-store.type': 'PKCS12',

--- a/security/src/test/groovy/io/micronaut/security/x509/AbstractX509Spec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/x509/AbstractX509Spec.groovy
@@ -19,9 +19,9 @@ abstract class AbstractX509Spec extends EmbeddedServerSpecification {
                 'micronaut.server.ssl.trust-store.password'             : 'secret',
                 'micronaut.server.ssl.trust-store.path'                 : 'classpath:ssl/x509/truststore.jks',
                 'micronaut.server.ssl.trust-store.type'                 : 'JKS',
-                'micronaut.ssl.build-self-signed'                       : false,
+                'micronaut.server.ssl.build-self-signed'                       : false,
                 'micronaut.ssl.enabled'                                 : true,
-                'micronaut.ssl.port'                                    : -1
+                'micronaut.server.ssl.port'                             : -1
         ]
     }
 }


### PR DESCRIPTION
Replace deprecated micronaut.ssl.build-self-signed and use micronaut.server.ssl.build-self-signed instead.
Replace deprecated micronaut.ssl.port with micronaut.server.ssl.port

Contributed by @altro3 via: https://github.com/micronaut-projects/micronaut-security/pull/1260