### PR TITLE
Add binder for annotated custom `Principal`

### DIFF
--- a/security-annotations/src/main/java/io/micronaut/security/annotation/User.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/User.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.annotation;
+
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that can be applied to a method argument to indicate that it is bound from the user
+ * object for the currently active authentication.
+ *
+ * @author Jeremy Grelle
+ * @since 4.5.0
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Bindable
+@Inherited
+@Documented
+public @interface User {
+}

--- a/security/src/main/java/io/micronaut/security/authentication/UserArgumentBinder.java
+++ b/security/src/main/java/io/micronaut/security/authentication/UserArgumentBinder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
+import io.micronaut.security.annotation.User;
+import io.micronaut.security.filters.SecurityFilter;
+import jakarta.inject.Singleton;
+
+import java.security.Principal;
+import java.util.Optional;
+
+/**
+ * Binds the authentication object to a route argument annotated with {@link User}.
+ *
+ * @param <T> The bound subtype of {@link Principal}
+ * @author Jeremy Grelle
+ * @since 4.5.0
+ */
+@Singleton
+public class UserArgumentBinder<T extends Principal> implements AnnotatedRequestArgumentBinder<User, T> {
+
+    @Override
+    public Class<User> getAnnotationType() {
+        return User.class;
+    }
+
+    @Override
+    public BindingResult<T> bind(ArgumentConversionContext<T> context, HttpRequest<?> source) {
+        if (!source.getAttributes().contains(SecurityFilter.KEY)) {
+            return BindingResult.unsatisfied();
+        }
+
+        final Optional<T> existing = source.getUserPrincipal(context.getArgument().getType());
+        return existing.isPresent() ? (() -> existing) : BindingResult.empty();
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -153,7 +153,7 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
 
     void "Authentication Argument Binders binds annotated custom subtype of Principal"() {
         expect:
-        embeddedServer.applicationContext.getBean(UserArgumentBinder.class)
+        embeddedServer.applicationContext.contains(UserArgumentBinder.class)
 
         when:
         HttpResponse<String> response = client.exchange(HttpRequest.GET("/customuserargumentbinder/single-user")

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -140,7 +140,7 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
 
     void "Authentication Argument Binders cannot bind non-annotated subtype of Principal"() {
         expect:
-        embeddedServer.applicationContext.getBean(UserArgumentBinder.class)
+        embeddedServer.applicationContext.containsBean(UserArgumentBinder.class)
 
         when:
         client.exchange(HttpRequest.GET("/subtypeargumentbinder/single-no-user-authentication")

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -115,7 +115,7 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
 
     void "Authentication Argument Binders binds annotated subtype of Principal"() {
         expect:
-        embeddedServer.applicationContext.getBean(UserArgumentBinder.class)
+        embeddedServer.applicationContext.containsBean(UserArgumentBinder.class)
 
         when:
         HttpResponse<String> response = client.exchange(HttpRequest.GET("/subtypeargumentbinder/single-server-authentication")

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -127,7 +127,7 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
 
     void "Authentication Argument Binders cannot bind annotated subtype of Principal if subtype doesn't match request.getPrincipal"() {
         expect:
-        embeddedServer.applicationContext.getBean(UserArgumentBinder.class)
+        embeddedServer.applicationContext.containsBean(UserArgumentBinder.class)
 
         when:
         client.exchange(HttpRequest.GET("/subtypeargumentbinder/single-client-authentication")

--- a/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/AuthorizationSpec.groovy
@@ -134,7 +134,7 @@ class AuthorizationSpec extends EmbeddedServerSpecification {
                 .basicAuth("valid", "password"), String)
 
         then:
-        HttpClientResponseException e = thrown(HttpClientResponseException)
+        HttpClientResponseException e = thrown()
         e.status == HttpStatus.BAD_REQUEST
     }
 


### PR DESCRIPTION
A new `@User` annotation is added that can be used to bind a custom `Principal` object to a method parameter for the 
currently active login.

This allows for users to provide their own custom authentication object and still be able to bind it to `@Controller` 
method parameters as long as the parameter is annotated with `@User` and matches the type of the authentication 
stored in the request.

For example:
```
@Post("/{var1}/method")
fun method(
        @PathVariable var1: String,
        @Body request: SomeOurRequest,
        @User userToken: our.package.TokenAuthentication,
    ): HttpResponse<Unit>
```

would work without requiring the user to supply their own `RequestArgumentBinder`

This resolves #1430
