### PR TITLE
feat: protected resource metadata

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ micronaut-data = "4.12.2"
 micronaut-sql = "6.1.1"
 micronaut-test-resources = "2.8.0"
 graalvm-native-buildtools = "0.10.6"
+jsonassert = "1.5.3"
 
 [libraries]
 # Core
@@ -67,6 +68,7 @@ bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bcpkix" }
 system-stubs-core = { module = "uk.org.webcompere:system-stubs-core", version.ref = "system-stubs-core" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-engine = { module = "org.junit.platform:junit-platform-suite-engine" }
+jsonassert = { module = 'org.skyscreamer:jsonassert', version.ref = 'jsonassert'}
 
 testcontainers-selenium = { module = "org.testcontainers:selenium"}
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter"}

--- a/security-oauth2/build.gradle.kts
+++ b/security-oauth2/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     testImplementation(mnLogging.logback.classic)
     testImplementation(libs.system.stubs.core)
     testImplementation(mn.micronaut.retry)
-
+    testImplementation(libs.jsonassert)
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -467,6 +467,7 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         private AuthorizationEndpointConfigurationProperties authorization;
         private TokenEndpointConfigurationProperties token;
         private EndSessionConfigurationProperties endSession = new EndSessionConfigurationProperties();
+        private boolean protectedResourceMetadata = DEFAULT_PROTECTED_RESOURCE_METADATA;
 
         /**
          * @param name The provider name
@@ -479,6 +480,19 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         @Override
         public String getName() {
             return name;
+        }
+
+        @Override
+        public boolean isProtectedResourceMetadata() {
+            return protectedResourceMetadata;
+        }
+
+        /**
+         * Whether the protected resource metadata endpoint should expose the OpenID issuer as an authorization server. Default value: true.
+         * @param protectedResourceMetadata Whether the protected resource metadata endpoint should expose the OpenID issuer as an authorization server.
+         */
+        public void setProtectedResourceMetadata(boolean protectedResourceMetadata) {
+            this.protectedResourceMetadata = protectedResourceMetadata;
         }
 
         @Override

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
@@ -31,6 +31,7 @@ import java.util.Optional;
  * @since 1.2.0
  */
 public interface OpenIdClientConfiguration extends Named {
+    Boolean DEFAULT_PROTECTED_RESOURCE_METADATA = true;
 
     /**
      * @return URL that the OpenID provider asserts as its issuer identifier.
@@ -81,4 +82,12 @@ public interface OpenIdClientConfiguration extends Named {
      */
     @NonNull
     EndSessionEndpointConfiguration getEndSession();
+
+    /**
+     * @since 4.14.0
+     * @return whether the protected resource metadata endpoint should expose the OpenID issuer as an authorization server.
+     */
+    default boolean isProtectedResourceMetadata() {
+        return DEFAULT_PROTECTED_RESOURCE_METADATA;
+    }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/DefaultProtectedResourceMetadataProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/DefaultProtectedResourceMetadataProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.server.util.HttpHostResolver;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
+import jakarta.inject.Singleton;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Default implementation of {@link ProtectedResourceMetadataProvider}.
+ */
+@Requires(classes = HttpRequest.class)
+@Experimental
+@Singleton
+public class DefaultProtectedResourceMetadataProvider implements ProtectedResourceMetadataProvider<HttpRequest<?>> {
+    /**
+     * Application configuration.
+     */
+    protected final ApplicationConfiguration applicationConfiguration;
+    /**
+     * HTTP Host Resolver.
+     */
+    protected final HttpHostResolver httpHostResolver;
+
+    /**
+     * OpenID client configurations.
+     */
+    protected final List<OpenIdClientConfiguration> openIdClients;
+
+    /**
+     *
+     * @param applicationConfiguration Application configuration.
+     * @param httpHostResolver HTTP Host Resolver.
+     * @param openIdClients OpenID client configurations.
+     */
+    public DefaultProtectedResourceMetadataProvider(ApplicationConfiguration applicationConfiguration,
+                                                    HttpHostResolver httpHostResolver,
+                                                    List<OpenIdClientConfiguration> openIdClients) {
+        this.applicationConfiguration = applicationConfiguration;
+        this.httpHostResolver = httpHostResolver;
+        this.openIdClients = openIdClients;
+    }
+
+    @Override
+    @NonNull
+    public ProtectedResourceMetadata get(@NonNull HttpRequest<?> request) {
+        return builder(null, request).build();
+    }
+
+    @Override
+    @NonNull
+    public ProtectedResourceMetadata get(@NonNull String path, @NonNull HttpRequest<?> request) {
+        return builder(path, request).build();
+    }
+
+    /**
+     * Creates a Protected Resource Metadata builder.
+     * @param path Path component
+     * @param request The HTTP Request
+     * @return a Protected Resource Metadata builder
+     */
+    @NonNull
+    protected ProtectedResourceMetadata.Builder builder(@Nullable String path, @NonNull HttpRequest<?> request) {
+        ProtectedResourceMetadata.Builder builder = ProtectedResourceMetadata.builder()
+            .resource(resource(path, request));
+        List<String> authorizationServers = authorizationServers(path, request);
+        if (CollectionUtils.isNotEmpty(authorizationServers)) {
+            builder.authorizationServers(authorizationServers);
+        }
+        applicationConfiguration.getName().ifPresent(builder::resourceName);
+        return builder;
+    }
+
+    /**
+     *
+     * @param path The Path component
+     * @param request the Request
+     * @return the Resource
+     */
+    @NonNull
+    protected String resource(@Nullable String path, @NonNull HttpRequest<?> request) {
+        String host = httpHostResolver.resolve(request);
+        return StringUtils.isNotEmpty(path)
+            ? host + path
+            : host;
+    }
+
+    /**
+     * Authorization Servers for the Protected Resource Metadata.
+     * @param path Path component
+     * @param request HTTP Requests
+     * @return Authorization Servers
+     */
+    @NonNull
+    protected List<String> authorizationServers(@Nullable String path, @NonNull HttpRequest<?> request) {
+        List<String> result = new ArrayList<>(openIdClients.size());
+        for (OpenIdClientConfiguration openIdClientConfiguration : openIdClients) {
+            if (openIdClientConfiguration.isProtectedResourceMetadata()) {
+                openIdClientConfiguration.getIssuer().map(URL::toString).ifPresent(result::add);
+            }
+        }
+        return result;
+    }
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadata.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadata.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Protected Resource Metadata as defined in RFC9728.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9728#Terminology">Protected Resource Metadata Terminology</a>
+ * @param resource The protected resource's resource identifier, which is a URL that uses the https scheme and has no fragment component.
+ * @param authorizationServers JSON array containing a list of OAuth authorization server issuer identifiers.
+ * @param jwksUri URL of the protected resource's JSON Web Key (JWK) Set [JWK] document.
+ * @param scopesSupported JSON array containing a list of scope values.
+ * @param bearerMethodsSupported JSON array containing a list of the supported methods of sending an OAuth 2.0 bearer token.
+ * @param resourceSigningAlgValuesSupported  JSON array containing a list of the JWS [JWS] signing algorithms (alg values).
+ * @param resourceName Human-readable name of the protected resource intended for display to the end user.
+ * @param resourceDocumentation URL of a page containing human-readable information that developers might want or need to know when using the protected resource.
+ * @param resourcePolicyUri URL of a page containing human-readable information about the protected resource's requirements on how the client can use the data provided by the protected resource.
+ * @param resourceTosUri URL of a page containing human-readable information about the protected resource's terms of service.
+ * @param tlsClientCertificateBoundAccessTokens Boolean value indicating protected resource support for mutual-TLS client certificate-bound access tokens.
+ * @param authorizationDetailsTypesSupported JSON array containing a list of the authorization details type values supported by the resource server when the authorization_details request parameter [RFC9396] is used.
+ * @param dpopSigningAlgValuesSupported SON array containing a list of the JWS alg values (from the "JSON Web Signature and Encryption Algorithms" registry [IANA.JOSE]) supported by the resource server for validating Demonstrating Proof of Possession (DPoP) proof JWTs [RFC9449].
+ * @param dpopBoundAccessTokensRequired Boolean value specifying whether the protected resource always requires the use of DPoP-bound access tokens [RFC9449].
+ */
+@Serdeable
+@Experimental
+public record ProtectedResourceMetadata(
+    @NonNull
+    String resource,
+
+    @JsonProperty("authorization_servers")
+    @Nullable
+    List<String> authorizationServers,
+
+    @JsonProperty("jwks_uri")
+    @Nullable
+    String jwksUri,
+
+    @JsonProperty("scopes_supported")
+    @Nullable
+    List<String> scopesSupported,
+
+    @JsonProperty("bearer_methods_supported")
+    @Nullable
+    List<String> bearerMethodsSupported,
+
+    @JsonProperty("resource_signing_alg_values_supported")
+    @Nullable
+    List<String> resourceSigningAlgValuesSupported,
+
+    @JsonProperty("resource_name")
+    String resourceName,
+
+    @JsonProperty("resource_documentation")
+    @Nullable
+    String resourceDocumentation,
+
+    @JsonProperty("resource_policy_uri")
+    @Nullable
+    String resourcePolicyUri,
+
+    @JsonProperty("resource_tos_uri")
+    @Nullable
+    String resourceTosUri,
+
+    @JsonProperty("tls_client_certificate_bound_access_tokens")
+    @Nullable
+    Boolean tlsClientCertificateBoundAccessTokens,
+
+    @JsonProperty("authorization_details_types_supported")
+    @Nullable
+    List<String> authorizationDetailsTypesSupported,
+
+    @JsonProperty("dpop_signing_alg_values_supported")
+    @Nullable
+    List<String> dpopSigningAlgValuesSupported,
+
+    @JsonProperty("dpop_bound_access_tokens_required")
+    Boolean dpopBoundAccessTokensRequired
+) {
+    /**
+     * Create a new builder.
+     * @return A builder instance.
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ProtectedResourceMetadata}.
+     */
+    public static final class Builder {
+        private String resource;
+        private List<String> authorizationServers;
+        private String jwksUri;
+        private List<String> scopesSupported;
+        private List<String> bearerMethodsSupported;
+        private List<String> resourceSigningAlgValuesSupported;
+        private String resourceName;
+        private String resourceDocumentation;
+        private String resourcePolicyUri;
+        private String resourceTosUri;
+        private Boolean tlsClientCertificateBoundAccessTokens;
+        private List<String> authorizationDetailsTypesSupported;
+        private List<String> dpopSigningAlgValuesSupported;
+        private Boolean dpopBoundAccessTokensRequired;
+
+        @NonNull
+        public Builder resource(@NonNull String resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        @NonNull
+        public Builder authorizationServers(@Nullable List<String> authorizationServers) {
+            this.authorizationServers = authorizationServers;
+            return this;
+        }
+
+        @NonNull
+        public Builder authorizationServer(@NonNull String issuer) {
+            if (this.authorizationServers == null) {
+                this.authorizationServers = new ArrayList<>();
+            }
+            this.authorizationServers.add(issuer);
+            return this;
+        }
+
+        @NonNull
+        public Builder authorizationServer(@NonNull URL issuer) {
+            return authorizationServer(issuer.toString());
+        }
+
+        @NonNull
+        public Builder jwksUri(@Nullable String jwksUri) {
+            this.jwksUri = jwksUri;
+            return this;
+        }
+
+        @NonNull
+        public Builder scopesSupported(@Nullable List<String> scopesSupported) {
+            this.scopesSupported = scopesSupported;
+            return this;
+        }
+
+        @NonNull
+        public Builder bearerMethodsSupported(@Nullable List<String> bearerMethodsSupported) {
+            this.bearerMethodsSupported = bearerMethodsSupported;
+            return this;
+        }
+
+        @NonNull
+        public Builder resourceSigningAlgValuesSupported(@Nullable List<String> resourceSigningAlgValuesSupported) {
+            this.resourceSigningAlgValuesSupported = resourceSigningAlgValuesSupported;
+            return this;
+        }
+
+        @NonNull
+        public Builder resourceName(String resourceName) {
+            this.resourceName = resourceName;
+            return this;
+        }
+
+        @NonNull
+        public Builder resourceDocumentation(@Nullable String resourceDocumentation) {
+            this.resourceDocumentation = resourceDocumentation;
+            return this;
+        }
+
+        @NonNull
+        public Builder resourcePolicyUri(@Nullable String resourcePolicyUri) {
+            this.resourcePolicyUri = resourcePolicyUri;
+            return this;
+        }
+
+        @NonNull
+        public Builder resourceTosUri(@Nullable String resourceTosUri) {
+            this.resourceTosUri = resourceTosUri;
+            return this;
+        }
+
+        @NonNull
+        public Builder tlsClientCertificateBoundAccessTokens(@Nullable Boolean tlsClientCertificateBoundAccessTokens) {
+            this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
+            return this;
+        }
+
+        @NonNull
+        public Builder authorizationDetailsTypesSupported(@Nullable List<String> authorizationDetailsTypesSupported) {
+            this.authorizationDetailsTypesSupported = authorizationDetailsTypesSupported;
+            return this;
+        }
+
+        @NonNull
+        public Builder dpopSigningAlgValuesSupported(@Nullable List<String> dpopSigningAlgValuesSupported) {
+            this.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported;
+            return this;
+        }
+
+        @NonNull
+        public Builder dpopBoundAccessTokensRequired(Boolean dpopBoundAccessTokensRequired) {
+            this.dpopBoundAccessTokensRequired = dpopBoundAccessTokensRequired;
+            return this;
+        }
+
+        /**
+         * Build the {@link ProtectedResourceMetadata} instance.
+         * @return a new {@link ProtectedResourceMetadata}
+         */
+        @NonNull
+        public ProtectedResourceMetadata build() {
+            Objects.requireNonNull(resource, "resource must not be null");
+            return new ProtectedResourceMetadata(
+                resource,
+                authorizationServers,
+                jwksUri,
+                scopesSupported,
+                bearerMethodsSupported,
+                resourceSigningAlgValuesSupported,
+                resourceName,
+                resourceDocumentation,
+                resourcePolicyUri,
+                resourceTosUri,
+                tlsClientCertificateBoundAccessTokens,
+                authorizationDetailsTypesSupported,
+                dpopSigningAlgValuesSupported,
+                dpopBoundAccessTokensRequired
+            );
+        }
+    }
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.security.oauth2.configuration.OauthConfigurationProperties;
+
+/**
+ * Protected Resource Metadata Configuration.
+ * @since 4.14.0
+ */
+public interface ProtectedResourceMetadataConfiguration extends Toggleable {
+    String PATH = "/.well-known/oauth-protected-resource";
+    String PREFIX = OauthConfigurationProperties.PREFIX + ".protected-resource-metadata";
+    String PROPERTY_WWW_AUTHENTICATE = PREFIX + ".www-authenticate";
+    String PROPERTY_ENABLED = PREFIX + ".enabled";
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 original authors
+ * Copyright 2017-2025 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.security.authentication;
+package io.micronaut.security.oauth2.metadata;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.core.util.Toggleable;
-import io.micronaut.security.config.SecurityConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
 
-/**
- * Configuration for basic authentication.
- *
- * @author James Kleeh
- * @since 2.0.0
- */
-@ConfigurationProperties(BasicAuthAuthenticationConfiguration.PREFIX)
-public class BasicAuthAuthenticationConfiguration implements Toggleable {
-
-    public static final String PREFIX = SecurityConfigurationProperties.PREFIX + ".basic-auth";
-    public static final String PROPERTY_ENABLED = PREFIX + ".enabled";
-    public static final String PROPERTY_WWW_AUTHENTICATE = PREFIX + ".www-authenticate";
-
+@Internal
+@ConfigurationProperties(ProtectedResourceMetadataConfiguration.PREFIX)
+class ProtectedResourceMetadataConfigurationProperties implements ProtectedResourceMetadataConfiguration {
     /**
      * The default enable value.
      */
+    @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ENABLED = true;
-
     private boolean enabled = DEFAULT_ENABLED;
 
     @Override
@@ -45,12 +34,10 @@ public class BasicAuthAuthenticationConfiguration implements Toggleable {
     }
 
     /**
-     * Enables the {@link BasicAuthAuthenticationFetcher}. Default value {@value #DEFAULT_ENABLED}.
-     *
-     * @param enabled True if enabled
+     * Whether /.well-known/oauth-protected-resource is exposed. Default value: {@value #DEFAULT_ENABLED}.
+     * @param enabled Whether /.well-known/oauth-protected-resource is exposed
      */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
-
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataController.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+
+@Internal
+@Requires(classes = HttpRequest.class)
+@Controller
+class ProtectedResourceMetadataController {
+    private final ProtectedResourceMetadataProvider<HttpRequest<?>> protectedResourceMetadataProvider;
+
+    ProtectedResourceMetadataController(ProtectedResourceMetadataProvider<HttpRequest<?>> protectedResourceMetadataProvider) {
+        this.protectedResourceMetadataProvider = protectedResourceMetadataProvider;
+    }
+
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    @Get(ProtectedResourceMetadataConfiguration.PATH)
+    ProtectedResourceMetadata getProtectedResourceMetadata(HttpRequest<?> request) {
+        return protectedResourceMetadataProvider.get(request);
+    }
+
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    @Get(ProtectedResourceMetadataConfiguration.PATH + "{path:.+}")
+    ProtectedResourceMetadata getProtectedResourceMetadata(@NonNull @PathVariable String path, HttpRequest<?> request) {
+        return protectedResourceMetadataProvider.get(path, request);
+    }
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Protected Resource Metadata Provider.
+ * @param <T> the Request
+ * @since 4.14.0
+ */
+public interface ProtectedResourceMetadataProvider<T> {
+    /**
+     *
+     * @param request The Request
+     * @return Protected Resource Metadata
+     */
+    @NonNull
+    ProtectedResourceMetadata get(@NonNull T request);
+
+    /**
+     *
+     * @param path Path Component
+     * @param request The Request
+     * @return Protected Resource Metadata
+     */
+    @NonNull
+    default ProtectedResourceMetadata get(@NonNull String path, @NonNull T request) {
+        return get(request);
+    }
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ResourceMetadataWwwAuthenticateChallengeProvider.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/ResourceMetadataWwwAuthenticateChallengeProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpHeaderValues;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.server.util.HttpHostResolver;
+import io.micronaut.security.authentication.WwwAuthenticateChallenge;
+import io.micronaut.security.authentication.WwwAuthenticateChallengeProvider;
+import jakarta.inject.Singleton;
+
+/**
+ * Use of WWW-Authenticate for Protected Resource Metadata.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9728#WWW-Authenticate">RFC 9728 WWW Authenticate</a>
+ */
+@Requires(classes = HttpRequest.class)
+@Requires(property = ProtectedResourceMetadataConfiguration.PROPERTY_WWW_AUTHENTICATE, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Internal
+@Singleton
+class ResourceMetadataWwwAuthenticateChallengeProvider implements WwwAuthenticateChallengeProvider<HttpRequest<?>> {
+    private static final String PARAM_RESOURCE_METADATA = "resource_metadata";
+    private static final String SLASH = "/";
+    private final HttpHostResolver  httpHostResolver;
+
+    ResourceMetadataWwwAuthenticateChallengeProvider(HttpHostResolver httpHostResolver) {
+        this.httpHostResolver = httpHostResolver;
+    }
+
+    @Override
+    @NonNull
+    public String getWwwAuthenticateChallenge(@Nullable HttpRequest<?> request) {
+        return WwwAuthenticateChallenge.builder()
+            .authScheme(HttpHeaderValues.AUTHORIZATION_PREFIX_BEARER)
+            .param(PARAM_RESOURCE_METADATA,  resourceMetadata(request))
+            .build()
+            .toString();
+    }
+
+    @NonNull
+    private String resourceMetadata(@Nullable HttpRequest<?> request) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(httpHostResolver.resolve(request));
+        sb.append(ProtectedResourceMetadataConfiguration.PATH);
+        if (request != null && StringUtils.isNotEmpty(request.getPath()) && !request.getPath().equals(SLASH)) {
+            sb.append(request.getPath());
+        }
+        return sb.toString();
+    }
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/package-info.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/metadata/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Protected Resource Metadata related classes.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9728">Protected Resource Metadata</a>
+ */
+@Requires(property = ProtectedResourceMetadataConfiguration.PROPERTY_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Configuration
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/DefaultProtectedResourceMetadataProviderTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/DefaultProtectedResourceMetadataProviderTest.java
@@ -1,0 +1,81 @@
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DefaultProtectedResourceMetadataProviderTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/resource1",
+        "/.well-known/oauth-protected-resource/foo/bar"
+    })
+    void testProtectedResourceMetadataController(String path) throws JSONException {
+        Map<String, Object> configuration = Map.of(
+            "spec.name", "DefaultProtectedResourceMetadataProviderTest",
+            "micronaut.security.oauth2.clients.oci.openid.issuer", "https://idcs-abcde.identity.oraclecloud.com");
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, configuration);
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        String expected = String.format("""
+              {
+               "resource": "%s",
+               "authorization_servers": ["https://idcs-abcde.identity.oraclecloud.com"]
+              }
+            """, server.getURL().toString() + path.replace("/.well-known/oauth-protected-resource", ""));
+        HttpResponse<String> resp = assertDoesNotThrow(() ->
+            client.exchange(HttpRequest.GET(path), String.class));
+        assertEquals(HttpStatus.OK, resp.getStatus());
+        String json = resp.body();
+        JSONAssert.assertEquals(expected, json, true);
+        client.close();
+        httpClient.close();
+        server.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/resource1",
+        "/.well-known/oauth-protected-resource/foo/bar"
+    })
+    void testProtectedResourceMetadataControllerWithDisabledOpenIdClient(String path) throws JSONException {
+        Map<String, Object> configuration = Map.of(
+            "spec.name", "DefaultProtectedResourceMetadataProviderTest",
+            "micronaut.security.oauth2.clients.oci.openid.issuer", "https://idcs-abcde.identity.oraclecloud.com",
+            "micronaut.security.oauth2.clients.notexposed.openid.issuer", "https://idcs-notexposed.identity.oraclecloud.com",
+            "micronaut.security.oauth2.clients.notexposed.openid.protected-resource-metadata", StringUtils.FALSE
+        );
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, configuration);
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        String expected = String.format("""
+              {
+               "resource": "%s",
+               "authorization_servers": ["https://idcs-abcde.identity.oraclecloud.com"]
+              }
+            """, server.getURL().toString() + path.replace("/.well-known/oauth-protected-resource", ""));
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.GET(path)));
+        JSONAssert.assertEquals(expected, json, true);
+        client.close();
+        httpClient.close();
+        server.close();
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataControllerTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataControllerTest.java
@@ -1,0 +1,75 @@
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.server.util.HttpHostResolver;
+import io.micronaut.runtime.server.EmbeddedServer;
+import jakarta.inject.Singleton;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class ProtectedResourceMetadataControllerTest {
+    @Test
+    void testProtectedResourceMetadataController() throws JSONException {
+        Map<String, Object> configuration = Map.of("spec.name", "ProtectedResourceMetadataControllerTest");
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, configuration);
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        String expected = String.format("""
+              {
+               "resource":
+                 "%s",
+               "authorization_servers":
+                 ["https://as1.example.com",
+                  "https://as2.example.net"],
+               "bearer_methods_supported":
+                 ["header", "body"],
+               "scopes_supported":
+                 ["profile", "email", "phone"],
+               "resource_documentation":
+                 "https://resource.example.com/resource_documentation.html"
+              }
+            """, server.getURL().toString());
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.GET("/.well-known/oauth-protected-resource")));
+        JSONAssert.assertEquals(expected, json, true);
+    }
+
+    @Requires(property = "spec.name", value = "ProtectedResourceMetadataControllerTest")
+    @Replaces(ProtectedResourceMetadataProvider.class)
+    @Singleton
+    static class ProtectedResourceMetadataProviderMock implements ProtectedResourceMetadataProvider<HttpRequest<?>> {
+        private final HttpHostResolver httpHostResolver;
+
+        ProtectedResourceMetadataProviderMock(HttpHostResolver httpHostResolver) {
+            this.httpHostResolver = httpHostResolver;
+        }
+
+        @Override
+        @NonNull
+        public ProtectedResourceMetadata get(@NonNull HttpRequest<?> request) {
+            String resource = httpHostResolver.resolve(request);
+            List<String> authorizationServers = List.of("https://as1.example.com",
+                "https://as2.example.net");
+            List<String> scopesSupported = List.of("profile", "email", "phone");
+            List<String> bearerMethodsSupported = List.of("header", "body");
+            String resourceDocumentation = "https://resource.example.com/resource_documentation.html";
+            return ProtectedResourceMetadata.builder().resource(resource)
+                .authorizationServers(authorizationServers)
+                .scopesSupported(scopesSupported)
+                .bearerMethodsSupported(bearerMethodsSupported)
+                .resourceDocumentation(resourceDocumentation)
+                .build();
+        }
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataProviderPathComponentTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataProviderPathComponentTest.java
@@ -1,0 +1,75 @@
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.server.util.HttpHostResolver;
+import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
+import jakarta.inject.Singleton;
+import org.json.JSONException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProtectedResourceMetadataProviderPathComponentTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/.well-known/oauth-protected-resource/foo/bar"
+    })
+    void testProtectedResourceMetadataController(String path) throws JSONException {
+        Map<String, Object> configuration = Map.of(
+            "micronaut.application.name", "demo",
+            "spec.name", "ProtectedResourceMetadataProviderPathComponentTest",
+            "micronaut.security.oauth2.clients.oci.openid.issuer", "https://idcs-abcde.identity.oraclecloud.com");
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, configuration);
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        String expected = String.format("""
+              {
+               "resource": "%s",
+               "resource_name": "demo",
+               "scopes_supported": ["foo","bar"],
+               "authorization_servers": ["https://idcs-abcde.identity.oraclecloud.com"]
+              }
+            """, server.getURL().toString() + path.replace("/.well-known/oauth-protected-resource", ""));
+        String json = assertDoesNotThrow(() -> client.retrieve(HttpRequest.GET(path)));
+        JSONAssert.assertEquals(json, expected, json, true);
+        client.close();
+        httpClient.close();
+        server.close();
+    }
+
+    @Requires(property = "spec.name", value = "ProtectedResourceMetadataProviderPathComponentTest")
+    @Replaces(ProtectedResourceMetadataProvider.class)
+    @Singleton
+    static class ProtectedResourceMetadataProviderMock extends DefaultProtectedResourceMetadataProvider {
+
+        ProtectedResourceMetadataProviderMock(ApplicationConfiguration applicationConfiguration, HttpHostResolver httpHostResolver, List<OpenIdClientConfiguration> openIdClients) {
+            super(applicationConfiguration, httpHostResolver, openIdClients);
+        }
+
+        @Override
+        @NonNull
+        public ProtectedResourceMetadata get(@NonNull String path, @NonNull HttpRequest<?> request) {
+            assertTrue(path.startsWith("/"));
+            return builder(path, request)
+                .scopesSupported(Arrays.stream(path.split("/")).filter(StringUtils::isNotEmpty).toList())
+                .build();
+        }
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ProtectedResourceMetadataTest.java
@@ -1,0 +1,173 @@
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import io.micronaut.core.type.Argument;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@MicronautTest(startApplication = false)
+class ProtectedResourceMetadataTest {
+
+    @Test
+    void serializeProtectedResourceMetadata(JsonMapper jsonMapper) throws IOException, JSONException {
+        String resource = "https://resource.example.com";
+        List<String> authorizationServers = List.of("https://as1.example.com",
+            "https://as2.example.net");
+        String jwksUri = null;
+        List<String> scopesSupported = List.of("profile", "email", "phone");
+        List<String> bearerMethodsSupported = List.of("header", "body");
+        List<String> resourceSigningAlgValuesSupported = null;
+        String resourceName = null;
+        String resourceDocumentation = "https://resource.example.com/resource_documentation.html";
+        String resourcePolicyUri = null;
+        String resourceTosUri = null;
+        Boolean tlsClientCertificateBoundAccessTokens = null;
+        List<String> authorizationDetailsTypesSupported = null;
+        List<String> dpopSigningAlgValuesSupported = null;
+        Boolean dpopBoundAccessTokensRequired = null;
+
+        ProtectedResourceMetadata metadata = new ProtectedResourceMetadata(resource,
+            authorizationServers,
+            jwksUri,
+            scopesSupported,
+            bearerMethodsSupported,
+            resourceSigningAlgValuesSupported,
+            resourceName,
+            resourceDocumentation,
+            resourcePolicyUri,
+            resourceTosUri,
+            tlsClientCertificateBoundAccessTokens,
+            authorizationDetailsTypesSupported,
+            dpopSigningAlgValuesSupported,
+            dpopBoundAccessTokensRequired);
+
+        String expected = """
+              {
+               "resource":
+                 "https://resource.example.com",
+               "authorization_servers":
+                 ["https://as1.example.com",
+                  "https://as2.example.net"],
+               "bearer_methods_supported":
+                 ["header", "body"],
+               "scopes_supported":
+                 ["profile", "email", "phone"],
+               "resource_documentation":
+                 "https://resource.example.com/resource_documentation.html"
+              }
+            """;
+        JSONAssert.assertEquals(expected, jsonMapper.writeValueAsString(metadata), true);
+
+        metadata = ProtectedResourceMetadata.builder().resource(resource)
+            .authorizationServers(authorizationServers)
+            .scopesSupported(scopesSupported)
+            .bearerMethodsSupported(bearerMethodsSupported)
+            .resourceDocumentation(resourceDocumentation)
+            .build();
+        JSONAssert.assertEquals(expected, jsonMapper.writeValueAsString(metadata), true);
+    }
+
+    @Test
+    void serializeAllProperties(JsonMapper jsonMapper) throws IOException, JSONException {
+        ProtectedResourceMetadata metadata = ProtectedResourceMetadata.builder()
+            .resource("https://api.example.com")
+            .authorizationServers(List.of("https://as.example.com"))
+            .jwksUri("https://api.example.com/jwks.json")
+            .scopesSupported(List.of("read", "write"))
+            .bearerMethodsSupported(List.of("header", "body", "query"))
+            .resourceSigningAlgValuesSupported(List.of("RS256", "ES256"))
+            .resourceName("Example API")
+            .resourceDocumentation("https://api.example.com/docs")
+            .resourcePolicyUri("https://api.example.com/policy")
+            .resourceTosUri("https://api.example.com/tos")
+            .tlsClientCertificateBoundAccessTokens(true)
+            .authorizationDetailsTypesSupported(List.of("payment_initiation"))
+            .dpopSigningAlgValuesSupported(List.of("ES256"))
+            .dpopBoundAccessTokensRequired(true)
+            .build();
+
+        String expected = """
+            {
+              "resource": "https://api.example.com",
+              "authorization_servers": ["https://as.example.com"],
+              "jwks_uri": "https://api.example.com/jwks.json",
+              "scopes_supported": ["read", "write"],
+              "bearer_methods_supported": ["header", "body", "query"],
+              "resource_signing_alg_values_supported": ["RS256", "ES256"],
+              "resource_name": "Example API",
+              "resource_documentation": "https://api.example.com/docs",
+              "resource_policy_uri": "https://api.example.com/policy",
+              "resource_tos_uri": "https://api.example.com/tos",
+              "tls_client_certificate_bound_access_tokens": true,
+              "authorization_details_types_supported": ["payment_initiation"],
+              "dpop_signing_alg_values_supported": ["ES256"],
+              "dpop_bound_access_tokens_required": true
+            }
+            """;
+
+        JSONAssert.assertEquals(expected, jsonMapper.writeValueAsString(metadata), true);
+    }
+
+    @Test
+    void serializeAllProperties_usesJsonPropertyNames(JsonMapper jsonMapper) throws IOException {
+        ProtectedResourceMetadata metadata = ProtectedResourceMetadata.builder()
+            .resource("https://api.example.com")
+            .authorizationServers(List.of("https://as.example.com"))
+            .jwksUri("https://api.example.com/jwks.json")
+            .scopesSupported(List.of("read", "write"))
+            .bearerMethodsSupported(List.of("header", "body", "query"))
+            .resourceSigningAlgValuesSupported(List.of("RS256", "ES256"))
+            .resourceName("Example API")
+            .resourceDocumentation("https://api.example.com/docs")
+            .resourcePolicyUri("https://api.example.com/policy")
+            .resourceTosUri("https://api.example.com/tos")
+            .tlsClientCertificateBoundAccessTokens(true)
+            .authorizationDetailsTypesSupported(List.of("payment_initiation"))
+            .dpopSigningAlgValuesSupported(List.of("ES256"))
+            .dpopBoundAccessTokensRequired(true)
+            .build();
+
+        String json = jsonMapper.writeValueAsString(metadata);
+        Map<String, Object> root = jsonMapper.readValue(json.getBytes(StandardCharsets.UTF_8), Argument.mapOf(String.class, Object.class));
+
+        // Presence of expected snake_case keys
+        assertTrue(root.containsKey("resource"));
+        assertTrue(root.containsKey("authorization_servers"));
+        assertTrue(root.containsKey("jwks_uri"));
+        assertTrue(root.containsKey("scopes_supported"));
+        assertTrue(root.containsKey("bearer_methods_supported"));
+        assertTrue(root.containsKey("resource_signing_alg_values_supported"));
+        assertTrue(root.containsKey("resource_name"));
+        assertTrue(root.containsKey("resource_documentation"));
+        assertTrue(root.containsKey("resource_policy_uri"));
+        assertTrue(root.containsKey("resource_tos_uri"));
+        assertTrue(root.containsKey("tls_client_certificate_bound_access_tokens"));
+        assertTrue(root.containsKey("authorization_details_types_supported"));
+        assertTrue(root.containsKey("dpop_signing_alg_values_supported"));
+        assertTrue(root.containsKey("dpop_bound_access_tokens_required"));
+
+        // Absence of camelCase keys
+        assertFalse(root.containsKey("authorizationServers"));
+        assertFalse(root.containsKey("jwksUri"));
+        assertFalse(root.containsKey("scopesSupported"));
+        assertFalse(root.containsKey("bearerMethodsSupported"));
+        assertFalse(root.containsKey("resourceSigningAlgValuesSupported"));
+        assertFalse(root.containsKey("resourceName"));
+        assertFalse(root.containsKey("resourceDocumentation"));
+        assertFalse(root.containsKey("resourcePolicyUri"));
+        assertFalse(root.containsKey("resourceTosUri"));
+        assertFalse(root.containsKey("tlsClientCertificateBoundAccessTokens"));
+        assertFalse(root.containsKey("authorizationDetailsTypesSupported"));
+        assertFalse(root.containsKey("dpopSigningAlgValuesSupported"));
+        assertFalse(root.containsKey("dpopBoundAccessTokensRequired"));
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ResourceMetadataWwwAuthenticateChallengeProviderTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/metadata/ResourceMetadataWwwAuthenticateChallengeProviderTest.java
@@ -1,0 +1,84 @@
+package io.micronaut.security.oauth2.metadata;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.annotation.Status;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourceMetadataWwwAuthenticateChallengeProviderTest {
+
+    static Stream<Object[]> wwwAuthenticateCases() {
+        return Stream.of(
+            new Object[]{"GET", "/", List.of("")},
+            new Object[]{"GET", "/foobar", List.of("", "/foobar")},
+            new Object[]{"POST", "/foobar", List.of("", "/foobar")}
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("wwwAuthenticateCases")
+    void wwwAuthenticateResourceMetadata(String method, String path, List<String> allowedSuffixes) {
+        Map<String, Object> configuration = Map.of(
+            "spec.name", "ResourceMetadataWwwAuthenticateChallengeProviderTest");
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, configuration);
+        HttpClient httpClient = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+        BlockingHttpClient client = httpClient.toBlocking();
+        try {
+            HttpRequest<?> request = switch (method) {
+                case "GET" -> HttpRequest.GET(path).accept(MediaType.TEXT_PLAIN);
+                case "POST" -> HttpRequest.POST(path, Collections.emptyMap());
+                default -> throw new IllegalArgumentException("Unsupported method: " + method);
+            };
+            HttpClientResponseException ex = assertThrows(HttpClientResponseException.class, () -> client.exchange(request));
+            String header = ex.getResponse().getHeaders().get("WWW-Authenticate");
+
+            String base = server.getURL().toString();
+            Set<String> allowed = allowedSuffixes.stream()
+                .map(suffix -> String.format("Bearer resource_metadata=\"%s/.well-known/oauth-protected-resource%s\"", base, suffix))
+                .collect(java.util.stream.Collectors.toSet());
+
+            assertTrue(allowed.contains(header), () -> "Unexpected WWW-Authenticate: " + header + ", allowed: " + allowed);
+        } finally {
+            client.close();
+            httpClient.close();
+            server.close();
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ResourceMetadataWwwAuthenticateChallengeProviderTest")
+    @Controller("/foobar")
+    static class FooBarController {
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get
+        String index() {
+            return "foobar";
+        }
+
+        @Post
+        @Status(HttpStatus.ACCEPTED)
+        void save() {
+        }
+    }
+
+}

--- a/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
+++ b/security/src/main/java/io/micronaut/security/authentication/Authenticator.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.authentication;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
@@ -56,6 +57,7 @@ import java.util.stream.Collectors;
  * @since 1.0
  * @param <T> Request Context Type
  */
+@Requires(condition = AuthenticatorCondition.class)
 @Singleton
 public class Authenticator<T> {
     private static final Logger LOG = LoggerFactory.getLogger(Authenticator.class);

--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticatorCondition.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticatorCondition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.security.authentication.provider.ReactiveAuthenticationProvider;
+
+/**
+ * Condition that evaluates to true if there is any bean of type {@link ReactiveAuthenticationProvider}, {@link io.micronaut.security.authentication.provider.AuthenticationProvider}, or {@link io.micronaut.security.authentication.AuthenticationProvider}.
+ */
+class AuthenticatorCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context) {
+        if (CollectionUtils.isNotEmpty(context.getBeansOfType(ReactiveAuthenticationProvider.class))) {
+            return true;
+        }
+        if (CollectionUtils.isNotEmpty(context.getBeansOfType(io.micronaut.security.authentication.provider.AuthenticationProvider.class))) {
+            return true;
+        }
+        if (CollectionUtils.isNotEmpty(context.getBeansOfType(io.micronaut.security.authentication.AuthenticationProvider.class))) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthAuthenticationFetcher.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Flux;
  */
 @Requires(classes = HttpRequest.class)
 @Requires(property = BasicAuthAuthenticationConfiguration.PREFIX + ".enabled", notEquals = StringUtils.FALSE)
+@Requires(beans = { Authenticator.class })
 @Singleton
 public class BasicAuthAuthenticationFetcher<B> implements AuthenticationFetcher<HttpRequest<B>> {
 

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
@@ -25,8 +25,6 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.runtime.ApplicationConfiguration;
 import jakarta.inject.Singleton;
 
-import java.nio.charset.StandardCharsets;
-
 /**
  * {@link WwwAuthenticateChallengeProvider} implementation for basic auth authentication.
  * @since 4.14.0

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpHeaderValues;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.runtime.ApplicationConfiguration;
+import jakarta.inject.Singleton;
+
+/**
+ * {@link WwwAuthenticateChallengeProvider} implementation for basic auth authentication.
+ * @since 4.14.0
+ */
+@Requires(classes = HttpRequest.class)
+@Requires(beans = { ApplicationConfiguration.class, BasicAuthAuthenticationFetcher.class })
+@Requires(property = BasicAuthAuthenticationConfiguration.PROPERTY_ENABLED, notEquals = StringUtils.FALSE)
+@Requires(property = BasicAuthAuthenticationConfiguration.PROPERTY_WWW_AUTHENTICATE, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
+@Internal
+@Singleton
+class BasicAuthWwwAuthenticateChallengeProvider implements WwwAuthenticateChallengeProvider<HttpRequest<?>> {
+    private static final String PARAM_REALM = "realm";
+    private final ApplicationConfiguration applicationConfiguration;
+
+    BasicAuthWwwAuthenticateChallengeProvider(ApplicationConfiguration applicationConfiguration) {
+        this.applicationConfiguration = applicationConfiguration;
+    }
+
+    @Override
+    @NonNull
+    public String getWwwAuthenticateChallenge(@Nullable HttpRequest<?> request) {
+        WwwAuthenticateChallenge.Builder builder = WwwAuthenticateChallenge.builder()
+            .authScheme(HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC);
+        applicationConfiguration.getName().ifPresent(name -> builder.param(PARAM_REALM, name));
+        return builder.build().toString();
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/BasicAuthWwwAuthenticateChallengeProvider.java
@@ -25,6 +25,8 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.runtime.ApplicationConfiguration;
 import jakarta.inject.Singleton;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * {@link WwwAuthenticateChallengeProvider} implementation for basic auth authentication.
  * @since 4.14.0
@@ -37,6 +39,8 @@ import jakarta.inject.Singleton;
 @Singleton
 class BasicAuthWwwAuthenticateChallengeProvider implements WwwAuthenticateChallengeProvider<HttpRequest<?>> {
     private static final String PARAM_REALM = "realm";
+    private static final String PARAM_NAME_CHARSET = "charset";
+    private static final String UTF_8 = "UTF-8";
     private final ApplicationConfiguration applicationConfiguration;
 
     BasicAuthWwwAuthenticateChallengeProvider(ApplicationConfiguration applicationConfiguration) {
@@ -47,7 +51,8 @@ class BasicAuthWwwAuthenticateChallengeProvider implements WwwAuthenticateChalle
     @NonNull
     public String getWwwAuthenticateChallenge(@Nullable HttpRequest<?> request) {
         WwwAuthenticateChallenge.Builder builder = WwwAuthenticateChallenge.builder()
-            .authScheme(HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC);
+            .authScheme(HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC)
+            .param(PARAM_NAME_CHARSET, UTF_8);
         applicationConfiguration.getName().ifPresent(name -> builder.param(PARAM_REALM, name));
         return builder.build().toString();
     }

--- a/security/src/main/java/io/micronaut/security/authentication/DefaultAuthorizationExceptionHandler.java
+++ b/security/src/main/java/io/micronaut/security/authentication/DefaultAuthorizationExceptionHandler.java
@@ -17,6 +17,8 @@ package io.micronaut.security.authentication;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -28,9 +30,13 @@ import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
 import io.micronaut.security.config.RedirectConfiguration;
 import io.micronaut.security.config.RedirectService;
 import io.micronaut.security.errors.PriorToLoginPersistence;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +51,12 @@ import org.slf4j.LoggerFactory;
 public class DefaultAuthorizationExceptionHandler implements ExceptionHandler<AuthorizationException, MutableHttpResponse<?>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultAuthorizationExceptionHandler.class);
+    private static final String COMMA_SPACE = ", ";
 
     private final ErrorResponseProcessor<?> errorResponseProcessor;
 
     private final RedirectConfiguration redirectConfiguration;
+    private final List<WwwAuthenticateChallengeProvider<HttpRequest<?>>> wwwAuthenticateChallengeProviders;
 
     private final RedirectService redirectService;
     private final PriorToLoginPersistence priorToLoginPersistence;
@@ -57,16 +65,35 @@ public class DefaultAuthorizationExceptionHandler implements ExceptionHandler<Au
      * @param errorResponseProcessor ErrorResponse processor API
      * @param redirectConfiguration Redirect configuration
      * @param redirectService Redirection Service
+     * @param wwwAuthenticateChallengeProviders  WWW-Authenticate Challenges
      * @param priorToLoginPersistence Persistence mechanism to redirect to prior login url
      */
+    @Inject
     public DefaultAuthorizationExceptionHandler(ErrorResponseProcessor<?> errorResponseProcessor,
                                                 RedirectConfiguration redirectConfiguration,
                                                 RedirectService redirectService,
+                                                List<WwwAuthenticateChallengeProvider<HttpRequest<?>>> wwwAuthenticateChallengeProviders,
                                                 @Nullable PriorToLoginPersistence priorToLoginPersistence) {
         this.errorResponseProcessor = errorResponseProcessor;
         this.redirectConfiguration = redirectConfiguration;
         this.redirectService = redirectService;
         this.priorToLoginPersistence = priorToLoginPersistence;
+        this.wwwAuthenticateChallengeProviders = wwwAuthenticateChallengeProviders;
+    }
+
+    /**
+     * @param errorResponseProcessor ErrorResponse processor API
+     * @param redirectConfiguration Redirect configuration
+     * @param redirectService Redirection Service
+     * @param priorToLoginPersistence Persistence mechanism to redirect to prior login url
+     * @deprecated Use {@link DefaultAuthorizationExceptionHandler(ErrorResponseProcessor, RedirectConfiguration, RedirectService, List, PriorToLoginPersistence)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "4.14.0")
+    public DefaultAuthorizationExceptionHandler(ErrorResponseProcessor<?> errorResponseProcessor,
+                                                RedirectConfiguration redirectConfiguration,
+                                                RedirectService redirectService,
+                                                @Nullable PriorToLoginPersistence priorToLoginPersistence) {
+        this(errorResponseProcessor, redirectConfiguration, redirectService, Collections.emptyList(), priorToLoginPersistence);
     }
 
     @Override
@@ -100,10 +127,17 @@ public class DefaultAuthorizationExceptionHandler implements ExceptionHandler<Au
      */
     protected MutableHttpResponse<?> httpResponseWithStatus(HttpRequest<?> request, AuthorizationException exception) {
         HttpStatus status = exception.isForbidden() ? HttpStatus.FORBIDDEN : HttpStatus.UNAUTHORIZED;
+        MutableHttpResponse<?> response = HttpResponse.status(status);
+        if (CollectionUtils.isNotEmpty(wwwAuthenticateChallengeProviders)) {
+            response.header(HttpHeaders.WWW_AUTHENTICATE,
+                String.join(COMMA_SPACE, wwwAuthenticateChallengeProviders.stream()
+                    .map(provider -> provider.getWwwAuthenticateChallenge(request))
+                    .toList()));
+        }
         return errorResponseProcessor.processResponse(ErrorContext.builder(request)
             .cause(exception)
             .errorMessage(status.getReason())
-            .build(), HttpResponse.status(status));
+            .build(), response);
     }
 
     /**

--- a/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallenge.java
+++ b/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallenge.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 
 /**
  *
+ * This is a helper class to create a challenge, the value of a WWW-Authenticate response header as described in WWW-Authenticate.
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-11.6.1">RFC 9110 WWW-Authenticate</a>
  * @param authScheme Authentication Schema
  * @param authParameters Authentication Parameters
  * @since 4.14.0

--- a/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallenge.java
+++ b/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallenge.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.List;
+import java.util.LinkedHashMap;
+
+/**
+ *
+ * @param authScheme Authentication Schema
+ * @param authParameters Authentication Parameters
+ * @since 4.14.0
+ */
+public record WwwAuthenticateChallenge(
+    @NonNull String authScheme,
+    @NonNull Map<String, Object> authParameters) {
+    private static final String SPACE = " ";
+    private static final String EQUAL = "=";
+    private static final String COMMA = ",";
+    private static final String DOUBLE_QUOTE = "\"";
+
+    @NonNull
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(authScheme);
+        if (CollectionUtils.isNotEmpty(authParameters)) {
+            sb.append(SPACE);
+            List<String> params = new ArrayList<>(authParameters.size());
+            for (Map.Entry<String, Object> entry : authParameters.entrySet()) {
+                Object v = entry.getValue();
+                if (v instanceof String s) {
+                    params.add(entry.getKey() + EQUAL + DOUBLE_QUOTE + escape(s) + DOUBLE_QUOTE);
+                } else {
+                    params.add(entry.getKey() + EQUAL + v);
+                }
+            }
+            sb.append(String.join(COMMA + SPACE, params));
+        }
+        return sb.toString();
+    }
+
+    private static String escape(String v) {
+        StringBuilder out = new StringBuilder(v.length() + 8);
+        for (int i = 0; i < v.length(); i++) {
+            char c = v.charAt(i);
+            if (c == '"' || c == '\\') {
+                out.append('\\');
+            }
+            out.append(c);
+        }
+        return out.toString();
+    }
+
+    /**
+     * Create a new builder.
+     * @return Builder
+     */
+    @NonNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link WwwAuthenticateChallenge}.
+     */
+    public static final class Builder {
+        private String authScheme;
+        private LinkedHashMap<String, Object> authParameters;
+
+        /**
+         * Set the authentication scheme.
+         * @param authScheme The scheme, e.g. Basic, Bearer
+         * @return this builder
+         */
+        @NonNull
+        public Builder authScheme(@NonNull String authScheme) {
+            this.authScheme = authScheme;
+            return this;
+        }
+
+        /**
+         * Add or replace a parameter.
+         * @param name Parameter name
+         * @param value Parameter value
+         * @return this builder
+         */
+        @NonNull
+        public Builder param(@NonNull String name, @NonNull Object value) {
+            if (this.authParameters == null) {
+                this.authParameters = new LinkedHashMap<>();
+            }
+            this.authParameters.put(name, value);
+            return this;
+        }
+
+        /**
+         * Build the challenge instance.
+         * @return A new {@link WwwAuthenticateChallenge}
+         */
+        @NonNull
+        public WwwAuthenticateChallenge build() {
+            return new WwwAuthenticateChallenge(authScheme, authParameters);
+        }
+    }
+}

--- a/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallengeProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallengeProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.authentication;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * API to provide WWW-Authenticate Response Header Challenges.
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-11.6.1">RFC 9110 WWW-Authenticate</a>
+ * @since 4.14.0
+ */
+@Experimental
+@FunctionalInterface
+public interface WwwAuthenticateChallengeProvider<T> {
+    /**
+     *
+     * @param request The Request
+     * @return The WWW-Authenticate response header challenge
+     */
+    @NonNull
+    String getWwwAuthenticateChallenge(@Nullable T request);
+}

--- a/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallengeProvider.java
+++ b/security/src/main/java/io/micronaut/security/authentication/WwwAuthenticateChallengeProvider.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.Nullable;
  * API to provide WWW-Authenticate Response Header Challenges.
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc9110#section-11.6.1">RFC 9110 WWW-Authenticate</a>
  * @since 4.14.0
+ * @param <T> Request Type
  */
 @Experimental
 @FunctionalInterface

--- a/security/src/test/groovy/io/micronaut/docs/security/token/basicauth/BasicAuthSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/token/basicauth/BasicAuthSpec.groovy
@@ -5,7 +5,9 @@ import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.inject.ExecutableMethod
 import io.micronaut.management.endpoint.EndpointSensitivityProcessor
 import io.micronaut.runtime.server.EmbeddedServer
@@ -24,6 +26,7 @@ class BasicAuthSpec extends Specification implements YamlAsciidocTagCleaner {
 
     @Shared
     Map<String, Object> config = [
+            "micronaut.application.name": "demo",
             'spec.name' : 'docsbasicauth',
             'endpoints.beans.enabled'                 : true,
             'endpoints.beans.sensitive'               : true,
@@ -38,9 +41,19 @@ class BasicAuthSpec extends Specification implements YamlAsciidocTagCleaner {
     HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
 
     void "test /beans is secured but accesible if you supply valid credentials with Basic Auth"() {
+        given:
+        BlockingHttpClient httpClient = client.toBlocking()
+
+        when:
+        httpClient.exchange(HttpRequest.GET("/beans"))
+
+        then:
+        HttpClientResponseException e = thrown()
+        'Basic realm="demo"' == e.response.headers.get("WWW-Authenticate")
+
         when:
         String token = 'dXNlcjpwYXNzd29yZA==' // user:passsword Base64
-        client.toBlocking().exchange(HttpRequest.GET("/beans")
+        httpClient.exchange(HttpRequest.GET("/beans")
                 .header("Authorization", "Basic ${token}".toString()), String)
 
         then:

--- a/security/src/test/groovy/io/micronaut/docs/security/token/basicauth/BasicAuthSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/docs/security/token/basicauth/BasicAuthSpec.groovy
@@ -49,7 +49,7 @@ class BasicAuthSpec extends Specification implements YamlAsciidocTagCleaner {
 
         then:
         HttpClientResponseException e = thrown()
-        'Basic realm="demo"' == e.response.headers.get("WWW-Authenticate")
+        'Basic charset="UTF-8", realm="demo"' == e.response.headers.get("WWW-Authenticate")
 
         when:
         String token = 'dXNlcjpwYXNzd29yZA==' // user:passsword Base64

--- a/security/src/test/groovy/io/micronaut/security/authentication/BasicAuthAuthenticationFetcherSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authentication/BasicAuthAuthenticationFetcherSpec.groovy
@@ -1,11 +1,29 @@
 package io.micronaut.security.authentication
 
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.security.authentication.provider.HttpRequestAuthenticationProvider
 import io.micronaut.security.testutils.ApplicationContextSpecification
+import jakarta.inject.Singleton
 
 class BasicAuthAuthenticationFetcherSpec extends ApplicationContextSpecification {
+
+    @Override
+    String getSpecName() {
+        return "BasicAuthAuthenticationFetcherSpec"
+    }
 
     void "by default BasicAuthAuthenticationFetcher exists"() {
         expect:
         applicationContext.containsBean(BasicAuthAuthenticationFetcher)
+    }
+
+    @Requires(property = "spec.name", value = "BasicAuthAuthenticationFetcherSpec")
+    @Singleton
+    static class CustomAuthenticationProvider<B> implements HttpRequestAuthenticationProvider<B> {
+        @Override
+        AuthenticationResponse authenticate(HttpRequest<B> requestContext, AuthenticationRequest<String, String> authRequest) {
+            return AuthenticationResponse.success("sherlock");
+        }
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/endpoints/LoginControllerValidationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/endpoints/LoginControllerValidationSpec.groovy
@@ -8,8 +8,10 @@ import io.micronaut.http.HttpStatus
 import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.authentication.AuthenticationRequest
 import io.micronaut.security.authentication.AuthenticationResponse
 import io.micronaut.security.authentication.UsernamePasswordCredentials
+import io.micronaut.security.authentication.provider.HttpRequestAuthenticationProvider
 import io.micronaut.security.handlers.LoginHandler
 import io.micronaut.security.testutils.EmbeddedServerSpecification
 import jakarta.inject.Singleton
@@ -60,6 +62,15 @@ class LoginControllerValidationSpec extends EmbeddedServerSpecification {
         ''       | 'aabbc12345678'
         'johnny' | null
         'johnny' | ''
+    }
+
+    @Requires(property = "spec.name", value = "LoginControllerValidationSpec")
+    @Singleton
+    static class CustomAuthenticationProvider<B> implements HttpRequestAuthenticationProvider<B> {
+        @Override
+        AuthenticationResponse authenticate(HttpRequest<B> requestContext, AuthenticationRequest<String, String> authRequest) {
+            return AuthenticationResponse.success("sherlock");
+        }
     }
 
     @Requires(property = 'spec.name', value = 'LoginControllerValidationSpec')

--- a/security/src/test/groovy/io/micronaut/security/token/basicauth/BasicAuthTokenValidatorSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/token/basicauth/BasicAuthTokenValidatorSpec.groovy
@@ -1,15 +1,20 @@
 package io.micronaut.security.token.basicauth
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.security.authentication.AuthenticationRequest
+import io.micronaut.security.authentication.AuthenticationResponse
 import io.micronaut.security.authentication.BasicAuthAuthenticationFetcher
+import io.micronaut.security.authentication.provider.HttpRequestAuthenticationProvider
+import jakarta.inject.Singleton
 import spock.lang.Specification
 
 class BasicAuthTokenValidatorSpec extends Specification {
-
+    private static final Map<String, String> CONFIGURATION = Map.of("spec.name", "BasicAuthTokenValidatorSpec");
     def "BasicAuthTokenValidator is loaded because by default security is turn on"() {
         given:
-        ApplicationContext applicationContext = ApplicationContext.run()
-
+        ApplicationContext applicationContext = ApplicationContext.run(CONFIGURATION)
         expect:
         applicationContext.containsBean(BasicAuthAuthenticationFetcher)
 
@@ -19,7 +24,7 @@ class BasicAuthTokenValidatorSpec extends Specification {
 
     def "BasicAuthTokenValidator not loaded if micronaut.security.enabled=false"() {
         given:
-        ApplicationContext applicationContext = ApplicationContext.run(['micronaut.security.enabled': false])
+        ApplicationContext applicationContext = ApplicationContext.run(['micronaut.security.enabled': false] + CONFIGURATION)
 
         expect:
         !applicationContext.containsBean(BasicAuthAuthenticationFetcher)
@@ -30,7 +35,7 @@ class BasicAuthTokenValidatorSpec extends Specification {
 
     def "BasicAuthTokenValidator is loaded by default"() {
         given:
-        ApplicationContext applicationContext = ApplicationContext.run([:])
+        ApplicationContext applicationContext = ApplicationContext.run(CONFIGURATION)
 
         expect:
         applicationContext.containsBean(BasicAuthAuthenticationFetcher)
@@ -43,12 +48,21 @@ class BasicAuthTokenValidatorSpec extends Specification {
         given:
         ApplicationContext applicationContext = ApplicationContext.run([
                 'micronaut.security.basic-auth.enabled': false
-        ])
+        ] + CONFIGURATION)
 
         expect:
         !applicationContext.containsBean(BasicAuthAuthenticationFetcher)
 
         cleanup:
         applicationContext.close()
+    }
+
+    @Requires(property = "spec.name", value = "BasicAuthTokenValidatorSpec")
+    @Singleton
+    static class CustomAuthenticationProvider<B> implements HttpRequestAuthenticationProvider<B> {
+        @Override
+        public AuthenticationResponse authenticate(HttpRequest<B> requestContext, AuthenticationRequest<String, String> authRequest) {
+            return AuthenticationResponse.success("sherlock");
+        }
     }
 }

--- a/security/src/test/java/io/micronaut/security/authentication/WwwAuthenticateChallengeTest.java
+++ b/security/src/test/java/io/micronaut/security/authentication/WwwAuthenticateChallengeTest.java
@@ -1,0 +1,31 @@
+package io.micronaut.security.authentication;
+
+import io.micronaut.http.HttpHeaderValues;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WwwAuthenticateChallengeTest {
+
+    @Test
+    void wwwAuthenticateChallengetoString() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("realm", "myapp");
+        m.put("charset", "UTF-8");
+        String value = new WwwAuthenticateChallenge(HttpHeaderValues.AUTHORIZATION_PREFIX_BASIC, m).toString();
+        assertEquals("Basic realm=\"myapp\", charset=\"UTF-8\"", value);
+        assertEquals(
+            "Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"\"",
+            WwwAuthenticateChallenge.builder()
+                .authScheme("Newauth")
+                .param("realm", "apps")
+                .param("type", 1)
+                .param("title", "Login to \"apps\"")
+                .build()
+                .toString()
+        );
+    }
+}

--- a/src/main/docs/guide/authenticationStrategies/basicAuth.adoc
+++ b/src/main/docs/guide/authenticationStrategies/basicAuth.adoc
@@ -1,4 +1,6 @@
-Out-of-the-box, Micronaut supports https://tools.ietf.org/html/rfc7617[RFC7617] which defines the "Basic" Hypertext Transfer Protocol (HTTP) authentication scheme, which transmits credentials as user-id/password pairs, encoded using Base64. Basic authentication is enabled by default. You can disable it by setting `micronaut.security.basic-auth.enabled` to `false`.  
+Out-of-the-box, Micronaut supports https://tools.ietf.org/html/rfc7617[RFC7617] which defines the "Basic" Hypertext Transfer Protocol (HTTP) authentication scheme, which transmits credentials as user-id/password pairs, encoded using Base64.
+
+Basic authentication is enabled by default if you have any <<authenticationProviders, Authentication Provider>>. You can disable it by setting `micronaut.security.basic-auth.enabled` to `false`.
 
 The following sequence illustrates the authentication flow:
 

--- a/src/main/docs/guide/oauth/oauth-endpoints/protectedResourceMetadata.adoc
+++ b/src/main/docs/guide/oauth/oauth-endpoints/protectedResourceMetadata.adoc
@@ -1,0 +1,12 @@
+____
+https://datatracker.ietf.org/doc/html/rfc9728[RFC 9728] metadata format that an OAuth 2.0 client or authorization server can use to obtain the information needed to interact with an OAuth 2.0 protected resource.
+____
+
+You can configure whether to expose the protected resource metadata:
+
+include::{includedir}configurationProperties/io.micronaut.security.oauth2.metadata.ProtectedResourceMetadataConfigurationProperties.adoc[]
+
+A GET endpoint is exposed in `/.well-known/oauth-protected-resource`. The API to control the metadata is:
+api:security.oauth2.metadata.ProtectedResourceMetadataProvider[]
+
+You can create a bean replacement for it if the default implementation does not fit your needs.

--- a/src/main/docs/guide/rejection/wwwAuthenticate.adoc
+++ b/src/main/docs/guide/rejection/wwwAuthenticate.adoc
@@ -1,0 +1,9 @@
+____
+The HTTP WWW-Authenticate response header advertises the HTTP authentication methods (or challenges) that might be used to gain access to a specific resource.
+____
+
+If any bean of type api:security.authentication.WwwAuthenticateChallengeProvider[] is available, Micronaut Security uses them to populate the `WWW-Authenticate` header when a 401 Unauthorized response is returned.
+
+If you have <<basicAuth, basic auth> enabled, an entry for "Basic" authentication scheme is added by default. You can disable it setting `micronaut.security.basic-auth.www-authenticate` to `false`.
+
+If you have <<protectedResourceMetadata, Resource Metadata> enabled, an entry as defined in the https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response[WWW-Authenticate Response] section of RFC9728 is added

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -87,7 +87,9 @@ authenticationStrategies:
     extending: Extending Default Behavior
   x509: X.509 Certificate Authentication
   custom: Custom Authorization Strategies
-rejection: Rejection Handling
+rejection:
+  title: Rejection Handling
+  wwwAuthenticate: WWW-Authenticate Response
 csrf:
   title: Cross-Site Request Forgery (CSRF)
   csrfDependency: CSRF Dependency
@@ -157,6 +159,7 @@ oauth:
     introspection: Introspection
     revocation: Revocation
     user-info: OpenID User Info
+    protectedResourceMetadata: Protected Resource Metadata
   custom-client: Custom Clients
   oauthGuides: Guides
 aot:

--- a/test-suite-hibernate-validator/src/test/java/io/micronaut/security/jacksondatabind/beanintrospectionfalse/LoginControllerValidationTest.java
+++ b/test-suite-hibernate-validator/src/test/java/io/micronaut/security/jacksondatabind/beanintrospectionfalse/LoginControllerValidationTest.java
@@ -12,8 +12,10 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.AuthenticationRequest;
 import io.micronaut.security.authentication.AuthenticationResponse;
 import io.micronaut.security.authentication.UsernamePasswordCredentials;
+import io.micronaut.security.authentication.provider.HttpRequestAuthenticationProvider;
 import io.micronaut.security.handlers.LoginHandler;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
@@ -75,6 +77,14 @@ class LoginControllerValidationTest {
             assertTrue(jsonError.contains("must not be blank") || jsonError.contains("must not be null"));
     }
 
+    @Requires(property = "spec.name", value = "LoginControllerValidationTest")
+    @Singleton
+    static class CustomAuthenticationProvider<B> implements HttpRequestAuthenticationProvider<B> {
+        @Override
+        public AuthenticationResponse authenticate(HttpRequest<B> requestContext, AuthenticationRequest<String, String> authRequest) {
+            return AuthenticationResponse.success("sherlock");
+        }
+    }
 
     @Requires(property = "spec.name", value = "LoginControllerValidationTest")
     @Singleton


### PR DESCRIPTION
- It adds [JSONAssert](https://github.com/skyscreamer/JSONassert) to simplify JSON assertions. 
- Adds [WWW-Authenticate response header]( https://datatracker.ietf.org/doc/html/rfc9110#section-11.6.19) support.
- Adds [protected resource metadata](https://datatracker.ietf.org/doc/html/rfc9728)
- Adds  `AuthenticatorCondition` - a condition that evaluates to true if there is any bean of type ` ReactiveAuthenticationProvider`, `io.micronaut.security.authentication.provider.AuthenticationProvider`, or `io.micronaut.security.authentication.AuthenticationProvider`. This ensures Basic authentication related beans are not loaded unless there is a backing authentication provider. 

These changes are necessary to support [MCP Server Authentication](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#standards-compliance). 