### PR TITLE
Docs: fix wrong package reference for ReactiveJwksSignature

### DIFF
--- a/src/main/docs/guide/authenticationStrategies/jwt/jwtValidation/jwks.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/jwtValidation/jwks.adoc
@@ -7,7 +7,7 @@ You can configure a remote JWKS as a signature validator:
 include::{testssecurityjwt}/jwks/JwksSpec.groovy[indent=0, tag=yamljwksconfig]
 ----
 
-The previous snippet creates a link:{api}/io/micronaut/security/token/jwt/signature/jwks/ReactiveJwksSignature.html[ReactiveJwksSignature] bean with a `awscognito` name qualifier.
+The previous snippet creates a link:{api}/io/micronaut/security/token/jwt/nimbus/ReactiveJwksSignature.html[ReactiveJwksSignature] bean with a `awscognito` name qualifier.
 
 If you have the https://docs.micronaut.io/latest/guide/#httpClient[Micronaut HTTP Client] on the classpath, then it will be used to retrieve the remote JWK Set. This allows for the configuration settings of the HTTP Client to be applied when fetching the resource. If a named service-specific client exists and the name of the service matches the name of the configured JWKS provider name, then that specific client instance will be used, otherwise a default Http Client instance (with any global configuration settings from `micronaut.http.client.*` applied) will be used. If the Micronaut HTTP Client is not on the classpath, then the implementation will fall back to the internal resource fetching mechanism of the external JWT library dependency.
 


### PR DESCRIPTION
in micronaut security docs see https://micronaut-projects.github.io/micronaut-security/latest/guide/index.html#jwks:~:text=ReactiveJwksSignature
ReactiveJwksSignature reference to wrong api reference.