### PR TITLE
Docs: fix typos in session authentication documentation

### DIFF
--- a/src/main/docs/guide/authenticationStrategies/session.adoc
+++ b/src/main/docs/guide/authenticationStrategies/session.adoc
@@ -10,7 +10,7 @@ $ mn create-app my-app --features security-session
 ====
 
 
-To use the Micronaut's session based authentication capabilities you must have the `security-session` dependency on your classpath. For example:
+To use the Micronaut's session based authentication capabilities, you must have the `security-session` dependency on your classpath. For example:
 
 dependency:io.micronaut.security:micronaut-security-annotations[scope='annotationProcessor']
 
@@ -31,7 +31,7 @@ Check the <<redirection, Redirection configuration>> to customize session based 
 include::{testsuitegeb}/security/session/SessionAuthenticationSpec.groovy[tag=yamlconfig,indent=0]
 ----
 
-Read the following guides to learn more abut session based authentication:
+Read the following guides to learn more about session based authentication:
 
 - https://guides.micronaut.io/latest/micronaut-security-session.html[Session-Based Authentication Micronaut Guide]
 - https://guides.micronaut.io/latest/micronaut-security-session-database-authentication.html[Database Authentication]
@@ -40,4 +40,4 @@ Read the following guides to learn more abut session based authentication:
 
 When you set `micronaut.security.authentication` to `session`, you enable api:security.session.SessionLoginHandler[] and api:security.session.SessionLogoutHandler[].
 
-These handlers return 303 responses to the urls defined in the <<redirection, Redirection Configuration>>. Disable redirection configuration with `micronaut.security.redirection.enabled=false` to respond with 200 responses instead.
+These handlers return 303 responses to the urls defined in the <<redirection, Redirection Configuration>>. Disable redirection configuration with `micronaut.security.redirect.enabled=false` to respond with 200 responses instead.


### PR DESCRIPTION
Fixes `micronaut.security.redirection.enabled` instead of `micronaut.security.redirect.enabled`