### PR TITLE
fix(jwt): downgrade unused JWKS read-timeout logging

### DIFF
--- a/security-jwt/build.gradle.kts
+++ b/security-jwt/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     testImplementation(mnMultitenancy.micronaut.multitenancy)
     testImplementation(mnViews.micronaut.views.velocity)
     testRuntimeOnly(mnViews.velocity.engine.core)
-    testRuntimeOnly(mnLogging.logback.classic)
+    testImplementation(mnLogging.logback.classic)
 
     testImplementation(mn.snakeyaml)
     testImplementation(mn.micronaut.websocket)

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/NimbusReactiveJsonWebTokenSignatureValidator.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/nimbus/NimbusReactiveJsonWebTokenSignatureValidator.java
@@ -22,10 +22,12 @@ import io.micronaut.core.async.annotation.SingleResult;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.security.token.jwt.signature.ReactiveSignatureConfiguration;
 import io.micronaut.security.token.jwt.signature.SignatureConfiguration;
+import io.micronaut.security.token.jwt.signature.jwks.JwksClientReactorContext;
 import io.micronaut.security.token.jwt.validator.ReactiveJsonWebTokenSignatureValidator;
 import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,9 +45,12 @@ class NimbusReactiveJsonWebTokenSignatureValidator implements ReactiveJsonWebTok
     @Override
     @SingleResult
     public Publisher<Boolean> validateSignature(@NonNull SignedJWT signedToken) {
+        JwksClientReactorContext jwksClientReactorContext = new JwksClientReactorContext();
         return Flux.fromIterable(signatures)
-                .flatMap(signatureConfiguration -> signatureConfiguration.verify(signedToken))
+                .flatMap(signatureConfiguration -> Mono.from(signatureConfiguration.verify(signedToken))
+                    .contextWrite(ctx -> ctx.put(JwksClientReactorContext.class, jwksClientReactorContext)))
                 .filter(Boolean::booleanValue)
+                .doOnNext(ignored -> jwksClientReactorContext.markTokenVerified())
                 .next();
     }
 

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/signature/jwks/HttpClientJwksClient.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/signature/jwks/HttpClientJwksClient.java
@@ -29,6 +29,7 @@ import io.micronaut.http.client.HttpVersionSelection;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.http.client.ServiceHttpClientConfiguration;
 import io.micronaut.http.client.exceptions.HttpClientException;
+import io.micronaut.http.client.exceptions.ReadTimeoutException;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.security.token.jwt.config.JwtConfigurationProperties;
 import jakarta.inject.Singleton;
