### PR TITLE
BREAKS: change Status for no redirect and  cookie

### DIFF
--- a/security/src/main/java/io/micronaut/security/token/cookie/CookieLoginHandler.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/CookieLoginHandler.java
@@ -107,7 +107,7 @@ public abstract class CookieLoginHandler implements RedirectingLoginHandler<Http
     public MutableHttpResponse<?> loginFailed(AuthenticationResponse authenticationFailed, HttpRequest<?> request) {
         try {
             if (loginFailure == null) {
-                return HttpResponse.ok();
+                return HttpResponse.unauthorized();
             }
             URI location = new URI(loginFailure);
             return HttpResponse.seeOther(location);

--- a/security/src/main/java/io/micronaut/security/token/cookie/CookieLoginHandler.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/CookieLoginHandler.java
@@ -101,7 +101,7 @@ public abstract class CookieLoginHandler implements RedirectingLoginHandler<Http
     /**
      * @param authenticationFailed Object encapsulates the Login failure
      * @param request The {@link HttpRequest} being executed
-     * @return A 303 HTTP Response or 200 HTTP Response if {@link CookieLoginHandler#loginFailure} is null, for example if {@link RedirectConfiguration} is disabled.
+     * @return A 303 HTTP Response or 401 HTTP Response if {@link CookieLoginHandler#loginFailure} is null, for example if {@link RedirectConfiguration} is disabled.
      */
     @Override
     public MutableHttpResponse<?> loginFailed(AuthenticationResponse authenticationFailed, HttpRequest<?> request) {

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -3,6 +3,8 @@ This section will document breaking changes that may happen during milestone or 
 
 == Micronaut Security 4.0 breaking changes
 
+- For applications with `micronaut.security.authentication` set to `cookie` and `micronaut.security.redirect.enabled` set to `false`, the server responds with 401 HTTP Status code instead of 200 for login failed attempts.
+
 - `micronaut.security.intercept-url-map-prepend-pattern-with-context-path` defaults to `true`. Thus intercept url patterns are be prepended with the server context path if it is set.
 
 === Configuration Changes


### PR DESCRIPTION
For applications with `micronaut.security.authentication` set to `cookie` and `micronaut.security.redirect.enabled` set to `false`, the server responds with 401 HTTP Status code instead of 200 for login failed attempts.

see https://github.com/micronaut-projects/micronaut-security/issues/1222