### PR TITLE
Use RouteAttributes::getRouteMatch

### DIFF
--- a/security-csrf/src/main/java/io/micronaut/security/csrf/filter/CsrfFilter.java
+++ b/security-csrf/src/main/java/io/micronaut/security/csrf/filter/CsrfFilter.java
@@ -17,6 +17,7 @@ package io.micronaut.security.csrf.filter;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
@@ -95,9 +96,10 @@ final class CsrfFilter implements Ordered {
     }
 
     boolean shouldTheFilterProcessTheRequestAccordingToTheUriMatch(HttpRequest<?> request) {
-        RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
-        if (routeMatch instanceof UriRouteMatch<?, ?> uriRouteMatch) {
-            return shouldTheFilterProcessTheRequestAccordingToTheUriMatch(uriRouteMatch);
+        try  (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
+            if (routeMatch instanceof UriRouteMatch<?, ?> uriRouteMatch) {
+                return shouldTheFilterProcessTheRequestAccordingToTheUriMatch(uriRouteMatch);
+            }
         }
         return true;
     }

--- a/security-csrf/src/main/java/io/micronaut/security/csrf/filter/CsrfFilter.java
+++ b/security-csrf/src/main/java/io/micronaut/security/csrf/filter/CsrfFilter.java
@@ -96,7 +96,7 @@ final class CsrfFilter implements Ordered {
     }
 
     boolean shouldTheFilterProcessTheRequestAccordingToTheUriMatch(HttpRequest<?> request) {
-        try  (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
+        try (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
             if (routeMatch instanceof UriRouteMatch<?, ?> uriRouteMatch) {
                 return shouldTheFilterProcessTheRequestAccordingToTheUriMatch(uriRouteMatch);
             }

--- a/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
+++ b/security/src/main/java/io/micronaut/security/filters/SecurityFilter.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.filters;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
@@ -173,13 +174,14 @@ public class SecurityFilter implements HttpServerFilter {
                                 method,
                                 path);
                     }
-                    RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
-                    // no rule found for the given request
-                    if (routeMatch == null && !securityConfiguration.isRejectNotFound()) {
-                        return chain.proceed(request);
-                    } else {
-                        request.setAttribute(REJECTION, forbidden ? HttpStatus.FORBIDDEN : HttpStatus.UNAUTHORIZED);
-                        return Mono.error(new AuthorizationException(authentication));
+                    try (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
+                        // no rule found for the given request
+                        if (routeMatch == null && !securityConfiguration.isRejectNotFound()) {
+                            return chain.proceed(request);
+                        } else {
+                            request.setAttribute(REJECTION, forbidden ? HttpStatus.FORBIDDEN : HttpStatus.UNAUTHORIZED);
+                            return Mono.error(new AuthorizationException(authentication));
+                        }
                     }
                 }));
     }

