### PR TITLE
Fix: Implement a reactive cache for the JWKS fetching

### DIFF
--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/ReactiveJwksSignature.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/ReactiveJwksSignature.java
@@ -104,12 +104,13 @@ public class ReactiveJwksSignature implements ReactiveSignatureConfiguration<Sig
     }
 
     private Mono<JWKSet> fetchJwkSet() {
-        return Mono.from(jwkSetFetcher.fetch(jwksSignatureConfiguration.getName(), jwksSignatureConfiguration.getUrl()));
+        return Mono.from(jwkSetFetcher.fetch(jwksSignatureConfiguration.getName(), jwksSignatureConfiguration.getUrl()))
+            .switchIfEmpty(Mono.just(new JWKSet()));
     }
 
     private record JwksCacheEntry(JWKSet jwkSet, Instant cacheExpiryAt) {
         private boolean isExpired() {
-            return cacheExpiryAt != null && Instant.now().isAfter(cacheExpiryAt);
+            return jwkSet.isEmpty() || (cacheExpiryAt != null && Instant.now().isAfter(cacheExpiryAt));
         }
     }
 }

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/ReactiveJwksSignature.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/ReactiveJwksSignature.java
@@ -40,11 +40,6 @@ import reactor.core.publisher.Mono;
 */
 @EachBean(JwksSignatureConfiguration.class)
 public class ReactiveJwksSignature implements ReactiveSignatureConfiguration<SignedJWT> {
-    private record JwksCacheEntry(JWKSet jwkSet, Instant cacheExpiryAt) {
-        private boolean isExpired() {
-            return cacheExpiryAt != null && Instant.now().isAfter(cacheExpiryAt);
-        }
-    }
 
     private static final Logger LOG = LoggerFactory.getLogger(ReactiveJwksSignature.class);
     private final JwkValidator jwkValidator;
@@ -110,5 +105,11 @@ public class ReactiveJwksSignature implements ReactiveSignatureConfiguration<Sig
 
     private Mono<JWKSet> fetchJwkSet() {
         return Mono.from(jwkSetFetcher.fetch(jwksSignatureConfiguration.getName(), jwksSignatureConfiguration.getUrl()));
+    }
+
+    private record JwksCacheEntry(JWKSet jwkSet, Instant cacheExpiryAt) {
+        private boolean isExpired() {
+            return cacheExpiryAt != null && Instant.now().isAfter(cacheExpiryAt);
+        }
     }
 }

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksCacheSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksCacheSpec.groovy
@@ -48,7 +48,6 @@ import jakarta.inject.Named
 import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -113,7 +112,6 @@ class JwksCacheSpec extends Specification {
         }
     }
 
-    @PendingFeature
     void "JWK are cached"() {
         given:
         HttpClient googleHttpClient = embeddedServer.applicationContext.createBean(HttpClient, googleEmbeddedServer.URL)
@@ -133,26 +131,26 @@ class JwksCacheSpec extends Specification {
 
         when:
         BearerAccessRefreshToken googleBearerAccessRefreshToken = login(googleClient)
-
-        then:
-        noExceptionThrown()
-        googleBearerAccessRefreshToken.accessToken
-
-        when:
         String googleAccessToken = googleBearerAccessRefreshToken.accessToken
         JWT googleJWT = JWTParser.parse(googleAccessToken)
+
         BearerAccessRefreshToken appleBearerAccessRefreshToken = login(appleClient)
         String appleAccessToken = appleBearerAccessRefreshToken.accessToken
         JWT appleJWT = JWTParser.parse(appleAccessToken)
+
         BearerAccessRefreshToken cognitoBearerAccessRefreshToken = login(cognitoClient)
         String cognitoAccessToken = cognitoBearerAccessRefreshToken.accessToken
         JWT cognitoJWT = JWTParser.parse(cognitoAccessToken)
 
         then:
         noExceptionThrown()
+
         assertKeyId(googleJWT, 'google')
+        googleBearerAccessRefreshToken.accessToken
+
         assertKeyId(appleJWT, 'apple')
         appleBearerAccessRefreshToken.accessToken
+
         assertKeyId(cognitoJWT, 'cognito')
         cognitoBearerAccessRefreshToken.accessToken
 
@@ -170,7 +168,9 @@ class JwksCacheSpec extends Specification {
 
         when: 'when you invoke it again all the keys are cached'
         oldInvocations = totalInvocations()
+        hello(client, googleAccessToken)
         hello(client, appleAccessToken)
+        hello(client, cognitoAccessToken)
 
         then:
         totalInvocations() == oldInvocations


### PR DESCRIPTION
Closes #1734 

As described on #1734, when the reactive JWKS fetching was added, the caching functionality was removed.

This pull request introduces a reactive `.cache()` alongside some expiry logic to determine when to invalidate the publisher.

### Separate Note

@sdelamo - I think there is an opportunity for a design discussion for future changes, as I believe the current approach has some shortcomings. I did begin implementing some changes, but felt that the complexity grew too much and kept this implementation simple. 

The shortcomings I see are:

- If you have multiple `JwksSignatureConfiguration`, each validator is enumerated until one succeeds - which could lead to multiple JWKS fetches. Rather than allowing someone to specify an `issuer` in their configuration, to quickly identify the appropriate JwksSignatureConfiguration to use from a JWT if the `iss` claim is present.
- If an Authorisation Server rotates a key set, a service will potentially reject newly minted JWTs until the cache expires. An idea I implemented separately was to invalidate the cache if a `kid` is observed that is not within the cache - there are trade-offs to this also worth discussion.

I have rough implementations for the first option, and the second option, but the first did include a change to the configuration to include an `issuer`, so I think it's worth discussing.