### PR TITLE
Change nimbus-jose-jwt version  (CVE-2025-53864)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-managed-nimbus-jose-jwt = "9.41.2"
+managed-nimbus-jose-jwt = "9.37.4"
 managed-jjwt = "0.12.6"
 
 micronaut = "4.7.5"


### PR DESCRIPTION
change nimbus-jose-jwt version to address [GHSA-xwmg-2g98-w7v9](https://github.com/advisories/GHSA-xwmg-2g98-w7v9) and [CVE-2025-53864](https://nvd.nist.gov/vuln/detail/CVE-2025-53864)