### PR TITLE
Revert "test: ignore keycloack tests on CI (#2021)"

### DIFF
--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectOauthDisabledSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectOauthDisabledSpec.groovy
@@ -32,7 +32,6 @@ import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class OpenIdAuthorizationRedirectOauthDisabledSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectSpec.groovy
@@ -30,7 +30,6 @@ import spock.lang.IgnoreIf
 import java.nio.charset.StandardCharsets
 
 @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class OpenIdAuthorizationRedirectSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectWithJustOpenIdSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/OpenIdAuthorizationRedirectWithJustOpenIdSpec.groovy
@@ -22,7 +22,6 @@ import spock.lang.Requires
 import java.nio.charset.StandardCharsets
 
 @Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class OpenIdAuthorizationRedirectWithJustOpenIdSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationPkceSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationPkceSpec.groovy
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 @Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class OpenIdAuthorizationPkceSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationRedirectPkceSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationRedirectPkceSpec.groovy
@@ -31,7 +31,6 @@ import spock.lang.IgnoreIf
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
-@IgnoreIf({ env['CI'] })
 @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
 class OpenIdAuthorizationRedirectPkceSpec extends EmbeddedServerSpecification {
 

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationRedirectWithJustOpenIdPkceSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/authorization/request/pkce/OpenIdAuthorizationRedirectWithJustOpenIdPkceSpec.groovy
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 @Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class OpenIdAuthorizationRedirectWithJustOpenIdPkceSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/endsession/request/KeycloakEndSessionEndpointSpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoint/endsession/request/KeycloakEndSessionEndpointSpec.groovy
@@ -14,7 +14,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 @Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class KeycloakEndSessionEndpointSpec extends EmbeddedServerSpecification {
 
     @Override

--- a/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
+++ b/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
@@ -68,7 +68,7 @@ class AuthenticationModeIdTokenSpec extends GebSpec {
         Map<String, Object> m = ConfigurationUtils.getConfiguration('AuthenticationModeIdTokenSpec') + [
                 'micronaut.security.authentication'              : 'idtoken',
                 "micronaut.security.endpoints.logout.get-allowed": true,
-                // ADDED: Persist the ID Token so it is available for the Logout Hint
+                // Persist the ID Token so it is available for the Logout Hint
                 "micronaut.security.oauth2.openid.additional-claims.jwt": true,
         ] as Map<String, Object>
         if ((System.getProperty(Keycloak.SYS_TESTCONTAINERS) == null) || Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS))) {

--- a/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
+++ b/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/AuthenticationModeIdTokenSpec.groovy
@@ -46,7 +46,6 @@ import java.security.Principal
 import java.util.function.Supplier
 
 @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env['CI'] })
 class AuthenticationModeIdTokenSpec extends GebSpec {
     @AutoCleanup
     @Shared

--- a/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/OpenIdAuthorizationCodeSpec.groovy
+++ b/test-suite-geb/src/test/groovy/io/micronaut/security/oauth2/e2e/OpenIdAuthorizationCodeSpec.groovy
@@ -41,7 +41,6 @@ import spock.lang.Shared
 import java.security.Principal
 import java.util.function.Supplier
 
-@IgnoreIf({ env['CI'] })
 @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
 class OpenIdAuthorizationCodeSpec extends GebSpec {
 

--- a/test-suite-geb/src/test/groovy/io/micronaut/security/websockets/HomePageSpec.groovy
+++ b/test-suite-geb/src/test/groovy/io/micronaut/security/websockets/HomePageSpec.groovy
@@ -88,7 +88,6 @@ class HomePageSpec extends GebSpec {
 
     @IgnoreIf({ System.getProperty(Keycloak.SYS_TESTCONTAINERS) != null && !Boolean.valueOf(System.getProperty(Keycloak.SYS_TESTCONTAINERS)) })
     @spock.lang.Requires({ DockerClientFactory.instance().isDockerAvailable() })
-    @IgnoreIf({ env['CI'] })
     @Issue("https://github.com/micronaut-projects/micronaut-core/issues/5618")
     @Ignore
     def "check websocket connects"() {


### PR DESCRIPTION
This reverts commit 98a3c68cbd08aebc5ea5c7e8e78a4e71224f2968.