--- a/security/src/main/java/io/micronaut/security/rules/SecuredAnnotationRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SecuredAnnotationRule.java
@@ -17,6 +17,7 @@ package io.micronaut.security.rules;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
@@ -67,24 +68,25 @@ public class SecuredAnnotationRule extends AbstractSecurityRule<HttpRequest<?>> 
      */
     @Override
     public Publisher<SecurityRuleResult> check(HttpRequest<?> request, @Nullable Authentication authentication) {
-        RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
-        if (routeMatch instanceof MethodBasedRouteMatch) {
-            MethodBasedRouteMatch<?, ?> methodRoute = ((MethodBasedRouteMatch) routeMatch);
-            AnnotationValue<Secured> securedAnnotation = methodRoute.getAnnotation(Secured.class);
-            if (securedAnnotation != null) {
-                if (securedAnnotation instanceof EvaluatedAnnotationValue<Secured>) {
-                    boolean[] arr = securedAnnotation.booleanValues();
-                    if (arr.length > 0) {
-                        return Mono.just(arr[0] ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED);
+        try (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
+            if (routeMatch instanceof MethodBasedRouteMatch) {
+                MethodBasedRouteMatch<?, ?> methodRoute = ((MethodBasedRouteMatch) routeMatch);
+                AnnotationValue<Secured> securedAnnotation = methodRoute.getAnnotation(Secured.class);
+                if (securedAnnotation != null) {
+                    if (securedAnnotation instanceof EvaluatedAnnotationValue<Secured>) {
+                        boolean[] arr = securedAnnotation.booleanValues();
+                        if (arr.length > 0) {
+                            return Mono.just(arr[0] ? SecurityRuleResult.ALLOWED : SecurityRuleResult.REJECTED);
+                        }
                     }
-                }
-                Optional<String[]> optionalValue = methodRoute.getValue(Secured.class, String[].class);
-                if (optionalValue.isPresent()) {
-                    List<String> values = Arrays.asList(optionalValue.get());
-                    if (values.contains(SecurityRule.DENY_ALL)) {
-                        return Mono.just(SecurityRuleResult.REJECTED);
+                    Optional<String[]> optionalValue = methodRoute.getValue(Secured.class, String[].class);
+                    if (optionalValue.isPresent()) {
+                        List<String> values = Arrays.asList(optionalValue.get());
+                        if (values.contains(SecurityRule.DENY_ALL)) {
+                            return Mono.just(SecurityRuleResult.REJECTED);
+                        }
+                        return compareRoles(values, getRoles(authentication));
                     }
-                    return compareRoles(values, getRoles(authentication));
                 }
             }
         }

--- a/security/src/main/java/io/micronaut/security/rules/SecuredAnnotationRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SecuredAnnotationRule.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.Nullable;
-import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.inject.annotation.EvaluatedAnnotationValue;
 import io.micronaut.security.annotation.Secured;

--- a/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
@@ -16,6 +16,7 @@
 package io.micronaut.security.rules;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.http.HttpAttributes;
@@ -107,11 +108,12 @@ public class SensitiveEndpointRule implements SecurityRule<HttpRequest<?>>, Endp
 
     @Override
     public Publisher<SecurityRuleResult> check(HttpRequest<?> request, @Nullable Authentication authentication) {
-        RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
-        if (routeMatch instanceof MethodBasedRouteMatch) {
-            ExecutableMethod<?, ?> method = ((MethodBasedRouteMatch<?, ?>) routeMatch).getExecutableMethod();
-            if (endpointMethods.containsKey(method)) {
-                return check(request, authentication, method);
+        try (RouteMatch<?> routeMatch = RouteAttributes.getRouteMatch(request).orElse(null)) {
+            if (routeMatch instanceof MethodBasedRouteMatch) {
+                ExecutableMethod<?, ?> method = ((MethodBasedRouteMatch<?, ?>) routeMatch).getExecutableMethod();
+                if (endpointMethods.containsKey(method)) {
+                    return check(request, authentication, method);
+                }
             }
         }
         return Mono.just(SecurityRuleResult.UNKNOWN);

--- a/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
+++ b/security/src/main/java/io/micronaut/security/rules/SensitiveEndpointRule.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.web.router.RouteAttributes;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.management.endpoint.EndpointSensitivityProcessor;

--- a/security/src/main/java/io/micronaut/security/utils/SecurityBindingResultUtils.java
+++ b/security/src/main/java/io/micronaut/security/utils/SecurityBindingResultUtils.java
@@ -26,6 +26,9 @@ import java.util.Optional;
 
 import static io.micronaut.core.bind.ArgumentBinder.BindingResult;
 
+/**
+ * Security Binding Result Utils.
+ */
 @Internal
 public final class SecurityBindingResultUtils {
     private SecurityBindingResultUtils() {


### PR DESCRIPTION
The usage: 

```java
        RouteMatch<?> routeMatch = request.getAttribute(HttpAttributes.ROUTE_MATCH, RouteMatch.class).orElse(null);
```

is deprecated in favour of `RouteAttributes.getRouteMatch`