### PR TITLE
feat(oauth2): Support prompt=create for OIDC User Registration

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/request/Prompt.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/authorization/request/Prompt.java
@@ -28,7 +28,8 @@ public enum Prompt {
     NONE("none"),
     LOGIN("login"),
     CONSENT("consent"),
-    SELECT_ACCOUNT("select_account");
+    SELECT_ACCOUNT("select_account"),
+    CREATE("create");
 
     private String promptName;
 


### PR DESCRIPTION
### Description
This PR adds the `CREATE("create")` value to the `Prompt` enum.

### Context
According to the **[Initiating User Registration via OpenID Connect 1.0](https://openid.net/specs/openid-connect-prompt-create-1_0.html)** specification, the `prompt` parameter can accept the value `create`.

This instructs the Authorization Server to display the account creation (registration) UI instead of the login UI.

### Motivation
Modern Identity Providers, such as **Keycloak 26.1+**, now officially support `prompt=create` as the standard way to deep-link to the registration page.

Currently, Micronaut Security throws an error if users attempt to configure `prompt: create` in `application.yml` because the value is missing from the Enum. This change fixes that and allows developers to leverage standard OIDC registration flows.

### Impact
- Non-breaking change (additive only).
- Enables configuration like:
  ```yaml
  openid:
    authorization:
      prompt: create