### PR TITLE
Security OAuth2: Support Keycloak >= 18 logout params via configurable provider version

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfiguration.java
@@ -147,4 +147,13 @@ public interface OauthClientConfiguration extends Toggleable {
     default boolean isProxyWellKnownOpenidConfiguration() {
         return false;
     }
+
+    /**
+     * @return The version of the provider (e.g. "18.0.0"). Used to determine feature support.
+     * @since 5.0.0
+     */
+    @Nullable
+    default String getVersion() {
+        return null;
+    }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -79,6 +79,8 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
     private boolean proxyWellKnownOauthAuthorizationServer;
     private boolean proxyWellKnownOpenidConfiguration;
 
+    private String version = "";
+
     /**
      * @param name The provider name
      */
@@ -125,6 +127,26 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
     @Nullable
     public AuthorizationServer getAuthorizationServer() {
         return authorizationServer;
+    }
+
+
+    /**
+     * Retrieves the configured version.
+     *
+     * @return the version string (e.g., "v2.0").
+     */
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Sets the version. Called by Spring Boot Binder.
+     *
+     * @param version the version string.
+     */
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     @NonNull

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/KeycloakEndSessionEndpoint.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/endsession/request/KeycloakEndSessionEndpoint.java
@@ -16,11 +16,16 @@
 package io.micronaut.security.oauth2.endpoint.endsession.request;
 
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.core.version.SemanticVersion;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.oauth2.client.OpenIdProviderMetadata;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
 import io.micronaut.security.oauth2.endpoint.endsession.response.EndSessionCallbackUrlBuilder;
+import io.micronaut.security.oauth2.endpoint.token.response.OpenIdAuthenticationMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -28,19 +33,24 @@ import java.util.function.Supplier;
 /**
  * Provides specific configuration to logout from Keycloak.
  *
- * @see <a href="https://github.com/keycloak/keycloak-documentation/blob/master/securing_apps/topics/oidc/java/logout.adoc">Keycloak Logout Endpoint</a>
- *
  * @author Lukas Moravec
+ * @author Knut Olav Bøhmer
+ * @see <a href="https://www.keycloak.org/docs/latest/server_admin/#rp-initiated-logout">Keycloak Logout Documentation</a>
  * @since 3.2.0
  */
 public class KeycloakEndSessionEndpoint extends AbstractEndSessionRequest {
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakEndSessionEndpoint.class);
     private static final String PARAM_REDIRECT_URI = "redirect_uri";
+    private static final String PARAM_POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
+    private static final String PARAM_ID_TOKEN_HINT = "id_token_hint";
+    private static final String PARAM_CLIENT_ID = "client_id";
     private static final String LOGOUT_URI = "/protocol/openid-connect/logout";
+    private static final SemanticVersion KEYCLOAK_18 = new SemanticVersion("18.0.0");
 
     /**
      * @param endSessionCallbackUrlBuilder The end session callback URL builder
-     * @param clientConfiguration The client configuration
-     * @param providerMetadata The provider metadata supplier
+     * @param clientConfiguration          The client configuration
+     * @param providerMetadata             The provider metadata supplier
      */
     public KeycloakEndSessionEndpoint(EndSessionCallbackUrlBuilder endSessionCallbackUrlBuilder,
                                       OauthClientConfiguration clientConfiguration,
@@ -52,15 +62,68 @@ public class KeycloakEndSessionEndpoint extends AbstractEndSessionRequest {
     protected String getUrl() {
         OpenIdProviderMetadata openIdProviderMetadata = providerMetadataSupplier.get();
         return openIdProviderMetadata.getEndSessionEndpoint() != null ?
-                openIdProviderMetadata.getEndSessionEndpoint() :
-                StringUtils.prependUri(openIdProviderMetadata.getIssuer(), LOGOUT_URI);
+            openIdProviderMetadata.getEndSessionEndpoint() :
+            StringUtils.prependUri(openIdProviderMetadata.getIssuer(), LOGOUT_URI);
     }
 
     @Override
     protected Map<String, Object> getArguments(HttpRequest<?> originating,
                                                Authentication authentication) {
         Map<String, Object> arguments = new HashMap<>();
-        arguments.put(PARAM_REDIRECT_URI, getRedirectUri(originating));
+        String redirectUri = getRedirectUri(originating);
+
+        populateHints(arguments, authentication);
+
+        if (isLegacyLogout()) {
+            arguments.put(PARAM_REDIRECT_URI, redirectUri);
+        } else if (StringUtils.isNotEmpty(redirectUri)) {
+            arguments.put(PARAM_POST_LOGOUT_REDIRECT_URI, redirectUri);
+        }
+
         return arguments;
+    }
+
+    /**
+     * Populates id_token_hint or client_id to ensure seamless logout.
+     */
+    private void populateHints(Map<String, Object> arguments, Authentication authentication) {
+        if (authentication == null) {
+            return;
+        }
+
+        Object idToken = authentication.getAttributes().get(OpenIdAuthenticationMapper.OPENID_TOKEN_KEY);
+
+        if (idToken != null) {
+            arguments.put(PARAM_ID_TOKEN_HINT, idToken.toString());
+        } else {
+            arguments.put(PARAM_CLIENT_ID, clientConfiguration.getClientId());
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("ID Token not found in Authentication attributes. Logout will fallback to " +
+                    "interactive confirmation. To enable seamless logout, set " +
+                    "'micronaut.security.oauth2.openid.additional-claims.jwt=true'.");
+            }
+        }
+    }
+
+    /**
+     * Determines if legacy logout (redirect_uri) should be used.
+     * Defaults to modern logout when version is missing/blank.
+     *
+     * @return true if configured version is < 18.0.0
+     */
+    private boolean isLegacyLogout() {
+        String v = clientConfiguration.getVersion();
+        if (v == null || v.isBlank()) return false;
+
+        try {
+            return new SemanticVersion(v.trim()).compareTo(KEYCLOAK_18) < 0;
+        } catch (IllegalArgumentException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Invalid Keycloak version '{}'. Expected d.d.d (semver). Falling back to modern logout.",
+                    v);
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This PR improves Keycloak RP-initiated logout handling in `KeycloakEndSessionEndpoint` by switching between legacy and modern logout parameters based on a configurable provider version.

#### What changed

- Added `OauthClientConfiguration#getVersion()` (default `null`) to represent the **provider/server version** used for feature support decisions.
    
- Implemented `version` property in `OauthClientConfigurationProperties` with getter/setter for configuration binding.
    
- Updated `KeycloakEndSessionEndpoint`:
    
    - Uses `redirect_uri` for Keycloak versions **< 18.0.0**.
        
    - Uses `post_logout_redirect_uri` for Keycloak versions **\>= 18.0.0**.
        
    - Adds `id_token_hint` if available, otherwise falls back to `client_id` and logs a debug message.
        
    - Uses Micronaut `SemanticVersion` parsing with a safe default (invalid/blank version → modern behavior).
        

#### Why

Keycloak 18 introduced/standardized `post_logout_redirect_uri` for RP-initiated logout flows, while older versions use `redirect_uri`. This change enables correct parameter usage without hardcoding assumptions in the endpoint.

#### Configuration

Example:

```yaml
micronaut:
  security:
    oauth2:
      clients:
        keycloak:
          version: "18.0.0"
```

#### Backward compatibility question

This change preserves backward compatibility with Keycloak versions prior to 18 by switching behavior based on the configured provider version.

That said, I’d like feedback on whether supporting legacy logout behavior is still desirable at all. Keycloak is a security-critical component, and older versions that require `redirect_uri` are no longer security-maintained upstream.

If Micronaut Security prefers to:

- **require modern Keycloak versions**, or
    
- **drop legacy logout support entirely**, or
    
- **support both only for a limited transition period**
    

I’m happy to adjust the implementation accordingly (including simplifying the logic and/or documentation).