### PR TITLE
revert breaking change

### DIFF
--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -2043,5 +2043,45 @@
     "type": "io.micronaut.security.rules.SensitiveEndpointRule",
     "member": "Implemented interface io.micronaut.security.rules.SecurityRule",
     "reason": "Provide a human readable reason for the change"
+  },
+  {
+    "type": "io.micronaut.security.authentication.AuthenticationProvider",
+    "member": "Implemented interface io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.authentication.AuthenticationProvider",
+    "member": "Implemented interface io.micronaut.core.order.Ordered",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.oauth2.endpoint.token.request.password.OauthPasswordAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.oauth2.endpoint.token.request.password.OauthPasswordAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.core.order.Ordered",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.oauth2.endpoint.token.request.password.OpenIdPasswordAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.oauth2.endpoint.token.request.password.OpenIdPasswordAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.core.order.Ordered",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.ldap.LdapAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider",
+    "reason": "Revert breaking changes"
+  },
+  {
+    "type": "io.micronaut.security.ldap.LdapAuthenticationProvider",
+    "member": "Implemented interface io.micronaut.core.order.Ordered",
+    "reason": "Revert breaking changes"
   }
 ]

--- a/security-ldap/src/main/java/io/micronaut/security/ldap/LdapAuthenticationProvider.java
+++ b/security-ldap/src/main/java/io/micronaut/security/ldap/LdapAuthenticationProvider.java
@@ -48,12 +48,10 @@ import static io.micronaut.security.utils.LoggingUtils.debug;
  * Authenticates against an LDAP server using the configuration provided through
  * {@link LdapConfiguration}. One provider will be created for each configuration.
  * @param <T> Request Context Type
- * @param <I> Authentication Request Identity Type
- * @param <S> Authentication Request Secret Type
  * @author James Kleeh
  * @since 1.0
  */
-public class LdapAuthenticationProvider<T, I, S> implements AuthenticationProvider<T, I, S>, Closeable {
+public class LdapAuthenticationProvider<T> implements AuthenticationProvider<T>, Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(LdapAuthenticationProvider.class);
 
@@ -87,7 +85,7 @@ public class LdapAuthenticationProvider<T, I, S> implements AuthenticationProvid
     }
 
     @Override
