### PR TITLE
Add configurable role case sensitivity

### DIFF
--- a/security/src/main/java/io/micronaut/security/config/SecurityConfiguration.java
+++ b/security/src/main/java/io/micronaut/security/config/SecurityConfiguration.java
@@ -55,6 +55,14 @@ public interface SecurityConfiguration extends Toggleable, AuthenticationModeCon
     }
 
     /**
+     * @since 5.1.0
+     * @return Whether role comparison is case-sensitive.
+     */
+    default boolean isRolesCaseSensitive() {
+        return true;
+    }
+
+    /**
      * @since 3.7.2
      * @return Whether the intercept URL patterns should be prepended with context path if defined.
      */

--- a/security/src/main/java/io/micronaut/security/config/SecurityConfigurationProperties.java
+++ b/security/src/main/java/io/micronaut/security/config/SecurityConfigurationProperties.java
@@ -58,6 +58,12 @@ public class SecurityConfigurationProperties implements SecurityConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_REJECT_NOT_FOUND = true;
 
+    /**
+     * The default roles case-sensitive value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ROLES_CASE_SENSITIVE = true;
+
     private boolean enabled = DEFAULT_ENABLED;
 
     private boolean interceptUrlMapPrependPatternWithContextPath = DEFAULT_INTERCEPT_URL_MAP_PREPEND_PATTERN_WITH_CONTEXT_PATH;
@@ -66,6 +72,7 @@ public class SecurityConfigurationProperties implements SecurityConfiguration {
     private List<String> ipPatterns = Collections.singletonList(ANYWHERE);
     private AuthenticationStrategy authenticationProviderStrategy = DEFAULT_AUTHENTICATION_STRATEGY;
     private boolean rejectNotFound = DEFAULT_REJECT_NOT_FOUND;
+    private boolean rolesCaseSensitive = DEFAULT_ROLES_CASE_SENSITIVE;
 
     @Nullable
     private AuthenticationMode authentication = null;
@@ -165,5 +172,20 @@ public class SecurityConfigurationProperties implements SecurityConfiguration {
      */
     public void setRejectNotFound(boolean rejectNotFound) {
         this.rejectNotFound = rejectNotFound;
+    }
+
+    @Override
+    public boolean isRolesCaseSensitive() {
+        return rolesCaseSensitive;
+    }
+
+    /**
+     * Whether role comparison is case-sensitive. When set to {@code false}, roles differing only by case are treated as equivalent.
+     * Default value ({@value #DEFAULT_ROLES_CASE_SENSITIVE}).
+     *
+     * @param rolesCaseSensitive True if roles should be compared case-sensitively
+     */
+    public void setRolesCaseSensitive(boolean rolesCaseSensitive) {
+        this.rolesCaseSensitive = rolesCaseSensitive;
     }
 }

