### PR TITLE
Alter Javadoc in TokenGenerator.java

### DIFF
--- a/security/src/main/java/io/micronaut/security/token/generator/TokenGenerator.java
+++ b/security/src/main/java/io/micronaut/security/token/generator/TokenGenerator.java
@@ -30,7 +30,7 @@ public interface TokenGenerator {
 
     /**
      * @param authentication Authenticated user's representation.
-     * @param expiration The amount of time in milliseconds until the token expires
+     * @param expiration The amount of time in seconds until the token expires
      * @return An optional JWT string
      */
     Optional<String> generateToken(Authentication authentication, @Nullable Integer expiration);


### PR DESCRIPTION
Fix incorrect time unit in Javadoc. The comment on "expiration" was indicating the value is in "milliseconds", but this value is in "seconds" in io.micronaut.security.token.jwt.generator.JwtTokenGenerator