### PR TITLE
Context-path prefix added to absolute redirect URLs

### DIFF
--- a/security/src/main/java/io/micronaut/security/config/ServerContextPathProviderUtils.java
+++ b/security/src/main/java/io/micronaut/security/config/ServerContextPathProviderUtils.java
@@ -17,8 +17,11 @@ package io.micronaut.security.config;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.context.ServerContextPathProvider;
 import io.micronaut.http.uri.UriBuilder;
+
+import java.net.URI;
 
 /**
  * Utility methods to prepend a URL with the context path provided via {@link ServerContextPathProvider}.
@@ -39,11 +42,20 @@ public final class ServerContextPathProviderUtils {
     @NonNull
     public static String prependContextPath(@NonNull String url,
                                             @NonNull ServerContextPathProvider serverContextPathProvider) {
+        URI uri = URI.create(url);
+        if (uri.isAbsolute()) {
+            return url;
+        }
+
         String contextPath = serverContextPathProvider.getContextPath();
-        return contextPath == null ?
-            url :
-            UriBuilder.of("/")
-                .path(contextPath)
-                .build() + url;
+        if (!StringUtils.hasText(contextPath)) {
+            return url;
+        }
+
+        return UriBuilder.of("/")
+            .path(contextPath)
+            .path(url)
+            .build()
+            .toString();
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/utils/ServerContextPathProviderUtilsSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/utils/ServerContextPathProviderUtilsSpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.security.utils
+
+import io.micronaut.http.context.ServerContextPathProvider
+import io.micronaut.security.config.ServerContextPathProviderUtils
+import spock.lang.Specification
+
+class ServerContextPathProviderUtilsSpec extends Specification {
+
+    void "returns original URL if it is absolute"() {
+        given:
+        String url = "http://example.com:8080/web"
+        ServerContextPathProvider serverContextPathProvider = Mock(ServerContextPathProvider)
+
+        when:
+        String result = ServerContextPathProviderUtils.prependContextPath(url, serverContextPathProvider)
+
+        then:
+        result == url
+    }
+
+    void "prepends context path to a relative URL"() {
+        given:
+        String url = "/relative"
+        ServerContextPathProvider serverContextPathProvider = Mock(ServerContextPathProvider) {
+            getContextPath() >> "/context-path"
+        }
+
+        when:
+        String result = ServerContextPathProviderUtils.prependContextPath(url, serverContextPathProvider)
+
+        then:
+        result == "/context-path/relative"
+    }
+
+    void "handles URL with query parameters and fragments"() {
+        given:
+        String url = "/relative?query=param#fragment"
+        ServerContextPathProvider serverContextPathProvider = Mock(ServerContextPathProvider) {
+            getContextPath() >> "/context-path"
+        }
+
+        when:
+        String result = ServerContextPathProviderUtils.prependContextPath(url, serverContextPathProvider)
+
+        then:
+        result == "/context-path/relative?query=param#fragment"
+    }
+
+    void "handles empty string as URL input"() {
+        given:
+        String url = ""
+        ServerContextPathProvider serverContextPathProvider = Mock(ServerContextPathProvider) {
+            getContextPath() >> "/context"
+        }
+
+        when:
+        String result = ServerContextPathProviderUtils.prependContextPath(url, serverContextPathProvider)
+
+        then:
+        result == "/context"
+    }
+
+    void "manages null context path from ServerContextPathProvider"() {
+        given:
+        String url = "relative/path"
+        ServerContextPathProvider serverContextPathProvider = Mock(ServerContextPathProvider) {
+            getContextPath() >> null
+        }
+
+        when:
+        String result = ServerContextPathProviderUtils.prependContextPath(url, serverContextPathProvider)
+
+        then:
+        result == url
+    }
+
+}


### PR DESCRIPTION
Hi again! :wave:

I've noticed an issue in the utility class `ServerContextPathProviderUtils`: the application context path (defined using the property `micronaut.server.context-path`) is always prefixed to all redirect URLs, even when they are configured as absolute URLs. However, when the context path is not set, the URLs remain unaltered.

This behavior results in the following configuration working perfectly:

```yaml
micronaut:
  server:
    port: 8081
  security:
    ... some-oidc-config ...
    redirect:
      enabled: true
      login-success: ${FE_LOGIN_PAGE:`http://localhost:4200/login`}
      login-failure: ${FE_LOGIN_FAILURE_PAGE:`http://localhost:4200/login?oauth2-unauthorized=true`}
      logout: ${FE_LOGOUT_PAGE:`http://localhost:4200/login`}
```
 
But a configuration like this generates invalid redirect URLs, such as _`http://localhost:8081/proxyhttp://localhost:4200/login`_:

```yaml
micronaut:
  server:
    port: 8081
    context-path: /proxy
  security:
    ... some-oidc-config ...
    redirect:
      enabled: true
      login-success: ${FE_LOGIN_PAGE:`http://localhost:4200/login`}
      login-failure: ${FE_LOGIN_FAILURE_PAGE:`http://localhost:4200/login?oauth2-unauthorized=true`}
      logout: ${FE_LOGOUT_PAGE:`http://localhost:4200/login`}
```

Am I misusing the redirect URLs, and would you recommend avoiding absolute URLs?
If not, I have proposed a pull request that attempts to resolve this issue with absolute URLs by checking if the URL includes a scheme. I also tryed to add some unit tests for the changes!

Thank you for your attention and for creating (and maintaining) this amazing framework! :rocket: