### PR TITLE
fix 1278-security-filter-nullpointer-debug

### DIFF
--- a/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
+++ b/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
@@ -142,7 +142,7 @@ public class SecurityFilter implements HttpServerFilter {
             LOG.debug("Attributes: {}", attributes
                     .entrySet()
                     .stream()
-                    .map((entry) -> entry.getKey() + "=>" + entry.getValue().toString())
+                    .map((entry) -> entry.getKey() + "=>" + (entry.getValue() != null ? entry.getValue().toString() : null))
                     .collect(Collectors.joining(", ")));
         }
     }


### PR DESCRIPTION
Avoid `NullPointerException` when degub is enabled