### PR TITLE
Fix OAuth2 native-image session definition initialization

### DIFF
--- a/security-oauth2/src/main/resources/META-INF/native-image/io.micronaut.security/micronaut-security-oauth2/native-image.properties
+++ b/security-oauth2/src/main/resources/META-INF/native-image/io.micronaut.security/micronaut-security-oauth2/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2026 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.security.oauth2.endpoint.nonce.persistence.session.$SessionNoncePersistence$Definition,io.micronaut.security.oauth2.endpoint.authorization.state.persistence.session.$SessionStatePersistence$Definition,io.micronaut.security.oauth2.endpoint.authorization.pkce.persistence.session.$SessionPkcePersistence$Definition

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/Oauth2NativeImageMetadataTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/Oauth2NativeImageMetadataTest.java
@@ -1,0 +1,31 @@
+package io.micronaut.security.oauth2;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Oauth2NativeImageMetadataTest {
+
+    private static final String NATIVE_IMAGE_PROPERTIES = "META-INF/native-image/io.micronaut.security/micronaut-security-oauth2/native-image.properties";
+
+    @Test
+    void nativeImageMetadataInitializesSessionPersistenceBeanDefinitionsAtRunTime() throws IOException {
+        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(NATIVE_IMAGE_PROPERTIES);
+        assertNotNull(inputStream);
+
+        String properties;
+        try (inputStream) {
+            properties = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertTrue(properties.contains("--initialize-at-run-time="));
+        assertTrue(properties.contains("io.micronaut.security.oauth2.endpoint.nonce.persistence.session.$SessionNoncePersistence$Definition"));
+        assertTrue(properties.contains("io.micronaut.security.oauth2.endpoint.authorization.state.persistence.session.$SessionStatePersistence$Definition"));
+        assertTrue(properties.contains("io.micronaut.security.oauth2.endpoint.authorization.pkce.persistence.session.$SessionPkcePersistence$Definition"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `security-oauth2` native-image metadata that initializes OAuth2 session-backed generated bean definitions at run time
- cover nonce, state, and same-pattern PKCE session persistence definitions
- add a focused classpath metadata assertion

Closes #870.

## Tests
- `./gradlew --no-daemon :micronaut-security-oauth2:test --tests io.micronaut.security.oauth2.Oauth2NativeImageMetadataTest -x compileTestGroovy`
- `./gradlew --no-daemon :micronaut-security-oauth2:jar`
- inspected the built JAR for `META-INF/native-image/io.micronaut.security/micronaut-security-oauth2/native-image.properties` and the three expected class names

## Release Target
- Target branch: `5.1.x`
- Target release: `5.1.0`
- Micronaut organization project selected by QA: `5.1.0 Release` (#147)

## PR Assets
No generated or rendered artifacts changed; no PR-visible asset upload is required.

---
###### ✨ This message was AI-generated using gpt-5