--- a/security/src/main/java/io/micronaut/security/token/DefaultRolesFinder.java
+++ b/security/src/main/java/io/micronaut/security/token/DefaultRolesFinder.java
@@ -19,13 +19,19 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import io.micronaut.security.config.SecurityConfiguration;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.security.token.config.TokenConfiguration;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Default implementation of {@link RolesFinder}.
@@ -37,13 +43,29 @@ import java.util.Map;
 public class DefaultRolesFinder implements RolesFinder {
 
     private final TokenConfiguration tokenConfiguration;
+    private final boolean rolesCaseSensitive;
 
     /**
      * Constructs a Roles Parser.
      * @param tokenConfiguration General Token Configuration
      */
     public DefaultRolesFinder(TokenConfiguration tokenConfiguration) {
+        this(tokenConfiguration, true);
+    }
+
+    /**
+     * Constructs a Roles Parser.
+     * @param tokenConfiguration General Token Configuration
+     * @param securityConfiguration General Security Configuration
+     */
+    @Inject
+    public DefaultRolesFinder(TokenConfiguration tokenConfiguration, SecurityConfiguration securityConfiguration) {
+        this(tokenConfiguration, securityConfiguration.isRolesCaseSensitive());
+    }
+
+    private DefaultRolesFinder(TokenConfiguration tokenConfiguration, boolean rolesCaseSensitive) {
         this.tokenConfiguration = tokenConfiguration;
+        this.rolesCaseSensitive = rolesCaseSensitive;
     }
 
     /**
@@ -79,5 +101,34 @@ public class DefaultRolesFinder implements RolesFinder {
     @NonNull
     public List<String> resolveRoles(@Nullable Map<String, Object> attributes) {
         return rolesAtObject(attributes != null ? attributes.get(tokenConfiguration.getRolesName()) : null);
+    }
+
+    @Override
+    public boolean hasAnyRequiredRoles(@NonNull List<String> requiredRoles, @NonNull Collection<String> grantedRoles) {
+        if (rolesCaseSensitive) {
+            return RolesFinder.super.hasAnyRequiredRoles(requiredRoles, grantedRoles);
+        }
+        if (requiredRoles.isEmpty() || grantedRoles.isEmpty()) {
+            return false;
+        }
+        Set<String> normalizedGrantedRoles = new HashSet<>(grantedRoles.size());
+        boolean grantedRolesContainsNull = false;
+        for (String grantedRole : grantedRoles) {
+            if (grantedRole == null) {
+                grantedRolesContainsNull = true;
+            } else {
+                normalizedGrantedRoles.add(grantedRole.toLowerCase(Locale.ROOT));
+            }
+        }
+        for (String requiredRole : requiredRoles) {
+            if (requiredRole == null) {
+                if (grantedRolesContainsNull) {
+                    return true;
+                }
+            } else if (normalizedGrantedRoles.contains(requiredRole.toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/authorization/SecuredRolesCaseInsensitiveConfigurationSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/authorization/SecuredRolesCaseInsensitiveConfigurationSpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.security.authorization
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import io.micronaut.security.MockAuthenticationProvider
+import io.micronaut.security.SuccessAuthenticationScenario
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.testutils.EmbeddedServerSpecification
+import io.micronaut.security.token.RolesFinder
+import io.micronaut.security.utils.DefaultSecurityService
+import io.micronaut.security.utils.SecurityService
+import jakarta.inject.Singleton
+
+import java.security.Principal
+
+class SecuredRolesCaseInsensitiveConfigurationSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'SecuredRolesCaseInsensitiveConfigurationSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + ['micronaut.security.roles-case-sensitive': false]
+    }
+
+    void "@Secured annotation value can be case insensitive"() {
+        when:
+        client.exchange(HttpRequest.GET("/uppercase").basicAuth('user', 'password'), String)
+
+        then:
+        noExceptionThrown()
+
+        when:
+        client.exchange(HttpRequest.GET("/lowercase").basicAuth('user', 'password'), String)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "SecurityService::hasRole can be case insensitive"() {
+        when:
+        Authentication authentication = Authentication.build("sherlock", ["ROLE_DETECTIVE"])
+        SecurityService securityService = new CustomSecurityService(applicationContext.getBean(RolesFinder), authentication)
+
+        then:
+        securityService.hasRole('ROLE_DETECTIVE')
+
+        and:
+        securityService.hasRole('role_detective')
+    }
+
+    @Requires(property = 'spec.name', value = 'SecuredRolesCaseInsensitiveConfigurationSpec')
+    @Controller
+    static class RolesCaseInsensitiveController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Secured(["role_user"])
+        @Get("/lowercase")
+        String lowercase(Principal principal) {
+            principal.name
+        }
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Secured(["ROLE_USER"])
+        @Get("/uppercase")
+        String uppercase(Principal principal) {
+            principal.name
+        }
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'SecuredRolesCaseInsensitiveConfigurationSpec')
+    static class AuthenticationProviderUserPassword extends MockAuthenticationProvider {
+        AuthenticationProviderUserPassword() {
+            super([new SuccessAuthenticationScenario('user', ['ROLE_USER'])])
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'SecuredRolesCaseInsensitiveConfigurationSpec')
+    static class CustomSecurityService extends DefaultSecurityService {
+
+        Authentication authentication
+
+        CustomSecurityService(RolesFinder rolesFinder, Authentication authentication) {
+            super(rolesFinder)
+            this.authentication = authentication
+        }
+
+        @Override
+        Optional<Authentication> getAuthentication() {
+            Optional.of(authentication)
+        }
+    }
+}

--- a/security/src/test/groovy/io/micronaut/security/config/SecurityConfigurationPropertiesSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/config/SecurityConfigurationPropertiesSpec.groovy
@@ -89,6 +89,23 @@ class SecurityConfigurationPropertiesSpec extends Specification {
         config.interceptUrlMap[3].pattern == '/health'
         config.interceptUrlMap[3].access == ['isAnonymous()']
         config.interceptUrlMap[3].httpMethod == HttpMethod.POST
+        config.rolesCaseSensitive
+
+        cleanup:
+        ctx.stop()
+    }
+
+    void "test roles case sensitive configuration"() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.security.roles-case-sensitive': false
+        ])
+
+        when:
+        SecurityConfigurationProperties config = ctx.getBean(SecurityConfigurationProperties)
+
+        then:
+        !config.rolesCaseSensitive
 
         cleanup:
         ctx.stop()

--- a/security/src/test/groovy/io/micronaut/security/rules/ConfigurationInterceptUrlMapRuleSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/rules/ConfigurationInterceptUrlMapRuleSpec.groovy
@@ -77,8 +77,22 @@ class ConfigurationInterceptUrlMapRuleSpec extends Specification {
         ['isAuthenticated()']        | ['ROLE_ADMIN', 'ROLE_USER', 'isAuthenticated()'] | SecurityRuleResult.ALLOWED
         ['ROLE_ADMIN', 'ROLE_USER']  | ['ROLE_USER']                                    | SecurityRuleResult.ALLOWED
         ['ROLE_ADMIN']               | ['ROLE_USER']                                    | SecurityRuleResult.REJECTED
+        ['role_admin']               | ['ROLE_ADMIN']                                   | SecurityRuleResult.REJECTED
         ['isAnonymous()']            | [SecurityRule.IS_ANONYMOUS]                      | SecurityRuleResult.ALLOWED
         ['isAuthenticated()']        | [SecurityRule.IS_AUTHENTICATED]                  | SecurityRuleResult.ALLOWED
         description = expected == SecurityRuleResult.ALLOWED ? 'Allowed' : 'Rejected'
+    }
+
+    def 'configured case-insensitive role comparison applies to intercept url map rules'() {
+        given:
+        def securityConfiguration = Stub(SecurityConfiguration) {
+            getInterceptUrlMap() >> []
+            isRolesCaseSensitive() >> false
+        }
+        RolesFinder caseInsensitiveRolesFinder = new DefaultRolesFinder(tokenConfiguration, securityConfiguration)
+        ConfigurationInterceptUrlMapRule provider = new ConfigurationInterceptUrlMapRule(caseInsensitiveRolesFinder, securityConfiguration, new DefaultInterceptUrlPatternModifier(securityConfiguration, () -> null))
+
+        expect:
+        SecurityRuleResult.ALLOWED == Mono.from(provider.compareRoles(['role_admin'], ['ROLE_ADMIN'])).block()
     }
 }

--- a/security/src/test/groovy/io/micronaut/security/token/DefaultRolesFinderSpec.groovy
+++ b/security/src/test/groovy/io/micronaut/security/token/DefaultRolesFinderSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.security.token
+
+import io.micronaut.security.config.SecurityConfiguration
+import io.micronaut.security.authentication.AuthenticationMode
+import io.micronaut.security.token.config.TokenConfiguration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultRolesFinderSpec extends Specification {
+
+    TokenConfiguration tokenConfiguration = new TokenConfiguration() {}
+
+    void "default constructor keeps role comparison case sensitive"() {
+        given:
+        DefaultRolesFinder rolesFinder = new DefaultRolesFinder(tokenConfiguration)
+
+        expect:
+        rolesFinder.hasAnyRequiredRoles(['ROLE_ADMIN'], ['ROLE_ADMIN'])
+        !rolesFinder.hasAnyRequiredRoles(['role_admin'], ['ROLE_ADMIN'])
+    }
+
+    @Unroll
+    void "configured case insensitive role comparison for #requiredRoles and #grantedRoles is #expected"() {
+        given:
+        SecurityConfiguration securityConfiguration = Stub(SecurityConfiguration) {
+            isRolesCaseSensitive() >> false
+        }
+        DefaultRolesFinder rolesFinder = new DefaultRolesFinder(tokenConfiguration, securityConfiguration)
+
+        expect:
+        rolesFinder.hasAnyRequiredRoles(requiredRoles, grantedRoles) == expected
+
+        where:
+        requiredRoles        | grantedRoles   || expected
+        ['role_admin']       | ['ROLE_ADMIN'] || true
+        ['role_admin']       | ['ROLE_USER']  || false
+        []                   | ['ROLE_ADMIN'] || false
+        ['role_admin']       | []             || false
+        [null]               | [null]         || true
+        [null, 'role_admin'] | ['ROLE_ADMIN'] || true
+    }
+
+    void "security configuration roles case-sensitive default is true"() {
+        given:
+        SecurityConfiguration securityConfiguration = new SecurityConfiguration() {
+            @Override
+            List<String> getIpPatterns() {
+                []
+            }
+
+            @Override
+            List getInterceptUrlMap() {
+                []
+            }
+
+            @Override
+            boolean isInterceptUrlMapPrependPatternWithContextPath() {
+                true
+            }
+
+            @Override
+            AuthenticationMode getAuthentication() {
+                null
+            }
+        }
+
+        expect:
+        securityConfiguration.rolesCaseSensitive
+    }
+}

--- a/src/main/docs/guide/securityConfiguration.adoc
+++ b/src/main/docs/guide/securityConfiguration.adoc
@@ -2,3 +2,4 @@ The following global configuration options are available:
 
 include::{includedir}configurationProperties/io.micronaut.security.config.SecurityConfigurationProperties.adoc[]
 
+By default, role comparisons are case-sensitive. Set `micronaut.security.roles-case-sensitive=false` to make the default `RolesFinder` compare roles case-insensitively for authorization rules and `SecurityService.hasRole`. Enable this only when your role model intentionally treats roles differing only by case as equivalent.


### PR DESCRIPTION
## Summary
- Adds `micronaut.security.roles-case-sensitive`, defaulting to `true` so existing role checks remain case-sensitive.
- Makes `micronaut.security.roles-case-sensitive=false` opt the default `DefaultRolesFinder` into case-insensitive role comparison for `@Secured`, intercept URL maps, and `SecurityService.hasRole`.
- Preserves the existing `DefaultRolesFinder(TokenConfiguration)` constructor behavior and adds focused tests plus security configuration guide documentation.

## Verification
- `./gradlew --no-build-cache :micronaut-security:compileJava :micronaut-security:spotlessCheck`
- `./gradlew :micronaut-security:test --tests 'io.micronaut.security.token.DefaultRolesFinderSpec' --tests 'io.micronaut.security.config.SecurityConfigurationPropertiesSpec' --tests 'io.micronaut.security.authorization.SecuredRolesCaseSensitiveSpec' --tests 'io.micronaut.security.authorization.SecuredRolesCaseInsensitiveConfigurationSpec' --tests 'io.micronaut.security.rules.ConfigurationInterceptUrlMapRuleSpec'`

Focused test result: 28 tests, 28 successes, 0 failures, 0 skipped.

## Release Metadata
- Target branch: `5.1.x`
- Release target: `5.1.0`
- SemVer impact: minor, backward-compatible opt-in enhancement
- Selected Micronaut organization project: `5.1.0 Release`
- PR-visible assets: not applicable; no rendered output, image, PDF, archive, log, or generated binary artifact changed.

Closes #327.

---
###### ✨ This message was AI-generated using gpt-5