### PR TITLE
@requires ann for HTTP Server classes and beans.

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationErrorResponseExceptionHandler.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/response/AuthorizationErrorResponseExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.security.oauth2.endpoint.authorization.response;
 
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -38,6 +39,8 @@ import java.net.URISyntaxException;
  * @author Sergio del Amo
  * @since 1.2.0
  */
+@Requires(classes = ExceptionHandler.class)
+@Requires(beans = ErrorResponseProcessor.class)
 @Singleton
 public class AuthorizationErrorResponseExceptionHandler implements ExceptionHandler<AuthorizationErrorResponseException, MutableHttpResponse<?>> {
     private static final Logger LOG = LoggerFactory.getLogger(AuthorizationErrorResponseExceptionHandler.class);

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/DefaultOauthController.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/DefaultOauthController.java
@@ -49,7 +49,7 @@ import reactor.core.publisher.Flux;
  * @author James Kleeh
  * @since 1.2.0
  */
-@Requires(beans = RedirectingLoginHandler.class)
+@Requires(beans = {RedirectingLoginHandler.class, HttpHostResolver.class, HttpLocaleResolver.class})
 @EachBean(OauthClient.class)
 public class DefaultOauthController implements OauthController {
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/OauthRouteBuilder.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/routes/OauthRouteBuilder.java
@@ -17,6 +17,7 @@ package io.micronaut.security.oauth2.routes;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.ExecutionHandleLocator;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.http.HttpMethod;
@@ -48,6 +49,7 @@ import static io.micronaut.security.utils.LoggingUtils.debug;
  * @author James Kleeh
  * @since 1.2.0
  */
+@Requires(classes = DefaultRouteBuilder.class)
 @Singleton
 @Internal
 class OauthRouteBuilder extends DefaultRouteBuilder {


### PR DESCRIPTION
micronaut-security-oauth2 has a compileOnly dependency to micronaut-http-server

This adds the `@Requires` annotation for HTTP Server related classes and beans.

Close: https://github.com/micronaut-projects/micronaut-security/issues/1828