### PR TITLE
Use debug log level for token validation failures

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AudienceClaimValidator.java
@@ -50,16 +50,16 @@ public class AudienceClaimValidator implements OpenIdClaimsValidator {
         //The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience.
         boolean condition = audienceList.stream().anyMatch(audience -> audience.equals(clientConfiguration.getClientId()));
         if (!condition) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("JWT validation failed for provider [{}]. Audience claims does not contain [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("JWT validation failed for provider [{}]. Audience claims does not contain [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
             }
             return false;
         }
 
         //If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
         if (audienceList.size() > 1 && claims.getAuthorizedParty() == null) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("JWT validation failed for provider [{}]. Multiple audience claims present but no authorized party", clientConfiguration.getName());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("JWT validation failed for provider [{}]. Multiple audience claims present but no authorized party", clientConfiguration.getName());
             }
             return false;
         }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AuthorizedPartyClaimValidator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/response/validation/AuthorizedPartyClaimValidator.java
@@ -46,8 +46,8 @@ public class AuthorizedPartyClaimValidator implements OpenIdClaimsValidator {
             return true;
         }
         boolean condition = authorizedParty.equals(clientConfiguration.getClientId());
-        if (!condition && LOG.isTraceEnabled()) {
-            LOG.trace("JWT validation failed for provider [{}]. Authorized party claim does not match [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
+        if (!condition && LOG.isDebugEnabled()) {
+            LOG.debug("JWT validation failed for provider [{}]. Authorized party claim does not match [{}]", clientConfiguration.getName(), clientConfiguration.getClientId());
         }
 
         return condition;


### PR DESCRIPTION
Some of our validators were logging to debug level, some to trace level.

This moves the trace ones to debug.

We have a validator which seems to use error level, but I'm hesitant to change this as error level logs tend to be used in monitoring.