### PR TITLE
Move @Creator to a new appropriate constructor

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/endpoints/TokenRefreshRequest.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/endpoints/TokenRefreshRequest.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.token.jwt.endpoints;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.Introspected;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -49,6 +50,7 @@ public class TokenRefreshRequest {
      *
      * @param refreshToken Refresh token
      */
+    @Creator
     public TokenRefreshRequest(String refreshToken) {
         this.grantType = GRANT_TYPE_REFRESH_TOKEN;
         this.refreshToken = refreshToken;

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/endpoints/TokenRefreshRequest.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/endpoints/TokenRefreshRequest.java
@@ -50,9 +50,19 @@ public class TokenRefreshRequest {
      *
      * @param refreshToken Refresh token
      */
-    @Creator
     public TokenRefreshRequest(String refreshToken) {
         this.grantType = GRANT_TYPE_REFRESH_TOKEN;
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     *
+     * @param grantType Grant type
+     * @param refreshToken Refresh token
+     */
+    @Creator
+    public TokenRefreshRequest(String grantType, String refreshToken) {
+        this.grantType = grantType;
         this.refreshToken = refreshToken;
     }
 

--- a/test-suite-serde/src/test/groovy/io/micronaut/security/token/jwt/endpoints/SerdeSpec.groovy
+++ b/test-suite-serde/src/test/groovy/io/micronaut/security/token/jwt/endpoints/SerdeSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.security.token.jwt.endpoints
+
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class SerdeSpec extends Specification {
+
+    @Inject
+    ObjectMapper objectMapper
+
+    void "TokenRefreshRequest should be Serializable and Deserializable with Serde"() {
+        given:
+        String json = "{\"grant_type\":\"refresh_token\",\"refresh_token\":\"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbkBsb2NhbC5jb20iLCJjb250ZW50LWxlbmd0aCI6IjEwNSIsInByb2R1Y3QiOiJwcm9kdWN0IiwibmJmIjoxNjU5MDc4ODcwLCJyb2xlcyI6W10sImlzcyI6InRlc3RhcHBsaWNhdGlvbiIsImhvc3QiOiJsb2NhbGhvc3Q6NTQ3MjUiLCJjb25uZWN0aW9uIjoiY2xvc2UiLCJjb250ZW50LXR5cGUiOiJhcHBsaWNhdGlvblwvanNvbiIsImV4cCI6MTY1OTA4MjQ3MCwiaWF0IjoxNjU5MDc4ODcwfQ.ugdU-pYUgwU44Skd2jmP4x_aNLAVhrIuSYwyW21ngAg\"}"
+
+        when:
+        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest(
+                "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbkBsb2NhbC5jb20iLCJjb250ZW50LWxlbmd0aCI6IjEwNSIsInByb2R1Y3QiOiJwcm9kdWN0IiwibmJmIjoxNjU5MDc4ODcwLCJyb2xlcyI6W10sImlzcyI6InRlc3RhcHBsaWNhdGlvbiIsImhvc3QiOiJsb2NhbGhvc3Q6NTQ3MjUiLCJjb25uZWN0aW9uIjoiY2xvc2UiLCJjb250ZW50LXR5cGUiOiJhcHBsaWNhdGlvblwvanNvbiIsImV4cCI6MTY1OTA4MjQ3MCwiaWF0IjoxNjU5MDc4ODcwfQ.ugdU-pYUgwU44Skd2jmP4x_aNLAVhrIuSYwyW21ngAg"
+                )
+        String result = objectMapper.writeValueAsString(tokenRefreshRequest)
+
+        then:
+        json == result
+
+        when:
+        tokenRefreshRequest = objectMapper.readValue(json, TokenRefreshRequest)
+
+        then:
+        tokenRefreshRequest
+        tokenRefreshRequest.refreshToken
+    }
+}


### PR DESCRIPTION
Fixes previous PR #1432

Seems the constructor previously created receiving only the `refreshToken` and defaulting `grantType` to `refresh_token` was a shorthand to be used on tests.

To avoid breaking binary compatibility changing a public constructor of a non-private class `TokenRefreshRequest` I have created another constructor receiving both parameters and marked it instead with @Creator.

That just bump in with tests in `OauthControllerSpec`. Sorry about that.