-    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<I, S> authenticationRequest) {
+    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<?, ?> authenticationRequest) {
         Flux<AuthenticationResponse> reactiveSequence = Flux.create(emitter -> {
             String username = authenticationRequest.getIdentity().toString();
             String password = authenticationRequest.getSecret().toString();

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OauthPasswordAuthenticationProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OauthPasswordAuthenticationProvider.java
@@ -38,10 +38,8 @@ import reactor.core.publisher.Flux;
  * @author Sergio del Amo
  * @since 1.2.0
  * @param <T> Request Context Type
- * @param <I> Authentication Request Identity Type
- * @param <S> Authentication Request Secret Type
  */
-public class OauthPasswordAuthenticationProvider<T, I, S> implements AuthenticationProvider<T, I, S> {
+public class OauthPasswordAuthenticationProvider<T> implements AuthenticationProvider<T> {
 
     private final TokenEndpointClient tokenEndpointClient;
     private final SecureEndpoint secureEndpoint;
@@ -63,7 +61,7 @@ public class OauthPasswordAuthenticationProvider<T, I, S> implements Authenticat
     }
 
     @Override
-    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<I, S> authenticationRequest) {
+    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<?, ?> authenticationRequest) {
 
         OauthPasswordTokenRequestContext context = new OauthPasswordTokenRequestContext(authenticationRequest, secureEndpoint, clientConfiguration);
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OpenIdPasswordAuthenticationProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/OpenIdPasswordAuthenticationProvider.java
@@ -45,10 +45,8 @@ import java.util.stream.Collectors;
  * @author James Kleeh
  * @since 1.2.0
  * @param <T> Request Context Type
- * @param <I> Authentication Request Identity Type
- * @param <S> Authentication Request Secret Type
  */
-public class OpenIdPasswordAuthenticationProvider<T, I, S> implements AuthenticationProvider<T, I, S> {
+public class OpenIdPasswordAuthenticationProvider<T> implements AuthenticationProvider<T> {
 
     private final TokenEndpointClient tokenEndpointClient;
     private final SecureEndpoint secureEndpoint;
@@ -79,7 +77,7 @@ public class OpenIdPasswordAuthenticationProvider<T, I, S> implements Authentica
     }
 
     @Override
-    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<I, S> authenticationRequest) {
+    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<?, ?> authenticationRequest) {
 
         OpenIdPasswordTokenRequestContext openIdPasswordTokenRequestContext = new OpenIdPasswordTokenRequestContext(authenticationRequest, secureEndpoint, clientConfiguration);
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/PasswordGrantFactory.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/password/PasswordGrantFactory.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider;
+import io.micronaut.security.authentication.provider.ReactiveAuthenticationProviderAdapter;
 import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.endpoint.token.request.TokenEndpointClient;
@@ -71,12 +72,12 @@ class PasswordGrantFactory {
             @Nullable OpenIdTokenResponseValidator tokenResponseValidator) {
 
         if (clientConfiguration.getToken().isPresent()) {
-            return new OauthPasswordAuthenticationProvider(tokenEndpointClient, clientConfiguration, authenticationMapper);
+            return new ReactiveAuthenticationProviderAdapter(new OauthPasswordAuthenticationProvider(tokenEndpointClient, clientConfiguration, authenticationMapper));
         } else {
             if (openIdAuthenticationMapper == null) {
                 openIdAuthenticationMapper = defaultOpenIdAuthenticationMapper;
             }
-            return new OpenIdPasswordAuthenticationProvider(clientConfiguration, openIdProviderMetadata, tokenEndpointClient, openIdAuthenticationMapper, tokenResponseValidator);
+            return new ReactiveAuthenticationProviderAdapter(new OpenIdPasswordAuthenticationProvider(clientConfiguration, openIdProviderMetadata, tokenEndpointClient, openIdAuthenticationMapper, tokenResponseValidator));
         }
     }
 }

--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationProvider.java
@@ -17,7 +17,6 @@ package io.micronaut.security.authentication;
 
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider;
 import org.reactivestreams.Publisher;
 
 /**
@@ -27,7 +26,7 @@ import org.reactivestreams.Publisher;
  * @author Graeme Rocher
  * @since 1.0
  * @param <T> Request Context Type
- * @deprecated Use {@link io.micronaut.security.authentication.provider.AuthenticationProvider} for an imperative API or {@link ReactiveAuthenticationProvider} for a reactive API instead.
+ * @deprecated Use {@link io.micronaut.security.authentication.provider.AuthenticationProvider} for an imperative API or {@link io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider} for a reactive API instead.
  */
 @Deprecated(forRemoval = true, since = "4.5.0")
 public interface AuthenticationProvider<T> {

--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationProvider.java
@@ -15,7 +15,10 @@
  */
 package io.micronaut.security.authentication;
 
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider;
+import org.reactivestreams.Publisher;
 
 /**
  * Defines an authentication provider.
@@ -24,10 +27,22 @@ import io.micronaut.security.authentication.provider.ReactiveAuthenticationProvi
  * @author Graeme Rocher
  * @since 1.0
  * @param <T> Request Context Type
- * @param <I> Authentication Request Identity Type
- * @param <S> Authentication Request Secret Type
  * @deprecated Use {@link io.micronaut.security.authentication.provider.AuthenticationProvider} for an imperative API or {@link ReactiveAuthenticationProvider} for a reactive API instead.
  */
 @Deprecated(forRemoval = true, since = "4.5.0")
-public interface AuthenticationProvider<T, I, S> extends ReactiveAuthenticationProvider<T, I, S> {
+public interface AuthenticationProvider<T> {
+    /**
+     * Authenticates a user with the given request. If a successful authentication is
+     * returned, the object must be an instance of {@link Authentication}.
+     *
+     * Publishers <b>MUST emit cold observables</b>! This method will be called for
+     * all authenticators for each authentication request and it is assumed no work
+     * will be done until the publisher is subscribed to.
+     *
+     * @param httpRequest The http request
+     * @param authenticationRequest The credentials to authenticate
+     * @return A publisher that emits 0 or 1 responses
+     */
+    @NonNull
+    Publisher<AuthenticationResponse> authenticate(@Nullable T httpRequest, AuthenticationRequest<?, ?> authenticationRequest);
 }

--- a/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
+++ b/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
@@ -44,6 +44,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -54,11 +55,9 @@ import java.util.stream.Collectors;
  * @author Graeme Rocher
  * @since 1.0
  * @param <T> Request Context Type
- * @param <I> Authentication Request Identity Type
- * @param <S> Authentication Request Secret Type
  */
 @Singleton
-public class Authenticator<T, I, S> {
+public class Authenticator<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Authenticator.class);
 
@@ -69,10 +68,10 @@ public class Authenticator<T, I, S> {
     @Deprecated(forRemoval = true, since = "4.5.0")
     protected final Collection<io.micronaut.security.authentication.AuthenticationProvider<T>> authenticationProviders;
 
-    private final List<ReactiveAuthenticationProvider<T, I, S>> reactiveAuthenticationProviders;
+    private final List<ReactiveAuthenticationProvider<T, ?, ?>> reactiveAuthenticationProviders;
     private final BeanContext beanContext;
 
-    private final List<AuthenticationProvider<T, I, S>> imperativeAuthenticationProviders;
+    private final List<AuthenticationProvider<T, ?, ?>> imperativeAuthenticationProviders;
     private final SecurityConfiguration securityConfiguration;
 
     private final Map<String, Scheduler> executeNameToScheduler = new ConcurrentHashMap<>();
@@ -87,15 +86,15 @@ public class Authenticator<T, I, S> {
      */
     @Inject
     public Authenticator(BeanContext beanContext,
-                         List<ReactiveAuthenticationProvider<T, I, S>> reactiveAuthenticationProviders,
-                         List<AuthenticationProvider<T, I, S>> authenticationProviders,
+                         List<ReactiveAuthenticationProvider<T, ?, ?>> reactiveAuthenticationProviders,
+                         List<AuthenticationProvider<T, ?, ?>> authenticationProviders,
                          List<io.micronaut.security.authentication.AuthenticationProvider<T>> deprecatedAuthenticationProviders,
                          SecurityConfiguration securityConfiguration) {
         this.beanContext = beanContext;
         this.reactiveAuthenticationProviders = reactiveAuthenticationProviders;
-        this.reactiveAuthenticationProviders.addAll(deprecatedAuthenticationProviders.stream()
-                .map(ap -> (ReactiveAuthenticationProvider<T, I, S>) new ReactiveAuthenticationProviderAdapter<T, I, S>(ap))
-                .toList());
+        for (io.micronaut.security.authentication.AuthenticationProvider<T> authenticationProvider : deprecatedAuthenticationProviders) {
+            reactiveAuthenticationProviders.add((new ReactiveAuthenticationProviderAdapter<>(authenticationProvider)));
+        }
         this.securityConfiguration = securityConfiguration;
         this.imperativeAuthenticationProviders = authenticationProviders;
         this.authenticationProviders = Collections.emptyList();
@@ -108,10 +107,9 @@ public class Authenticator<T, I, S> {
      * @param securityConfiguration The security configuration
      * @deprecated Use {@link Authenticator#Authenticator(BeanContext, List, List, List, SecurityConfiguration)} instead.
      */
-    @Deprecated
     public Authenticator(BeanContext beanContext,
-                         List<ReactiveAuthenticationProvider<T, I, S>> reactiveAuthenticationProviders,
-                         List<AuthenticationProvider<T, I, S>> authenticationProviders,
+                         List<ReactiveAuthenticationProvider<T, ?, ?>> reactiveAuthenticationProviders,
+                         List<AuthenticationProvider<T, ?, ?>> authenticationProviders,
                          SecurityConfiguration securityConfiguration) {
         this.beanContext = beanContext;
         this.reactiveAuthenticationProviders = reactiveAuthenticationProviders;
@@ -121,18 +119,19 @@ public class Authenticator<T, I, S> {
     }
 
     /**
-     * @param authenticationProviders A list of available authentication providers
+     * @param deprecatedAuthenticationProviders A list of available authentication providers
      * @param securityConfiguration   The security configuration
      * @deprecated Use {@link Authenticator#Authenticator(BeanContext, List, List, SecurityConfiguration)} instead.
      */
     @Deprecated(forRemoval = true, since = "4.5.0")
-    public Authenticator(Collection<io.micronaut.security.authentication.AuthenticationProvider<T>> authenticationProviders,
+    public Authenticator(Collection<io.micronaut.security.authentication.AuthenticationProvider<T>> deprecatedAuthenticationProviders,
                          SecurityConfiguration securityConfiguration) {
         this.beanContext = null;
-        this.authenticationProviders = authenticationProviders;
-        this.reactiveAuthenticationProviders = authenticationProviders.stream()
-                .map(ap -> (ReactiveAuthenticationProvider<T, I, S>) new ReactiveAuthenticationProviderAdapter<T, I, S>(ap))
-                .toList();
+        this.authenticationProviders = deprecatedAuthenticationProviders;
+        reactiveAuthenticationProviders = new ArrayList<>();
+        for (io.micronaut.security.authentication.AuthenticationProvider<T> authenticationProvider : deprecatedAuthenticationProviders) {
+            reactiveAuthenticationProviders.add((new ReactiveAuthenticationProviderAdapter<>(authenticationProvider)));
+        }
         this.securityConfiguration = securityConfiguration;
         this.imperativeAuthenticationProviders = Collections.emptyList();
     }
@@ -144,7 +143,7 @@ public class Authenticator<T, I, S> {
      * @param authenticationRequest Represents a request to authenticate.
      * @return A publisher that emits {@link AuthenticationResponse} objects
      */
-    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<I, S> authenticationRequest) {
+    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<?, ?> authenticationRequest) {
         if (CollectionUtils.isEmpty(reactiveAuthenticationProviders) && CollectionUtils.isEmpty(imperativeAuthenticationProviders)) {
             return Mono.empty();
         }
@@ -179,8 +178,8 @@ public class Authenticator<T, I, S> {
 
     @NonNull
     private AuthenticationResponse authenticate(@NonNull T requestContext,
-                                                @NonNull AuthenticationRequest<I, S> authenticationRequest,
-                                                @NonNull List<AuthenticationProvider<T, I, S>> authenticationProviders,
+                                                @NonNull AuthenticationRequest<?, ?> authenticationRequest,
+                                                @NonNull List<AuthenticationProvider<T, ?, ?>> authenticationProviders,
                                                 @Nullable SecurityConfiguration securityConfiguration) {
         if (securityConfiguration != null && securityConfiguration.getAuthenticationProviderStrategy() == AuthenticationStrategy.ALL) {
             return authenticateAll(requestContext, authenticationRequest, authenticationProviders);
@@ -194,8 +193,8 @@ public class Authenticator<T, I, S> {
 
     @NonNull
     private AuthenticationResponse authenticateAll(@NonNull T requestContext,
-                                                   @NonNull AuthenticationRequest<I, S> authenticationRequest,
-                                                   @NonNull List<AuthenticationProvider<T, I, S>> authenticationProviders) {
+                                                   @NonNull AuthenticationRequest<?, ?> authenticationRequest,
+                                                   @NonNull List<AuthenticationProvider<T, ?, ?>> authenticationProviders) {
         List<AuthenticationResponse> authenticationResponses = authenticationProviders.stream()
                         .map(provider -> authenticationResponse(provider, requestContext, authenticationRequest))
                         .toList();
@@ -207,8 +206,8 @@ public class Authenticator<T, I, S> {
                 : AuthenticationResponse.failure();
     }
 
-    private List<ReactiveAuthenticationProvider<T, I, S>> everyProviderSorted() {
-        List<ReactiveAuthenticationProvider<T, I, S>> providers = new ArrayList<>(reactiveAuthenticationProviders);
+    private List<ReactiveAuthenticationProvider<T, ?, ?>> everyProviderSorted() {
+        List<ReactiveAuthenticationProvider<T, ?, ?>> providers = new ArrayList<>(reactiveAuthenticationProviders);
         if (beanContext != null) {
             providers.addAll(imperativeAuthenticationProviders.stream()
                     .map(imperativeAuthenticationProvider -> {
@@ -227,8 +226,8 @@ public class Authenticator<T, I, S> {
     }
 
     private Publisher<AuthenticationResponse> authenticate(T request,
-                                                           AuthenticationRequest<I, S> authenticationRequest,
-                                                           List<ReactiveAuthenticationProvider<T, I, S>> providers) {
+                                                           AuthenticationRequest authenticationRequest,
+                                                           List<ReactiveAuthenticationProvider<T, ?, ?>> providers) {
         if (providers == null) {
             return Flux.empty();
         }
@@ -240,9 +239,11 @@ public class Authenticator<T, I, S> {
 
             return Flux.mergeDelayError(1,
                             providers.stream()
-                            .map(provider -> Flux.from(provider.authenticate(request, authenticationRequest))
-                                    .switchMap(Authenticator::handleResponse)
-                                    .switchIfEmpty(Flux.error(() -> new AuthenticationException("Provider did not respond. Authentication rejected"))))
+                            .map(provider ->
+                                Flux.from(provider.authenticate(request, authenticationRequest))
+                                        .switchMap(rsp -> Authenticator.handleResponse((AuthenticationResponse) rsp))
+                                        .switchIfEmpty(Flux.error(() -> new AuthenticationException("Provider did not respond. Authentication rejected")))
+                            )
                             .toList()
                     .toArray(emptyArr))
                     .last()
@@ -251,12 +252,13 @@ public class Authenticator<T, I, S> {
         } else {
             AtomicReference<Throwable> lastError = new AtomicReference<>();
             Flux<AuthenticationResponse> authentication = Flux.mergeDelayError(1,  providers.stream()
-                    .map(auth -> auth.authenticate(request, authenticationRequest))
-                    .map(Flux::from)
-                    .map(sequence -> sequence.switchMap(Authenticator::handleResponse).onErrorResume(t -> {
-                        lastError.set(t);
-                        return Flux.empty();
-                    })).toList()
+                    .map(auth -> Flux.from(auth.authenticate(request, authenticationRequest)))
+                    .map(sequence -> sequence.switchMap(rsp -> Authenticator.handleResponse((AuthenticationResponse) rsp))
+                            .onErrorResume((Function<Throwable, Publisher>) t -> {
+                                lastError.set(t);
+                                return Flux.empty();
+                            })
+                            ).toList()
                     .toArray(emptyArr));
 
             return authentication.take(1)
@@ -290,9 +292,9 @@ public class Authenticator<T, I, S> {
     }
 
     @NonNull
-    private AuthenticationResponse authenticationResponse(@NonNull AuthenticationProvider<T, I, S> provider,
+    private AuthenticationResponse authenticationResponse(@NonNull AuthenticationProvider<T, ?, ?> provider,
                                                           @NonNull T requestContext,
-                                                          @NonNull AuthenticationRequest<I, S> authenticationRequest) {
+                                                          @NonNull AuthenticationRequest authenticationRequest) {
         try {
             return provider.authenticate(requestContext, authenticationRequest);
         } catch (Exception t) {

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
@@ -39,12 +39,12 @@ import reactor.core.publisher.Flux;
 public class BasicAuthAuthenticationFetcher<B> implements AuthenticationFetcher<HttpRequest<B>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(BasicAuthAuthenticationFetcher.class);
-    private final Authenticator<HttpRequest<B>, String, String> authenticator;
+    private final Authenticator<HttpRequest<B>> authenticator;
 
     /**
      * @param authenticator The authenticator to authenticate the credentials
      */
-    public BasicAuthAuthenticationFetcher(Authenticator<HttpRequest<B>, String, String> authenticator) {
+    public BasicAuthAuthenticationFetcher(Authenticator<HttpRequest<B>> authenticator) {
         this.authenticator = authenticator;
     }
 

--- a/security/src/main/java/io/micronaut/security/authentication/provider/ExecutorAuthenticationProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/provider/ExecutorAuthenticationProvider.java
@@ -31,7 +31,7 @@ public interface ExecutorAuthenticationProvider<T, I, S> extends AuthenticationP
 
     /**
      *
-     * @return The executor name where the code {@link AuthenticationProvider#authenticate(T, AuthenticationRequest)} will be executed.
+     * @return The executor name where the code {@link AuthenticationProvider#authenticate(Object, AuthenticationRequest)} will be executed.
      */
     default String getExecutorName() {
         return TaskExecutors.BLOCKING;

--- a/security/src/main/java/io/micronaut/security/authentication/provider/ReactiveAuthenticationProviderAdapter.java
+++ b/security/src/main/java/io/micronaut/security/authentication/provider/ReactiveAuthenticationProviderAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication.provider;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.security.authentication.AuthenticationProvider;
+import io.micronaut.security.authentication.AuthenticationRequest;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import org.reactivestreams.Publisher;
+
+/**
+ * Adapts from {@link AuthenticationProvider} to {@link ReactiveAuthenticationProvider}.
+ * @author Sergio del Amo
+ * @since 4.5.1
+ * @param <T> Request Context Type
+ * @param <I> Authentication Request Identity Type
+ * @param <S> Authentication Request Secret Type
+ */
+@Internal
+@Deprecated(forRemoval = true, since = "4.5.1")
+public final class ReactiveAuthenticationProviderAdapter<T, I, S> implements ReactiveAuthenticationProvider<T, I, S> {
+
+    private final AuthenticationProvider<T> authenticationProvider;
+
+    public ReactiveAuthenticationProviderAdapter(AuthenticationProvider<T> authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    @Override
+    public Publisher<AuthenticationResponse> authenticate(T requestContext, AuthenticationRequest<I, S> authenticationRequest) {
+        return authenticationProvider.authenticate(requestContext, authenticationRequest);
+    }
+}

--- a/security/src/main/java/io/micronaut/security/endpoints/LoginController.java
+++ b/security/src/main/java/io/micronaut/security/endpoints/LoginController.java
@@ -59,7 +59,7 @@ import reactor.core.publisher.Mono;
 public class LoginController<B> {
     private static final Logger LOG = LoggerFactory.getLogger(LoginController.class);
 
-    protected final Authenticator<HttpRequest<B>, String, String> authenticator;
+    protected final Authenticator<HttpRequest<B>> authenticator;
     protected final LoginHandler<HttpRequest<?>, MutableHttpResponse<?>>  loginHandler;
     protected final ApplicationEventPublisher<LoginSuccessfulEvent> loginSuccessfulEventPublisher;
     protected final ApplicationEventPublisher<LoginFailedEvent> loginFailedEventPublisher;
@@ -70,7 +70,7 @@ public class LoginController<B> {
      * @param loginSuccessfulEventPublisher Application event publisher for {@link LoginSuccessfulEvent}.
      * @param loginFailedEventPublisher     Application event publisher for {@link LoginFailedEvent}.
      */
-    public LoginController(Authenticator<HttpRequest<B>, String, String> authenticator,
+    public LoginController(Authenticator<HttpRequest<B>> authenticator,
                            LoginHandler<HttpRequest<?>, MutableHttpResponse<?>> loginHandler,
                            ApplicationEventPublisher<LoginSuccessfulEvent> loginSuccessfulEventPublisher,
                            ApplicationEventPublisher<LoginFailedEvent> loginFailedEventPublisher) {

--- a/security/src/test/groovy/io/micronaut/security/authentication/DeprecatedAuthenticationProviderStillWorksSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/DeprecatedAuthenticationProviderStillWorksSpec.groovy
@@ -1,0 +1,93 @@
+package io.micronaut.security.authentication
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.FluxSink
+import spock.lang.Specification
+
+import java.security.Principal
+
+import static io.micronaut.http.HttpStatus.OK
+import static io.micronaut.http.HttpStatus.UNAUTHORIZED
+import static io.micronaut.http.MediaType.TEXT_PLAIN
+
+@Property(name = "spec.name", value = "DeprecatedAuthenticationProviderStillWorksSpec")
+@MicronautTest
+class DeprecatedAuthenticationProviderStillWorksSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient;
+
+    void verifyHttpBasicAuthWorks() {
+        given:
+        BlockingHttpClient client = httpClient.toBlocking();
+
+        when: 'Accessing a secured URL without authenticating'
+        client.exchange(HttpRequest.GET("/").accept(TEXT_PLAIN));
+
+        then: 'returns unauthorized'
+        HttpClientResponseException thrown = thrown()
+        UNAUTHORIZED == thrown.status
+
+        when: 'A secured URL is accessed with Basic Auth'
+        HttpResponse<String> rsp = client.exchange(HttpRequest.GET("/")
+                        .accept(TEXT_PLAIN)
+                        .basicAuth("sherlock", "password"),
+                String)
+        then: 'the endpoint can be accessed'
+        noExceptionThrown()
+        OK == rsp.status
+        "sherlock" == rsp.body.get()
+    }
+
+    @Requires(property = "spec.name", value = "DeprecatedAuthenticationProviderStillWorksSpec")
+    @Singleton
+    static class AuthenticationProviderUserPassword implements AuthenticationProvider<HttpRequest<?>> {
+
+        @Override
+        Publisher<AuthenticationResponse> authenticate(@Nullable HttpRequest<?> httpRequest,
+                                                              AuthenticationRequest<?, ?> authenticationRequest) {
+            return Flux.create(emitter -> {
+                if (authenticationRequest.getIdentity().equals("sherlock") &&
+                        authenticationRequest.getSecret().equals("password")) {
+                    emitter.next(AuthenticationResponse.success((String) authenticationRequest.getIdentity()));
+                    emitter.complete()
+                } else {
+                    emitter.error(AuthenticationResponse.exception())
+                }
+            }, FluxSink.OverflowStrategy.ERROR)
+        }
+    }
+
+    @Requires(property = "spec.name", value = "DeprecatedAuthenticationProviderStillWorksSpec")
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Controller
+    static class HomeController {
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get
+        String index(Principal principal) {  // <4>
+            return principal.getName();
+        }
+    }
+}
+
+


### PR DESCRIPTION
Several breaking changes were introduced accidentally in https://github.com/micronaut-projects/micronaut-security/pull/1526

if a user had a bean extending `AuthenticationProvider` they will get: 

```
java/example/micronaut/AuthenticationProviderUserPassword.java:29: error: wrong number of type arguments; required 3
public class AuthenticationProviderUserPassword implements AuthenticationProvider<HttpRequest<?>>  { // <2>
                                                                                 ^
````

This PR reverts the changes to `Authenticator` and `AuthenticationProvider` so that users are able to upgrade their applications and see only a deprecation notice. 