### PR TITLE
SameSite cookie attribute handling on logout

### DIFF
--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieClearerLogoutHandlerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieClearerLogoutHandlerSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.security.token.jwt.cookie
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.MutableHttpResponse
+import io.micronaut.http.cookie.SameSite
 import io.micronaut.security.authentication.AuthenticationMode
 import io.micronaut.security.config.RedirectConfiguration
 import io.micronaut.security.config.RedirectService
@@ -69,11 +70,13 @@ class JwtCookieClearerLogoutHandlerSpec extends Specification {
             1 * getCookieDomain() >> Optional.of("domain")
             1 * getCookiePath() >> Optional.of("/")
             1 * getCookieName() >> "JWT"
+            1 * getCookieSameSite() >> Optional.of(SameSite.Strict)
         }
         RefreshTokenCookieConfiguration refreshTokenCookieConfiguration = Mock() {
             1 * getCookieDomain() >> Optional.of("domain")
             1 * getCookiePath() >> Optional.of("/oauth/access_token")
             1 * getCookieName() >> "JWT_REFRESH"
+            1 * getCookieSameSite() >> Optional.of(SameSite.None)
         }
         HttpRequest<?> request = Mock()
 
@@ -87,9 +90,11 @@ class JwtCookieClearerLogoutHandlerSpec extends Specification {
         cookieHeaders.get(0).containsIgnoreCase("JWT=")
         cookieHeaders.get(0).containsIgnoreCase("Path=/")
         cookieHeaders.get(0).containsIgnoreCase("Max-Age=0")
+        cookieHeaders.get(0).containsIgnoreCase("SameSite=Strict")
         cookieHeaders.get(1).containsIgnoreCase("Domain=domain")
         cookieHeaders.get(1).containsIgnoreCase("JWT_REFRESH=")
         cookieHeaders.get(1).containsIgnoreCase("Path=/oauth/access_token")
         cookieHeaders.get(1).containsIgnoreCase("Max-Age=0")
+        cookieHeaders.get(1).containsIgnoreCase("SameSite=None")
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieClearerLogoutHandlerSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/JwtCookieClearerLogoutHandlerSpec.groovy
@@ -13,6 +13,8 @@ import io.micronaut.security.token.cookie.TokenCookieClearerLogoutHandler
 import io.micronaut.security.token.cookie.RefreshTokenCookieConfiguration
 import spock.lang.Specification
 
+import java.time.temporal.TemporalAmount
+
 class JwtCookieClearerLogoutHandlerSpec extends Specification {
 
     void "by default no bean of type JwtCookieClearerLogoutHandler exists"() {
@@ -70,13 +72,19 @@ class JwtCookieClearerLogoutHandlerSpec extends Specification {
             1 * getCookieDomain() >> Optional.of("domain")
             1 * getCookiePath() >> Optional.of("/")
             1 * getCookieName() >> "JWT"
-            1 * getCookieSameSite() >> Optional.of(SameSite.Strict)
+            1 * getCookieSameSite() >> Optional.of(SameSite.None)
+            1 * isCookieSecure() >> Optional.of(true)
+            1 * isCookieHttpOnly() >> Optional.of(true)
+            1 * getCookieMaxAge() >> Optional.empty()
         }
         RefreshTokenCookieConfiguration refreshTokenCookieConfiguration = Mock() {
             1 * getCookieDomain() >> Optional.of("domain")
             1 * getCookiePath() >> Optional.of("/oauth/access_token")
             1 * getCookieName() >> "JWT_REFRESH"
             1 * getCookieSameSite() >> Optional.of(SameSite.None)
+            1 * isCookieSecure() >> Optional.of(true)
+            1 * isCookieHttpOnly() >> Optional.of(true)
+            1 * getCookieMaxAge() >> Optional.empty()
         }
         HttpRequest<?> request = Mock()
 
@@ -90,11 +98,15 @@ class JwtCookieClearerLogoutHandlerSpec extends Specification {
         cookieHeaders.get(0).containsIgnoreCase("JWT=")
         cookieHeaders.get(0).containsIgnoreCase("Path=/")
         cookieHeaders.get(0).containsIgnoreCase("Max-Age=0")
-        cookieHeaders.get(0).containsIgnoreCase("SameSite=Strict")
+        cookieHeaders.get(0).containsIgnoreCase("SameSite=None")
+        cookieHeaders.get(0).containsIgnoreCase("Secure")
+        cookieHeaders.get(0).containsIgnoreCase("HTTPOnly")
         cookieHeaders.get(1).containsIgnoreCase("Domain=domain")
         cookieHeaders.get(1).containsIgnoreCase("JWT_REFRESH=")
         cookieHeaders.get(1).containsIgnoreCase("Path=/oauth/access_token")
         cookieHeaders.get(1).containsIgnoreCase("Max-Age=0")
         cookieHeaders.get(1).containsIgnoreCase("SameSite=None")
+        cookieHeaders.get(1).containsIgnoreCase("Secure")
+        cookieHeaders.get(1).containsIgnoreCase("HTTPOnly")
     }
 }

--- a/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieClearerLogoutHandler.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieClearerLogoutHandler.java
@@ -22,6 +22,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.CookieConfiguration;
+import io.micronaut.http.cookie.SameSite;
 import io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition;
 import io.micronaut.security.config.RedirectConfiguration;
 import io.micronaut.security.config.RedirectService;
@@ -77,8 +78,9 @@ public class TokenCookieClearerLogoutHandler implements LogoutHandler<HttpReques
     private void clearCookie(CookieConfiguration cookieConfiguration, MutableHttpResponse<?> response) {
         String domain = cookieConfiguration.getCookieDomain().orElse(null);
         String path = cookieConfiguration.getCookiePath().orElse(null);
+        SameSite sameSite = cookieConfiguration.getCookieSameSite().orElse(null);
         Cookie cookie = Cookie.of(cookieConfiguration.getCookieName(), "");
-        cookie.maxAge(0).domain(domain).path(path);
+        cookie.maxAge(0).domain(domain).path(path).sameSite(sameSite);
         response.cookie(cookie);
     }
 }

--- a/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieClearerLogoutHandler.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieClearerLogoutHandler.java
@@ -65,9 +65,9 @@ public class TokenCookieClearerLogoutHandler implements LogoutHandler<HttpReques
     public MutableHttpResponse<?> logout(HttpRequest<?> request) {
         try {
             MutableHttpResponse<?> response = logout == null ? HttpResponse.ok() : HttpResponse.seeOther(new URI(logout));
-            clearCookie(accessTokenCookieConfiguration, response);
+            clearCookie(accessTokenCookieConfiguration, response, request.isSecure());
             if (refreshTokenCookieConfiguration != null) {
-                clearCookie(refreshTokenCookieConfiguration, response);
+                clearCookie(refreshTokenCookieConfiguration, response, request.isSecure());
             }
             return response;
         } catch (URISyntaxException var5) {
@@ -75,12 +75,10 @@ public class TokenCookieClearerLogoutHandler implements LogoutHandler<HttpReques
         }
     }
 
-    private void clearCookie(CookieConfiguration cookieConfiguration, MutableHttpResponse<?> response) {
-        String domain = cookieConfiguration.getCookieDomain().orElse(null);
-        String path = cookieConfiguration.getCookiePath().orElse(null);
-        SameSite sameSite = cookieConfiguration.getCookieSameSite().orElse(null);
+    private void clearCookie(CookieConfiguration cookieConfiguration, MutableHttpResponse<?> response, boolean isSecure) {
         Cookie cookie = Cookie.of(cookieConfiguration.getCookieName(), "");
-        cookie.maxAge(0).domain(domain).path(path).sameSite(sameSite);
+        cookie.configure(cookieConfiguration, isSecure);
+        cookie.maxAge(0);
         response.cookie(cookie);
     }
 }


### PR DESCRIPTION
Hi!

I've noticed that in the `TokenCookieClearerLogoutHandler` class, the `logout()` method seems to ignore the configuration of the _SameSite_, _Secure_, and _HTTPOnly_ attributes, focusing only on _Domain_, _Path_, _Name_, and _Max-Age_.

I wonder if this behaviour could deny cross-site authentication proxies from revoking authentication cookies with SameSite=None, Secure, and HTTPOnly attributes, even if originally provided by the proxy itself.

For example, in Chrome v120 I've got exactly replicated this issue, while the logout it's still working in Firefox:
![image](https://github.com/micronaut-projects/micronaut-security/assets/25744564/2b4526a8-051a-429c-a555-ec9679fc0479)

I'm not sure if there are specific reasons for the current implementation, but in case the mentioned attributes should also be handled during the logout phase, I propose the attached pull request.

To ensure consistency within the project, I've employed the same method implementation as found in the `TokenCookieLoginHandler` and tried to provide an update that reflects the changes in the unit tests.

I'm new to contributions, I really hope this is an adequate format, I apologize in advance if not, I'm also open for feedbacks and discussions.

Thank you in advance for your time and consideration! :)