### PR TITLE
doc: idtoken not custom OpenIdAuthenticationMapper

### DIFF
--- a/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-user-details.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-user-details.adoc
@@ -8,6 +8,8 @@ IMPORTANT: Enabling all of the above with cookie JWT storage has been known to c
 
 If the default implementation is not sufficient, it is possible to override the global default or provide an implementation specific to a provider.
 
+IMPORTANT: You cannot use `micronaut.security.authentication` = `idtoken`, if you wish to use a custom `OpenIdAuthenticationMapper`. You should use  `micronaut.security.authentication` = `cookie` or provide your own implementation of <<loginHandler, Login Handler>> and <<logoutHandler, Logout Handler>>.
+
 To override the global default mapper, register a bean that replaces api:security.oauth2.endpoint.token.response.DefaultOpenIdAuthenticationMapper[].
 
 snippet::io.micronaut.security.oauth2.docs.openid.GlobalOpenIdAuthenticationMapper[tags="clazz"]


### PR DESCRIPTION
This PR documents that it is not possible to use `micronaut.security.authentication` = `idtoken` with a custom `OpenIdAuthenticationMapper`. When you use a custom `OpenIdAuthenticationMapper` is because you wish to modify the originall idtoken and add for example extra claims. That requries generate a new token. When you use `idtoken`, you say that you want to use the OAutheServer `idtoken` directly

Close #1391