### PR TITLE
Fix asymmetric serialization in JacksonStateSerDes

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDes.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDes.java
@@ -61,7 +61,7 @@ public class JacksonStateSerDes implements StateSerDes {
     @Override
     public String serialize(State state) {
         try {
-            return Base64.getEncoder().encodeToString(jsonMapper.writeValueAsBytes(state));
+            return Base64.getUrlEncoder().encodeToString(jsonMapper.writeValueAsBytes(state));
         } catch (IOException e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Failed to serialize the authorization request state to JSON", e);

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDesTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/authorization/state/JacksonStateSerDesTest.java
@@ -1,0 +1,29 @@
+package io.micronaut.security.oauth2.endpoint.authorization.state;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class JacksonStateSerDesTest {
+
+    @Inject JacksonStateSerDes serDes;
+
+    @Test
+    void testUrlSerialization() throws URISyntaxException {
+        MutableState expected = new DefaultState();
+        expected.setNonce("nonce");
+        expected.setRedirectUri(new URI("https://example.com/path?query=param"));
+
+        State deserialized = serDes.deserialize(serDes.serialize(expected));
+
+        assertEquals(expected.getNonce(), deserialized.getNonce());
+        assertEquals(expected.getRedirectUri(), deserialized.getRedirectUri());
+    }
+
+}


### PR DESCRIPTION
using the normal encoder and then the urldecoder leads to errors like "Illegal base64 character 2f" when encoding more complex urls