### PR TITLE
Fix LoginController to check configured content types against request content type name without parameters

### DIFF
--- a/security/src/main/java/io/micronaut/security/endpoints/LoginController.java
+++ b/security/src/main/java/io/micronaut/security/endpoints/LoginController.java
@@ -177,7 +177,7 @@ public class LoginController<B> {
     @SingleResult
     public Publisher<MutableHttpResponse<?>> login(@Valid @Body UsernamePasswordCredentials usernamePasswordCredentials, HttpRequest<B> request) {
         Optional<MediaType> contentTypeOptional = request.getContentType();
-        if (!(contentTypeOptional.isPresent() && loginControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().toString()))) {
+        if (!(contentTypeOptional.isPresent() && loginControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().getName()))) {
             return Publishers.just(HttpResponse.notFound());
         }
         return Flux.from(authenticator.authenticate(request, usernamePasswordCredentials))

--- a/security/src/main/java/io/micronaut/security/endpoints/LogoutController.java
+++ b/security/src/main/java/io/micronaut/security/endpoints/LogoutController.java
@@ -143,7 +143,7 @@ public class LogoutController {
     @Post
     public MutableHttpResponse<?> index(HttpRequest<?> request, @Nullable Authentication authentication) {
         Optional<MediaType> contentTypeOptional = request.getContentType();
-        if (!(contentTypeOptional.isPresent() && logoutControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().toString()))) {
+        if (!(contentTypeOptional.isPresent() && logoutControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().getName()))) {
             return HttpResponse.notFound();
         }
         return handleLogout(request, authentication);

--- a/security/src/main/java/io/micronaut/security/endpoints/OauthController.java
+++ b/security/src/main/java/io/micronaut/security/endpoints/OauthController.java
@@ -120,7 +120,7 @@ public class OauthController {
                                                    @Nullable @Body Map<String, String> body,
                                                    @Nullable @CookieValue("JWT_REFRESH_TOKEN") String cookieRefreshToken) {
         Optional<MediaType> contentTypeOptional = request.getContentType();
-        if (!(contentTypeOptional.isPresent() && oauthControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().toString()))) {
+        if (!(contentTypeOptional.isPresent() && oauthControllerConfiguration.getPostContentTypes().contains(contentTypeOptional.get().getName()))) {
             return Publishers.just(HttpResponse.notFound());
         }
         TokenRefreshRequest tokenRefreshRequest = body == null ? null :

--- a/security/src/test/java/io/micronaut/security/endpoints/LoginControllerContentTypesForPostTest.java
+++ b/security/src/test/java/io/micronaut/security/endpoints/LoginControllerContentTypesForPostTest.java
@@ -81,6 +81,21 @@ class LoginControllerContentTypesForPostTest {
         server.close();
     }
 
+    @Test
+    void defaultContentTypesSupportJsonWithCharset() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "spec.name", "LoginControllerContentTypesForPostTest"
+        ));
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        UsernamePasswordCredentials creds = new UsernamePasswordCredentials("user", "password");
+        HttpRequest<?> request = HttpRequest.POST("/login", creds).contentType("application/json; charset=UTF-8");
+        assertDoesNotThrow(() -> client.exchange(request));
+        assertDoesNotThrow(() -> client.exchange(HttpRequest.POST("/login", creds)));
+        httpClient.close();
+        server.close();
+    }
+
     @Requires(property = "spec.name", value = "LoginControllerContentTypesForPostTest")
     @Singleton
     static class CustomAuthenticationProvider extends MockAuthenticationProvider {

--- a/security/src/test/java/io/micronaut/security/endpoints/LogoutControllerContentTypesForPostTest.java
+++ b/security/src/test/java/io/micronaut/security/endpoints/LogoutControllerContentTypesForPostTest.java
@@ -77,6 +77,20 @@ class LogoutControllerContentTypesForPostTest {
         server.close();
     }
 
+    @Test
+    void defaultContentTypesSupportJsonWithCharset() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "spec.name", "LogoutControllerContentTypesForPostTest"
+        ));
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.POST("/logout", Collections.emptyMap()).contentType("application/json; charset=UTF-8");
+        assertDoesNotThrow(() -> client.exchange(request));
+        assertDoesNotThrow(() -> client.exchange(HttpRequest.POST("/logout", Collections.emptyMap())));
+        httpClient.close();
+        server.close();
+    }
+
     @Requires(property = "spec.name", value = "LogoutControllerContentTypesForPostTest")
     @Singleton
     static class CustomAuthenticationFetcher implements AuthenticationFetcher<HttpRequest<?>> {

--- a/security/src/test/java/io/micronaut/security/endpoints/OauthControllerContentTypesForPostTest.java
+++ b/security/src/test/java/io/micronaut/security/endpoints/OauthControllerContentTypesForPostTest.java
@@ -84,6 +84,20 @@ class OauthControllerContentTypesForPostTest {
         server.close();
     }
 
+    @Test
+    void defaultContentTypesSupportJsonWithCharset() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "spec.name", "OauthControllerContentTypesForPostTest"
+        ));
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.POST("/oauth/access_token", Collections.emptyMap()).contentType("application/json; charset=UTF-8");
+        HttpClientResponseException ex = assertThrows(HttpClientResponseException.class, () ->client.exchange(request));
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatus());
+        httpClient.close();
+        server.close();
+    }
+
     @Requires(property = "spec.name", value = "OauthControllerContentTypesForPostTest")
     @Singleton
     static class CustomAuthenticationProvider extends MockAuthenticationProvider {


### PR DESCRIPTION
The toString method includes parameters like charset. Using getName instead means only the type and subtype (inc extension) are compared.
Associated with https://github.com/micronaut-projects/micronaut-security/issues/1971