### PR TITLE
feat: allow define the authorization-server via config

### DIFF
--- a/security-oauth2/build.gradle.kts
+++ b/security-oauth2/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(platform(mnTest.boms.junit))
     testImplementation(libs.junit.jupiter.params)
+    testImplementation(mnTest.mockito.core)
 }
 tasks.withType<Test> {
     useJUnitPlatform()

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
@@ -129,7 +129,7 @@ public interface OauthClientConfiguration extends Toggleable {
     }
 
     /**
-     * @return The {@link AuthorizationServer} used by the OpenID Client.
+     * @return The {@link AuthorizationServer} used by the OAuth Client.
      * @since 4.15.0
      */
     @Nullable

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
@@ -26,6 +26,7 @@ import io.micronaut.security.oauth2.endpoint.AuthenticationMethod;
 import io.micronaut.security.oauth2.endpoint.AuthenticationMethods;
 import io.micronaut.security.oauth2.endpoint.DefaultSecureEndpoint;
 import io.micronaut.security.oauth2.endpoint.SecureEndpoint;
+import io.micronaut.security.oauth2.endpoint.endsession.request.AuthorizationServer;
 import io.micronaut.security.oauth2.grants.GrantType;
 import java.time.Duration;
 import java.util.List;
@@ -38,7 +39,6 @@ import java.util.Optional;
  * @since 1.2.0
  */
 public interface OauthClientConfiguration extends Toggleable {
-
     /**
      * @deprecated Use {@link OauthClientConfiguration#DEFAULT_AUTH_METHOD} instead.
      */
@@ -126,5 +126,14 @@ public interface OauthClientConfiguration extends Toggleable {
     default SecureEndpoint getTokenEndpoint() throws ConfigurationException {
         return getToken().map(secureEndpointConfiguration -> new DefaultSecureEndpoint(secureEndpointConfiguration, DEFAULT_AUTH_METHOD))
                 .orElseThrow(() -> new ConfigurationException("Oauth client "  + getName() + " requires the token endpoint configuration to be set in configuration"));
+    }
+
+    /**
+     * @return The {@link AuthorizationServer} used by the OpenID Client.
+     * @since 4.15.0
+     */
+    @Nullable
+    default AuthorizationServer getAuthorizationServer() {
+        return null;
     }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -32,6 +32,7 @@ import io.micronaut.security.oauth2.endpoint.authorization.request.Display;
 import io.micronaut.security.oauth2.endpoint.authorization.request.OpenIdScope;
 import io.micronaut.security.oauth2.endpoint.authorization.request.Prompt;
 import io.micronaut.security.oauth2.endpoint.authorization.request.ResponseType;
+import io.micronaut.security.oauth2.endpoint.endsession.request.AuthorizationServer;
 import io.micronaut.security.oauth2.grants.GrantType;
 import io.micronaut.security.token.propagation.AbstractOutgoingRequestProcessorMatcher;
 
@@ -73,12 +74,28 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
     private RevocationEndpointConfigurationProperties revocation;
     private OpenIdClientConfigurationProperties openid;
     private ClientCredentialsConfigurationProperties clientCredentials;
+    private AuthorizationServer authorizationServer;
 
     /**
      * @param name The provider name
      */
     public OauthClientConfigurationProperties(@Parameter String name) {
         this.name = name;
+    }
+
+    /**
+     * Micronaut attempts to infer the authorization server used by the client based on the issuer. However, if you are using a custom domain, it may be impossible to infer it.
+     * You can set it explicitly via this property.
+     * @param authorizationServer The authorization server
+     */
+    public void setAuthorizationServer(@Nullable AuthorizationServer authorizationServer) {
+        this.authorizationServer = authorizationServer;
+    }
+
+    @Override
+    @Nullable
+    public AuthorizationServer getAuthorizationServer() {
+        return authorizationServer;
     }
 
     @NonNull

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/EndSessionEndpointResolver.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/EndSessionEndpointResolver.java
@@ -17,6 +17,7 @@ package io.micronaut.security.oauth2.endpoint.endsession.request;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.security.config.SecurityConfiguration;
 import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
@@ -127,20 +128,31 @@ public class EndSessionEndpointResolver {
         return getEndSessionEndpoint(oauthClientConfiguration, openIdProviderMetadata, endSessionCallbackUrlBuilder, providerName, issuer);
     }
 
+    @Nullable
+    static AuthorizationServer authorizationServer(@NonNull AuthorizationServerResolver authorizationServerResolver,
+                                                   @NonNull OauthClientConfiguration oauthClientConfiguration,
+                                                   @NonNull String issuer) {
+        AuthorizationServer authorizationServer = oauthClientConfiguration.getAuthorizationServer();
+        if (authorizationServer == null) {
+            return authorizationServerResolver.resolve(issuer).orElse(null);
+        }
+        return authorizationServer;
+    }
+
     @NonNull
     private Optional<EndSessionEndpoint> getEndSessionEndpoint(OauthClientConfiguration oauthClientConfiguration,
                                                                Supplier<OpenIdProviderMetadata> openIdProviderMetadata,
                                                                EndSessionCallbackUrlBuilder endSessionCallbackUrlBuilder,
                                                                @NonNull String providerName,
                                                                @NonNull String issuer) {
-        Optional<AuthorizationServer> inferOptional = authorizationServerResolver.resolve(issuer);
-        if (!inferOptional.isPresent()) {
+        AuthorizationServer authorizationServer = authorizationServer(authorizationServerResolver, oauthClientConfiguration, issuer);
+        if (authorizationServer == null) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("No EndSessionEndpoint can be resolved. The issuer for provider [{}] does not match any of the providers supported by default", providerName);
+                LOG.debug("No EndSessionEndpoint can be resolved. no authorization-server is set for [{}] and the issuer does not match any of the providers supported by default", providerName);
             }
             return Optional.empty();
         }
-        switch (inferOptional.get()) {
+        switch (authorizationServer) {
             case MICROSOFT:
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Resolved the MicrosoftEndSessionEndpoint for provider [{}]", providerName);
@@ -150,7 +162,7 @@ public class EndSessionEndpointResolver {
             //  Oracle Cloud Logout https://docs.oracle.com/en/cloud/paas/identity-cloud/rest-api/op-oauth2-v1-userlogout-get.html
             case ORACLE_CLOUD, OKTA:
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Resolved auth server {} for provider [{}]", inferOptional.get(), providerName);
+                    LOG.debug("Resolved auth server {} for provider [{}]", authorizationServer, providerName);
                 }
                 return oktaEndSessionEndpoint(oauthClientConfiguration, openIdProviderMetadata, endSessionCallbackUrlBuilder);
             case COGNITO:

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
@@ -33,6 +33,10 @@ class OauthClientConfigurationTest {
     @Named("stravanew")
     OauthClientConfiguration stravaNewConfiguration;
 
+    @Test
+    void authorizationServerDefaultsToNull() {
+        assertNull(stravaNewConfiguration.getAuthorizationServer());
+    }
 
     @Test
     void deprecatedAuthMethodConfigurationIsStillSupported() {

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/endsession/request/EndSessionEndpointResolverAuthorizationServerTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/endsession/request/EndSessionEndpointResolverAuthorizationServerTest.java
@@ -1,0 +1,62 @@
+package io.micronaut.security.oauth2.endpoint.endsession.request;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Property(name = "micronaut.security.oauth2.clients.myauthserver.authorization-server", value = "KEYCLOAK")
+@MicronautTest(startApplication = false)
+class EndSessionEndpointResolverAuthorizationServerTest {
+
+    @Test
+    void returnsConfiguredAuthorizationServerWhenSetViaConfiguration(AuthorizationServerResolver resolver, OauthClientConfiguration config) {
+        AuthorizationServer result = EndSessionEndpointResolver.authorizationServer(
+            resolver,
+            config,
+            "https://micronautguides.eu.auth0.com"
+        );
+        assertEquals(AuthorizationServer.KEYCLOAK, result);
+        assertEquals(AuthorizationServer.KEYCLOAK, config.getAuthorizationServer());
+    }
+
+
+    @Test
+    void returnsConfiguredAuthorizationServerWhenPresent(AuthorizationServerResolver resolver) {
+        OauthClientConfiguration config = mock(OauthClientConfiguration.class);
+        when(config.getAuthorizationServer()).thenReturn(AuthorizationServer.KEYCLOAK);
+        AuthorizationServer result = EndSessionEndpointResolver.authorizationServer(
+            resolver,
+            config,
+            "https://micronautguides.eu.auth0.com"
+        );
+        assertEquals(AuthorizationServer.KEYCLOAK, result);
+    }
+
+    @Test
+    void resolvesAuthorizationServerViaResolverWhenNotConfigured(AuthorizationServerResolver resolver) {
+        OauthClientConfiguration config = mock(OauthClientConfiguration.class);
+        when(config.getAuthorizationServer()).thenReturn(null);
+        AuthorizationServer result = EndSessionEndpointResolver.authorizationServer(
+            resolver,
+            config,
+            "https://micronautguides.eu.auth0.com"
+        );
+        assertEquals(AuthorizationServer.AUTH0, result);
+    }
+
+    @Test
+    void returnsNullWhenResolverDoesNotResolveAnything(AuthorizationServerResolver resolver) {
+        OauthClientConfiguration config = mock(OauthClientConfiguration.class);
+        when(config.getAuthorizationServer()).thenReturn(null);
+        AuthorizationServer result = EndSessionEndpointResolver.authorizationServer(
+            resolver,
+            config,
+            "https://auth.micronautguides.com"
+        );
+        assertNull(result);
+    }
+}

--- a/src/main/docs/guide/oauth/oauth-endpoints/endsession.adoc
+++ b/src/main/docs/guide/oauth/oauth-endpoints/endsession.adoc
@@ -15,6 +15,8 @@ IMPORTANT: The `get-allowed` configuration option must be set to `true` because 
 
 This library supports end session for Auth0, AWS Cognito, and Okta out of the box. The api:security.oauth2.endpoint.endsession.request.EndSessionEndpointResolver[] is responsible for determining which api:security.oauth2.endpoint.endsession.request.EndSessionEndpoint[] will be used for a given provider, if any.
 
+WARNING: If you are using a custom domain URL for your auth server, instead of inferring it, you can set the authorization server you use by setting the property `micronaut.security.oauth2.clients.*.authorization-server`.
+
 Before choosing any of the default providers, the endpoint resolver will first look for an api:security.oauth2.endpoint.endsession.request.EndSessionEndpoint[] bean with a named qualifier that matches the name of the client in configuration. If no bean is found then the default endpoints will be matched against the issuer URL.
 
 If for example you are using one of the providers that is supported out of the box and you don't want the end session support, it is possible to disable it per client.


### PR DESCRIPTION
If you are using a custom domain for your authorization server, a feature common in providers such as Auth0, it is not possible to infer it. This PR allows users to set it explicitly.