@@ -36,6 +37,7 @@ import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.util.context.ContextView;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -78,14 +80,25 @@ public class HttpClientJwksClient implements JwksClient {
     @Override
     @SingleResult
     public Publisher<String> load(@Nullable String providerName, @NonNull String url) throws HttpClientException {
-        return Mono.from(getClient(providerName)
-                .retrieve(url))
-                .onErrorResume(HttpClientException.class, throwable -> {
-                    if (LOG.isErrorEnabled()) {
-                        LOG.error("Exception loading JWK from " + url, throwable);
+        return Mono.deferContextual(ctx -> Mono.from(getClient(providerName).retrieve(url))
+            .onErrorResume(HttpClientException.class, throwable -> {
+                if (throwable instanceof ReadTimeoutException && alreadyVerified(ctx)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Read timeout loading JWK from {} (ignored because token already verified)", url, throwable);
                     }
-                    return Mono.empty();
-                });
+                } else if (LOG.isErrorEnabled()) {
+                    LOG.error("Exception loading JWK from " + url, throwable);
+                }
+                return Mono.empty();
+            }));
+    }
+
+    private static boolean alreadyVerified(ContextView ctx) {
+        if (ctx != null && ctx.hasKey(JwksClientReactorContext.class)) {
+            JwksClientReactorContext reactorContext = ctx.get(JwksClientReactorContext.class);
+            return reactorContext.isTokenVerified();
+        }
+        return false;
     }
 
     /**

--- a/security-jwt/src/main/java/io/micronaut/security/token/jwt/signature/jwks/JwksClientReactorContext.java
+++ b/security-jwt/src/main/java/io/micronaut/security/token/jwt/signature/jwks/JwksClientReactorContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.token.jwt.signature.jwks;
+
+import io.micronaut.core.annotation.Internal;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Reactor context object used to coordinate JWKS retrieval logging during reactive JWT signature validation.
+ *
+ * @since 4.16.0
+ */
+@Internal
+public final class JwksClientReactorContext {
+    private final AtomicBoolean tokenVerified = new AtomicBoolean(false);
+
+    /**
+     * @return Whether the token has already been verified by any configured signature.
+     */
+    public boolean isTokenVerified() {
+        return tokenVerified.get();
+    }
+
+    /**
+     * Mark the token as verified.
+     */
+    public void markTokenVerified() {
+        tokenVerified.set(true);
+    }
+}

--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksReadTimeoutUnusedSourcesLoggingSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/signature/jwks/JwksReadTimeoutUnusedSourcesLoggingSpec.groovy
@@ -1,0 +1,214 @@
+package io.micronaut.security.token.jwt.signature.jwks
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.JWSSigner
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import groovy.json.JsonOutput
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.client.DefaultHttpClientConfiguration
+import io.micronaut.http.client.HttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.time.Duration
+import java.time.Instant
+
+class JwksReadTimeoutUnusedSourcesLoggingSpec extends Specification {
+
+    void "unused JWKS ReadTimeout is not logged as ERROR"() {
+        given:
+        Logger logger = (Logger) LoggerFactory.getLogger(HttpClientJwksClient)
+        Level previousLevel = logger.level
+        boolean previousAdditive = logger.additive
+        MemoryAppender appender = new MemoryAppender()
+        logger.level = Level.DEBUG
+        logger.additive = false
+        logger.addAppender(appender)
+        appender.start()
+
+        RSAKey rsaKey = new RSAKeyGenerator(2048)
+                .keyID('provider1')
+                .generate()
+        String jwksJson = JsonOutput.toJson(new JWKSet(rsaKey.toPublicJWK()).toJSONObject(false))
+        String token = jwt(rsaKey)
+
+        EmbeddedServer provider1 = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider1',
+                'jwks.json' : jwksJson
+        ])
+
+        EmbeddedServer provider2 = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider2',
+                'jwks.json' : jwksJson
+        ])
+
+        EmbeddedServer provider3 = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider3',
+                'jwks.json' : jwksJson
+        ])
+
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': 'JwksReadTimeoutUnusedSourcesLoggingSpec',
+                'micronaut.security.authentication': 'bearer',
+                'micronaut.http.client.read-timeout': '50ms',
+                'micronaut.http.client.pool.enabled': false,
+                'micronaut.security.token.jwt.signatures.jwks.provider1.url': "http://localhost:${provider1.port}/keys",
+                'micronaut.security.token.jwt.signatures.jwks.provider2.url': "http://localhost:${provider2.port}/keys",
+                'micronaut.security.token.jwt.signatures.jwks.provider3.url': "http://localhost:${provider3.port}/keys",
+                'micronaut.security.token.jwt.signatures.jwks.provider1.cache-expiration': 0,
+                'micronaut.security.token.jwt.signatures.jwks.provider2.cache-expiration': 0,
+                'micronaut.security.token.jwt.signatures.jwks.provider3.cache-expiration': 0,
+        ])
+
+        DefaultHttpClientConfiguration clientConfiguration = new DefaultHttpClientConfiguration(readTimeout: Duration.ofSeconds(5))
+        HttpClient httpClient = server.applicationContext.createBean(HttpClient, server.URL, clientConfiguration)
+        def client = httpClient.toBlocking()
+
+        when:
+        String response = client.retrieve(HttpRequest.GET('/hello').bearerAuth(token))
+
+        then:
+        response == 'Hello'
+
+        and:
+        PollingConditions conditions = new PollingConditions(timeout: 3)
+        conditions.eventually {
+            assert !appender.contains(Level.ERROR, 'Exception loading JWK', 'io.micronaut.http.client.exceptions.ReadTimeoutException')
+            assert appender.contains(Level.DEBUG, 'Read timeout loading JWK', 'io.micronaut.http.client.exceptions.ReadTimeoutException')
+        }
+
+        cleanup:
+        logger.detachAppender(appender)
+        logger.level = previousLevel
+        logger.additive = previousAdditive
+
+        server?.close()
+        provider1?.close()
+        provider2?.close()
+        provider3?.close()
+    }
+
+    private static String jwt(RSAKey rsaKey) {
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject('123')
+                .issuer('https://example.local')
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .build()
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .keyID(rsaKey.keyID)
+                .build()
+
+        SignedJWT signedJWT = new SignedJWT(header, claimsSet)
+        JWSSigner signer = new RSASSASigner(rsaKey.toPrivateKey())
+        signedJWT.sign(signer)
+        signedJWT.serialize()
+    }
+
+    static class MemoryAppender extends AppenderBase<ILoggingEvent> {
+        final List<ILoggingEvent> events = []
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            events << eventObject
+        }
+
+        void clear() {
+            events.clear()
+        }
+
+        boolean contains(Level level, String messageContains, String throwableClassName) {
+            events.any { ILoggingEvent e ->
+                e.level == level &&
+                        e.formattedMessage?.contains(messageContains) &&
+                        e.throwableProxy?.className == throwableClassName
+            }
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JwksReadTimeoutUnusedSourcesLoggingSpec')
+    @Controller('/hello')
+    static class HelloController {
+        @Secured(SecurityRule.IS_AUTHENTICATED)
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get
+        String index() {
+            'Hello'
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider1')
+    @Controller('/keys')
+    static class Provider1KeysController {
+        private final String jwksJson
+
+        Provider1KeysController(Environment environment) {
+            this.jwksJson = environment.getProperty('jwks.json', String).orElseThrow()
+        }
+
+        @Produces(MediaType.APPLICATION_JSON)
+        @Secured(SecurityRule.IS_ANONYMOUS)
+        @Get
+        String keys() {
+            jwksJson
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider2')
+    @Controller('/keys')
+    static class Provider2KeysController {
+        private final String jwksJson
+
+        Provider2KeysController(Environment environment) {
+            this.jwksJson = environment.getProperty('jwks.json', String).orElseThrow()
+        }
+
+        @Produces(MediaType.APPLICATION_JSON)
+        @Secured(SecurityRule.IS_ANONYMOUS)
+        @Get
+        String keys() {
+            sleep(250)
+            jwksJson
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'JwksReadTimeoutUnusedSourcesLoggingSpecProvider3')
+    @Controller('/keys')
+    static class Provider3KeysController {
+        private final String jwksJson
+
+        Provider3KeysController(Environment environment) {
+            this.jwksJson = environment.getProperty('jwks.json', String).orElseThrow()
+        }
+
+        @Produces(MediaType.APPLICATION_JSON)
+        @Secured(SecurityRule.IS_ANONYMOUS)
+        @Get
+        String keys() {
+            sleep(250)
+            jwksJson
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Downgrade JWKS `ReadTimeoutException` logs to DEBUG once another JWKS signature has already verified the token (keeps parallel verification).
- Add regression spec using 3 local embedded JWKS servers (1 fast, 2 slow) to ensure timeouts from unused sources are not logged at ERROR.
- Potential fix for #2070

