### PR TITLE
Document JTI claim generation

### DIFF
--- a/src/main/docs/guide/authenticationStrategies/jwt/claimsGeneration.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/claimsGeneration.adoc
@@ -1,3 +1,10 @@
 If the built-in
 link:{api}/io/micronaut/security/token/jwt/generator/claims/JWTClaimsSetGenerator.html[JWTClaimsSetGenerator], does not
-fulfil your needs you can provide your own https://micronaut-projects.github.io/micronaut-core/latest/guide/#replaces[replacement] of link:{api}/io/micronaut/security/token/jwt/generator/claims/ClaimsGenerator.html[ClaimsGenerator].
+fulfil your needs you can provide your own https://micronaut-projects.github.io/micronaut-core/latest/guide/#replaces[replacement] of api:io.micronaut.security.token.claims.ClaimsGenerator[].
+
+The built-in `JWTClaimsSetGenerator` adds the JWT ID (`jti`) claim when the application provides a bean of type api:io.micronaut.security.token.claims.JtiGenerator[].
+The value returned by `generateJtiClaim()` is used as the case-sensitive unique identifier for the JWT:
+
+snippet::io.micronaut.docs.claimsjti.CustomJtiGenerator[tags="clazz"]
+
+If you are migrating from the old `io.micronaut.security.token.jwt.generator.claims.JwtIdGenerator`, use `io.micronaut.security.token.claims.JtiGenerator` instead.

--- a/test-suite/src/test/java/io/micronaut/docs/claimsjti/CustomJtiGenerator.java
+++ b/test-suite/src/test/java/io/micronaut/docs/claimsjti/CustomJtiGenerator.java
@@ -1,0 +1,19 @@
+package io.micronaut.docs.claimsjti;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.security.token.claims.JtiGenerator;
+import jakarta.inject.Singleton;
+
+import java.util.UUID;
+
+@Requires(property = "spec.name", value = "claims-generation-docs")
+//tag::clazz[]
+@Singleton
+class CustomJtiGenerator implements JtiGenerator {
+
+    @Override
+    public String generateJtiClaim() {
+        return UUID.randomUUID().toString();
+    }
+}
+//end::clazz[]


### PR DESCRIPTION
## Summary
- Document the current `JtiGenerator` extension point for JWT ID (`jti`) claim generation.
- Add a compiled Java docs snippet showing a custom `JtiGenerator` bean.
- Correct the touched `ClaimsGenerator` API link to the current package.

## Verification
- `git diff --check -- src/main/docs/guide/authenticationStrategies/jwt/claimsGeneration.adoc test-suite/src/test/java/io/micronaut/docs/claimsjti/CustomJtiGenerator.java`
- `./gradlew :test-suite:compileTestJava publishGuide --no-daemon --no-parallel --rerun-tasks`
- Rendered HTML spot-check confirmed `JtiGenerator`, `generateJtiClaim()`, `CustomJtiGenerator`, `jti`, and the `JwtIdGenerator` migration note.

## Release Metadata
- Target branch: `5.1.x`
- Release target: `5.1.0`
- Micronaut organization project selected upstream: `5.1.0 Release` (#147), no ambiguity noted upstream.
- Live project association status: not linked by this run; GitHub rejected `addProjectV2ItemById` because the active `GITHUB_TOKEN` lacks the required `project` scope.
- Type label: `type: docs`

## Reviewer Routing
- Linked issue creator: `sdelamo`.
- Reviewer request status: GitHub rejected requesting `sdelamo` with `Review cannot be requested from pull request author.`

## PR Assets
None required; this is a text-only guide/snippet change and the rendered guide output was verified locally.

Closes #402

---
###### ✨ This message was AI-generated using gpt-5
