### PR TITLE
initialize at build time AuthenticationMode in native-image.properties

### DIFF
--- a/security/src/main/java/io/micronaut/security/authentication/AuthenticationMode.java
+++ b/security/src/main/java/io/micronaut/security/authentication/AuthenticationMode.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.security.authentication;
 
-import io.micronaut.core.annotation.BuildTimeInit;
 import io.micronaut.core.annotation.Internal;
 
 /**
@@ -27,7 +26,6 @@ import io.micronaut.core.annotation.Internal;
  * @since 2.0.0
  */
 @Internal
-@BuildTimeInit("io.micronaut.security.authentication.AuthenticationMode")
 public enum AuthenticationMode {
     BEARER,
     COOKIE,

--- a/security/src/main/resources/META-INF/native-image/io.micronaut.security/micronaut-security/native-image.properties
+++ b/security/src/main/resources/META-INF/native-image/io.micronaut.security/micronaut-security/native-image.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=io.micronaut.security.converters.PrincipalToStringConverter
+Args = --initialize-at-build-time=io.micronaut.security.converters.PrincipalToStringConverter,io.micronaut.security.authentication.AuthenticationMode


### PR DESCRIPTION
It seems there is a regression in `@BuildTimeInit`

```
./gradlew :test-suite-ldap:nativeTestCompile
Type-safe project accessors is an incubating feature.
Project accessors enabled, but root project name not explicitly set for 'buildSrc'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.

> Task :test-suite-ldap:nativeTestCompile
[native-image-plugin] GraalVM Toolchain detection is disabled
[native-image-plugin] GraalVM location read from environment variable: GRAALVM_HOME
[native-image-plugin] Native Image executable path: /Users/sdelamo/.sdkman/candidates/java/25.0.2-graal/lib/svm/bin/native-image
Warning: Using a deprecated option --install-exit-handlers from 'META-INF/native-image/io.micronaut/micronaut-context/native-image.properties' in 'file:///Users/sdelamo/.gradle/caches/modules-2/files-2.1/io.micronaut/micronaut-context/5.0.0-M17/87535d21a25503d7ffd9e79a68c645feda04f712/micronaut-context-5.0.0-M17.jar'. --install-exit-handlers is enabled by default for executables and it can likely be removed. To use this option for the shared libraries, please use -H:+InstallExitHandlers.
========================================================================================================================
GraalVM Native Image: Generating 'test-suite-ldap-tests' (executable)...
========================================================================================================================
For detailed information and explanations on the build output, visit:
https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/BuildOutput.md
------------------------------------------------------------------------------------------------------------------------
Warning: "customTargetConstructorClass" is deprecated in serialization-config.json. All serializable classes can be instantiated through any superclass constructor without the use of the flag.
[1/8] Initializing...                                                                                    (4,7s @ 0,77GB)
 Java version: 25.0.2+10-LTS, vendor version: Oracle GraalVM 25.0.2+10.1
 Graal compiler: optimization level: 2, target machine: armv8.1-a, PGO: ML-inferred
 C compiler: cc (apple, arm64, 17.0.0)
 Garbage collector: Serial GC (max heap size: 80% of RAM)
 3 user-specific feature(s):
 - com.oracle.svm.thirdparty.gson.GsonFeature
 - io.micronaut.core.io.service.ServiceLoaderFeature
 - org.graalvm.junit.platform.JUnitPlatformFeature
------------------------------------------------------------------------------------------------------------------------
Build resources:
 - 28,45GB of memory (13,8% of system memory, using available memory)
 - 24 thread(s) (100,0% of 24 available processor(s), determined at start)
[junit-platform-native] Running in 'test listener' mode using files matching pattern [junit-platform-unique-ids*] found in folder [/Users/sdelamo/github/micronaut-projects/micronaut-security/test-suite-ldap/build/test-results/test/testlist] and its subfolders.
[2/8] Performing analysis...  []                                                                         (3,3s @ 1,30GB)
    6.726 types,   6.666 fields, and  25.336 methods found reachable
    2.711 types,     260 fields, and   2.927 methods registered for reflection
        0 downcalls and 0 upcalls registered for foreign access
        1 native library: -framework CoreServices

2 fatal errors detected:
Fatal error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'io.micronaut.security.authentication.AuthenticationMode' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.micronaut.security.authentication.AuthenticationMode' are persisted in the image heap, add

    '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.micronaut.security.authentication.AuthenticationMode' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=io.micronaut.security.authentication.AuthenticationMode'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.

The following detailed trace displays from which field in the code the object was reached.
Object was reached by
  indexing into array io.micronaut.security.authentication.AuthenticationMode[]@6edff25c: [Lio.micronaut.security.authentication.AuthenticationMode;@6edff25c at index 1
  reading field java.util.Arrays$ArrayList.a of constant
    java.util.Arrays$ArrayList@13e78289: [cookie, idtoken]
  reading field io.micronaut.security.authentication.AuthenticationModeCondition.acceptableModes of constant
    io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition@48af721b: io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition@48af...
  reading field io.micronaut.core.annotation.AnnotationClassValue.instance of constant
    io.micronaut.core.annotation.AnnotationClassValue@24a289c6: io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition
  reading field java.util.ImmutableCollections$Map1.v0 of constant
    java.util.ImmutableCollections$Map1@6d786e6b: {condition=io.micronaut.security.authentication.CookieBasedAuthenticationModeCon...
  reading field io.micronaut.core.annotation.AnnotationValue.values of constant
    io.micronaut.core.annotation.AnnotationValue@425378af: @io.micronaut.context.annotation.Requires(condition=io.micronaut.security.authen...
  indexing into array io.micronaut.core.annotation.AnnotationValue[]@70153e0d: [Lio.micronaut.core.annotation.AnnotationValue;@70153e0d at index 1
  reading field java.util.ImmutableCollections$Map1.v0 of constant
    java.util.ImmutableCollections$Map1@270a10c8: {value=[Lio.micronaut.core.annotation.AnnotationValue;@70153e0d}
  indexing into array java.lang.Object[]@705474f: [Ljava.lang.Object;@705474f at index 1
  reading field java.util.ImmutableCollections$MapN.table of constant
    java.util.ImmutableCollections$MapN@570befd2: {jakarta.inject.Singleton={}, io.micronaut.context.annotation.Requirements={valu...
  reading field io.micronaut.inject.annotation.DefaultAnnotationMetadata.allAnnotations of constant
    io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a: io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a
  scanning root io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a: io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a embedded in
    io.micronaut.security.token.cookie.$CookieTokenReader$Definition.<init>(Unknown Source)
  parsing method io.micronaut.security.token.cookie.$CookieTokenReader$Definition.<init>(Unknown Source) reachable via the parsing context <no parsing context available>

        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onObjectReachable(ImageHeapScanner.java:618)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.heap.SVMImageHeapScanner.onObjectReachable(SVMImageHeapScanner.java:127)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.lambda$markReachable$0(ImageHeapScanner.java:589)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:166)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:152)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1750)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1742)
        at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(ForkJoinTask.java:1659)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'io.micronaut.security.authentication.AuthenticationMode' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.micronaut.security.authentication.AuthenticationMode' are persisted in the image heap, add

    '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.micronaut.security.authentication.AuthenticationMode' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=io.micronaut.security.authentication.AuthenticationMode'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.

The following detailed trace displays from which field in the code the object was reached.
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.checkImageHeapInstance(ClassInitializationFeature.java:205)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.SVMHost.validateReachableObject(SVMHost.java:371)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onObjectReachable(ImageHeapScanner.java:607)
        ... 11 more
Fatal error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'io.micronaut.security.authentication.AuthenticationMode' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.micronaut.security.authentication.AuthenticationMode' are persisted in the image heap, add

    '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.micronaut.security.authentication.AuthenticationMode' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=io.micronaut.security.authentication.AuthenticationMode'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.

The following detailed trace displays from which field in the code the object was reached.
Object was reached by
  indexing into array io.micronaut.security.authentication.AuthenticationMode[]@6edff25c: [Lio.micronaut.security.authentication.AuthenticationMode;@6edff25c at index 0
  reading field java.util.Arrays$ArrayList.a of constant
    java.util.Arrays$ArrayList@13e78289: [cookie, idtoken]
  reading field io.micronaut.security.authentication.AuthenticationModeCondition.acceptableModes of constant
    io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition@48af721b: io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition@48af...
  reading field io.micronaut.core.annotation.AnnotationClassValue.instance of constant
    io.micronaut.core.annotation.AnnotationClassValue@24a289c6: io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition
  reading field java.util.ImmutableCollections$Map1.v0 of constant
    java.util.ImmutableCollections$Map1@6d786e6b: {condition=io.micronaut.security.authentication.CookieBasedAuthenticationModeCon...
  reading field io.micronaut.core.annotation.AnnotationValue.values of constant
    io.micronaut.core.annotation.AnnotationValue@425378af: @io.micronaut.context.annotation.Requires(condition=io.micronaut.security.authen...
  indexing into array io.micronaut.core.annotation.AnnotationValue[]@70153e0d: [Lio.micronaut.core.annotation.AnnotationValue;@70153e0d at index 1
  reading field java.util.ImmutableCollections$Map1.v0 of constant
    java.util.ImmutableCollections$Map1@270a10c8: {value=[Lio.micronaut.core.annotation.AnnotationValue;@70153e0d}
  indexing into array java.lang.Object[]@705474f: [Ljava.lang.Object;@705474f at index 1
  reading field java.util.ImmutableCollections$MapN.table of constant
    java.util.ImmutableCollections$MapN@570befd2: {jakarta.inject.Singleton={}, io.micronaut.context.annotation.Requirements={valu...
  reading field io.micronaut.inject.annotation.DefaultAnnotationMetadata.allAnnotations of constant
    io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a: io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a
  scanning root io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a: io.micronaut.inject.annotation.DefaultAnnotationMetadata@6665b29a embedded in
    io.micronaut.security.token.cookie.$CookieTokenReader$Definition.<init>(Unknown Source)
  parsing method io.micronaut.security.token.cookie.$CookieTokenReader$Definition.<init>(Unknown Source) reachable via the parsing context <no parsing context available>

        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onObjectReachable(ImageHeapScanner.java:618)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.heap.SVMImageHeapScanner.onObjectReachable(SVMImageHeapScanner.java:127)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.lambda$markReachable$0(ImageHeapScanner.java:589)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:166)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:152)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1750)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(ForkJoinTask.java:1742)
        at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(ForkJoinTask.java:1659)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'io.micronaut.security.authentication.AuthenticationMode' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.

You now have two options to resolve this:

1) If it is intended that objects of type 'io.micronaut.security.authentication.AuthenticationMode' are persisted in the image heap, add

    '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode'

to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'io.micronaut.security.authentication.AuthenticationMode' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.

2) If these objects should not be stored in the image heap, you can use

    '--trace-object-instantiation=io.micronaut.security.authentication.AuthenticationMode'

to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with

    '--initialize-at-run-time=<culprit>'

to prevent the instantiation of the object.

If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
To fix this, include '--initialize-at-build-time=io.micronaut.security.authentication.AuthenticationMode' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.

The following detailed trace displays from which field in the code the object was reached.
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.classinitialization.ClassInitializationFeature.checkImageHeapInstance(ClassInitializationFeature.java:205)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.SVMHost.validateReachableObject(SVMHost.java:371)
        at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.heap.ImageHeapScanner.onObjectReachable(ImageHeapScanner.java:607)
        ... 11 more
------------------------------------------------------------------------------------------------------------------------
                        0,4s (4,8% of total time) in 14 GCs | Peak RSS: 2,51GB | CPU load: 12,12
========================================================================================================================
Failed generating 'test-suite-ldap-tests' after 8,6s.

> Task :test-suite-ldap:nativeTestCompile FAILED

[Incubating] Problems report is available at: file:///Users/sdelamo/github/micronaut-projects/micronaut-security/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test-suite-ldap:nativeTestCompile'.
> Process 'command '/Users/sdelamo/.sdkman/candidates/java/25.0.2-graal/bin/native-image'' finished with non-zero exit value 1

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.4.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 10s
29 actionable tasks: 4 executed, 25 up-to-date
```