### PR TITLE
docs: document 1Password Secrets Automation

### DIFF
--- a/src/main/docs/guide/securityConfiguration/onePasswordSecretsAutomation.adoc
+++ b/src/main/docs/guide/securityConfiguration/onePasswordSecretsAutomation.adoc
@@ -1,0 +1,110 @@
+1Password Secrets Automation can supply Micronaut Security secrets without adding a 1Password client to the application.
+Use 1Password Secrets Automation or 1Password Connect to manage the secret lifecycle, then expose the required values to the Micronaut application as normal configuration, such as environment variables or Kubernetes secrets.
+
+Micronaut Security does not call the 1Password Connect API directly for this integration.
+It reads the same configuration properties it already supports, and the deployment environment is responsible for resolving 1Password-managed values before the application starts.
+
+See the 1Password documentation for the secret-management side of this setup:
+
+* https://support.1password.com/secrets-automation/[1Password Secrets Automation]
+* https://support.1password.com/connect-api-reference/[1Password Connect API reference]
+* https://blog.1password.com/introducing-secrets-automation/[Introducing 1Password Secrets Automation]
+
+== OAuth 2.0 Client Secrets
+
+Store OAuth client secrets in 1Password, inject them into the runtime environment, and reference the injected values from the existing OAuth 2.0 client configuration.
+
+[configuration]
+----
+micronaut:
+  security:
+    oauth2:
+      clients:
+        github:
+          client-id: ${OAUTH_CLIENT_ID}
+          client-secret: ${OAUTH_CLIENT_SECRET}
+          authorization:
+            url: https://github.com/login/oauth/authorize
+          token:
+            url: https://github.com/login/oauth/access_token
+            auth-method: client-secret-post
+----
+
+For Kubernetes deployments, expose the materialized secret as environment variables and keep the application configuration unchanged.
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: example/app:latest
+          env:
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: micronaut-security-secrets
+                  key: oauth-client-id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: micronaut-security-secrets
+                  key: oauth-client-secret
+----
+
+The Kubernetes `Secret` can be created or synchronized by the 1Password component you use in your cluster.
+Do not commit OAuth client secrets, 1Password Connect tokens, or `op://` references that reveal vault, item, or field structure beyond what your deployment policy allows.
+
+== JWT Signing Secrets
+
+The same pattern works for JWT signing secrets.
+Keep the secret value in 1Password and inject it into the environment before Micronaut Security creates the JWT signature configuration.
+
+[configuration]
+----
+micronaut:
+  security:
+    token:
+      jwt:
+        signatures:
+          secret:
+            generator:
+              secret: ${JWT_GENERATOR_SECRET}
+              jws-algorithm: HS256
+----
+
+If the injected value is Base64 encoded, keep using the existing `base64` option.
+
+[configuration]
+----
+micronaut:
+  security:
+    token:
+      jwt:
+        signatures:
+          secret:
+            generator:
+              secret: ${JWT_GENERATOR_SECRET_BASE64}
+              base64: true
+              jws-algorithm: HS256
+----
+
+== Operational Boundaries
+
+Treat the 1Password Connect token as infrastructure credential material.
+Store and rotate it with the same controls you use for other deployment credentials, and grant only the vault, item, and field access required by the application.
+
+Missing or invalid injected values fail like any other missing or invalid Micronaut configuration value.
+Micronaut Security does not add a retry loop, local cache, or fallback secret source for this docs-only integration.
+Caching, offline availability, synchronization, and token renewal belong to the selected 1Password deployment component.
+
+For AOT and native-image deployments, provide secrets at runtime.
+Do not bake secret values into generated documentation, build outputs, AOT resources, container image layers, or native-image build arguments.
+
+To roll back, restore the previous deployment secret source or change the environment variables referenced by the Micronaut configuration.
+No Micronaut Security code or dependency changes are required.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -45,6 +45,7 @@ securityConfiguration:
   authenticationStrategy: Authentication Strategy
   noRedirection: Handlers without redirection
   redirection: Redirection Configuration
+  onePasswordSecretsAutomation: 1Password Secrets Automation
 authenticationProviders:
   title: Reactive Authentication Providers
   imperativeAuthenticationProviders: Authentication Provider


### PR DESCRIPTION
## Summary
- Adds a Security Configuration guide page for using 1Password Secrets Automation or 1Password Connect to supply existing Micronaut Security configuration values.
- Documents OAuth client secret and JWT signing secret placeholder patterns, including Kubernetes `secretKeyRef` injection.
- States the scope boundary explicitly: Micronaut Security does not call the 1Password Connect API directly, add a client/cache/retry loop, or capture secrets at build/AOT time.

Fixes #628

## Tests
- `./gradlew publishGuide`
- Rendered output checked for the new `1Password Secrets Automation` navigation entry and preserved `${OAUTH_CLIENT_SECRET}`, `${JWT_GENERATOR_SECRET}`, and `${JWT_GENERATOR_SECRET_BASE64}` placeholders.

## PR Assets
- [Rendered 1Password Secrets Automation guide page](https://raw.githubusercontent.com/micronaut-projects/micronaut-security/02cc755e9a3724e6d261e610243a1c91c405dbd3/assets/pr-2191/83e23518b86d/onePasswordSecretsAutomation.html)

## Release Targeting
- Target branch: `5.1.x`
- Target release: `5.1.0`
- Micronaut organization project selected by QA: `5.1.0 Release` (#147)
- Live project linkage: project #147 exists, but this run could not apply the PR-to-project association. `gh project item-add 147 --owner micronaut-projects` returned `unknown owner type`; the direct GraphQL `addProjectV2ItemById` fallback returned `INSUFFICIENT_SCOPES` because the token lacks the `project` scope.
- Type label: `type: enhancement`

---
###### ✨ This message was AI-generated using gpt-5