### PR TITLE
Add RunWithSecurityAttribute annotation

### DIFF
--- a/security-annotations/build.gradle.kts
+++ b/security-annotations/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("io.micronaut.build.internal.security-module")
 }
 dependencies {
+    compileOnly(mn.micronaut.aop)
     compileOnly("io.micronaut:micronaut-core-processor")
     compileOnly(mnData.micronaut.data.model)
 }

--- a/security-annotations/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttribute.java
+++ b/security-annotations/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttribute.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.annotation;
+
+import io.micronaut.aop.Around;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Temporarily adds an attribute to the current authentication while the annotated method executes.
+ *
+ * @since 5.1.0
+ */
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Around
+public @interface RunWithSecurityAttribute {
+
+    /**
+     * @return The authentication attribute name to set for the invocation.
+     */
+    String name();
+
+    /**
+     * @return The literal authentication attribute value to set for the invocation.
+     */
+    String value() default "true";
+}

--- a/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
+++ b/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
@@ -31,8 +31,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
@@ -62,7 +60,7 @@ public final class RunWithSecurityAttributeInterceptor implements MethodIntercep
 
         String value = context.stringValue(RunWithSecurityAttribute.class, AnnotationMetadata.VALUE_MEMBER)
             .orElse("true");
-        Authentication scopedAuthentication = new RunWithSecurityAttributeAuthentication(authentication, name, value);
+        Authentication scopedAuthentication = scopedAuthentication(authentication, name, value);
         securityContext.withAuthentication(scopedAuthentication);
 
         boolean restoreOnExit = true;
@@ -115,7 +113,7 @@ public final class RunWithSecurityAttributeInterceptor implements MethodIntercep
             if (previousAuthentication == null) {
                 return mono;
             }
-            securityContext.withAuthentication(new RunWithSecurityAttributeAuthentication(previousAuthentication, name, value));
+            securityContext.withAuthentication(scopedAuthentication(previousAuthentication, name, value));
             return mono.doFinally(signalType -> restore(securityContext, previousAuthentication));
         });
     }
@@ -130,43 +128,21 @@ public final class RunWithSecurityAttributeInterceptor implements MethodIntercep
             if (previousAuthentication == null) {
                 return Flux.from(publisher);
             }
-            securityContext.withAuthentication(new RunWithSecurityAttributeAuthentication(previousAuthentication, name, value));
+            securityContext.withAuthentication(scopedAuthentication(previousAuthentication, name, value));
             return Flux.from(publisher).doFinally(signalType -> restore(securityContext, previousAuthentication));
         });
     }
 
-    private void restore(@NonNull SecurityContext securityContext, @NonNull Authentication authentication) {
-        securityContext.withAuthentication(authentication);
+    @NonNull
+    private Authentication scopedAuthentication(@NonNull Authentication authentication,
+                                                @NonNull String name,
+                                                @NonNull String value) {
+        Map<String, Object> attributes = new LinkedHashMap<>(authentication.getAttributes());
+        attributes.put(name, value);
+        return Authentication.build(authentication.getName(), authentication.getRoles(), attributes);
     }
 
-    private static final class RunWithSecurityAttributeAuthentication implements Authentication {
-        private static final long serialVersionUID = 1L;
-
-        private final Authentication delegate;
-        private final Map<String, Object> attributes;
-
-        private RunWithSecurityAttributeAuthentication(Authentication delegate, String name, String value) {
-            this.delegate = delegate;
-            Map<String, Object> mutableAttributes = new LinkedHashMap<>(delegate.getAttributes());
-            mutableAttributes.put(name, value);
-            this.attributes = Collections.unmodifiableMap(mutableAttributes);
-        }
-
-        @Override
-        public String getName() {
-            return delegate.getName();
-        }
-
-        @Override
-        @NonNull
-        public Collection<String> getRoles() {
-            return delegate.getRoles();
-        }
-
-        @Override
-        @NonNull
-        public Map<String, Object> getAttributes() {
-            return attributes;
-        }
+    private void restore(@NonNull SecurityContext securityContext, @NonNull Authentication authentication) {
+        securityContext.withAuthentication(authentication);
     }
 }

--- a/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
+++ b/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
@@ -16,10 +16,12 @@
 package io.micronaut.security.annotation;
 
 import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.InterceptedMethod;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.context.SecurityContext;
 import io.micronaut.security.context.SecurityContextHolder;
@@ -71,7 +73,7 @@ public final class RunWithSecurityAttributeInterceptor implements MethodIntercep
                 return completionStage.whenComplete((unused, throwable) -> restore(securityContext, authentication));
             }
             if (result instanceof Publisher<?> publisher) {
-                return wrapPublisher(publisher, securityContext, authentication, scopedAuthentication);
+                return wrapPublisher(context, publisher, securityContext, name, value);
             }
             return result;
         } finally {
@@ -82,25 +84,54 @@ public final class RunWithSecurityAttributeInterceptor implements MethodIntercep
     }
 
     @NonNull
-    private Object wrapPublisher(@NonNull Publisher<?> publisher,
+    private Object wrapPublisher(@NonNull MethodInvocationContext<Object, Object> context,
+                                 @NonNull Publisher<?> publisher,
                                  @NonNull SecurityContext securityContext,
-                                 @NonNull Authentication originalAuthentication,
-                                 @NonNull Authentication scopedAuthentication) {
+                                 @NonNull String name,
+                                 @NonNull String value) {
         if (publisher instanceof Mono<?> mono) {
-            return Mono.defer(() -> {
-                securityContext.withAuthentication(scopedAuthentication);
-                return mono.doFinally(signalType -> restore(securityContext, originalAuthentication));
-            });
+            return wrapMono(mono, securityContext, name, value);
         }
         if (publisher instanceof Flux<?> flux) {
-            return Flux.defer(() -> {
-                securityContext.withAuthentication(scopedAuthentication);
-                return flux.doFinally(signalType -> restore(securityContext, originalAuthentication));
-            });
+            return wrapFlux(flux, securityContext, name, value);
         }
+        Publisher<?> scopedPublisher = wrapFlux(publisher, securityContext, name, value);
+        Object result = InterceptedMethod.of(context, ConversionService.SHARED).handleResult(scopedPublisher);
+        Class<?> returnType = context.getReturnType().getType();
+        if (!returnType.isInstance(result)) {
+            throw new IllegalStateException("@RunWithSecurityAttribute does not support concrete Publisher return type: "
+                + returnType.getName());
+        }
+        return result;
+    }
+
+    @NonNull
+    private <T> Mono<T> wrapMono(@NonNull Mono<T> mono,
+                                 @NonNull SecurityContext securityContext,
+                                 @NonNull String name,
+                                 @NonNull String value) {
+        return Mono.defer(() -> {
+            Authentication previousAuthentication = securityContext.getAuthentication();
+            if (previousAuthentication == null) {
+                return mono;
+            }
+            securityContext.withAuthentication(new RunWithSecurityAttributeAuthentication(previousAuthentication, name, value));
+            return mono.doFinally(signalType -> restore(securityContext, previousAuthentication));
+        });
+    }
+
+    @NonNull
+    private <T> Flux<T> wrapFlux(@NonNull Publisher<T> publisher,
+                                 @NonNull SecurityContext securityContext,
+                                 @NonNull String name,
+                                 @NonNull String value) {
         return Flux.defer(() -> {
-            securityContext.withAuthentication(scopedAuthentication);
-            return Flux.from(publisher).doFinally(signalType -> restore(securityContext, originalAuthentication));
+            Authentication previousAuthentication = securityContext.getAuthentication();
+            if (previousAuthentication == null) {
+                return Flux.from(publisher);
+            }
+            securityContext.withAuthentication(new RunWithSecurityAttributeAuthentication(previousAuthentication, name, value));
+            return Flux.from(publisher).doFinally(signalType -> restore(securityContext, previousAuthentication));
         });
     }
 

--- a/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
+++ b/security/src/main/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.annotation;
+
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.context.SecurityContext;
+import io.micronaut.security.context.SecurityContextHolder;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Intercepts {@link RunWithSecurityAttribute} methods and scopes a temporary authentication attribute.
+ *
+ * @since 5.1.0
+ */
+@Internal
+@Singleton
+@InterceptorBean(RunWithSecurityAttribute.class)
+public final class RunWithSecurityAttributeInterceptor implements MethodInterceptor<Object, Object> {
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        String name = context.stringValue(RunWithSecurityAttribute.class, "name").orElse(null);
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("@RunWithSecurityAttribute name cannot be blank");
+        }
+
+        SecurityContext securityContext = SecurityContextHolder.getSecurityContext();
+        Authentication authentication = securityContext.getAuthentication();
+        if (authentication == null) {
+            return context.proceed();
+        }
+
+        String value = context.stringValue(RunWithSecurityAttribute.class, AnnotationMetadata.VALUE_MEMBER)
+            .orElse("true");
+        Authentication scopedAuthentication = new RunWithSecurityAttributeAuthentication(authentication, name, value);
+        securityContext.withAuthentication(scopedAuthentication);
+
+        boolean restoreOnExit = true;
+        try {
+            Object result = context.proceed();
+            if (result instanceof CompletionStage<?> completionStage) {
+                restoreOnExit = false;
+                return completionStage.whenComplete((unused, throwable) -> restore(securityContext, authentication));
+            }
+            if (result instanceof Publisher<?> publisher) {
+                return wrapPublisher(publisher, securityContext, authentication, scopedAuthentication);
+            }
+            return result;
+        } finally {
+            if (restoreOnExit) {
+                restore(securityContext, authentication);
+            }
+        }
+    }
+
+    @NonNull
+    private Object wrapPublisher(@NonNull Publisher<?> publisher,
+                                 @NonNull SecurityContext securityContext,
+                                 @NonNull Authentication originalAuthentication,
+                                 @NonNull Authentication scopedAuthentication) {
+        if (publisher instanceof Mono<?> mono) {
+            return Mono.defer(() -> {
+                securityContext.withAuthentication(scopedAuthentication);
+                return mono.doFinally(signalType -> restore(securityContext, originalAuthentication));
+            });
+        }
+        if (publisher instanceof Flux<?> flux) {
+            return Flux.defer(() -> {
+                securityContext.withAuthentication(scopedAuthentication);
+                return flux.doFinally(signalType -> restore(securityContext, originalAuthentication));
+            });
+        }
+        return Flux.defer(() -> {
+            securityContext.withAuthentication(scopedAuthentication);
+            return Flux.from(publisher).doFinally(signalType -> restore(securityContext, originalAuthentication));
+        });
+    }
+
+    private void restore(@NonNull SecurityContext securityContext, @NonNull Authentication authentication) {
+        securityContext.withAuthentication(authentication);
+    }
+
+    private static final class RunWithSecurityAttributeAuthentication implements Authentication {
+        private static final long serialVersionUID = 1L;
+
+        private final Authentication delegate;
+        private final Map<String, Object> attributes;
+
+        private RunWithSecurityAttributeAuthentication(Authentication delegate, String name, String value) {
+            this.delegate = delegate;
+            Map<String, Object> mutableAttributes = new LinkedHashMap<>(delegate.getAttributes());
+            mutableAttributes.put(name, value);
+            this.attributes = Collections.unmodifiableMap(mutableAttributes);
+        }
+
+        @Override
+        public String getName() {
+            return delegate.getName();
+        }
+
+        @Override
+        @NonNull
+        public Collection<String> getRoles() {
+            return delegate.getRoles();
+        }
+
+        @Override
+        @NonNull
+        public Map<String, Object> getAttributes() {
+            return attributes;
+        }
+    }
+}

--- a/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
+++ b/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
@@ -212,7 +212,8 @@ class RunWithSecurityAttributeInterceptorTest {
 
             CompletionStage<String> errorStage = withRequest(request, service::error);
             service.future.completeExceptionally(new IllegalStateException("stage-boom"));
-            CompletionException thrown = assertThrows(CompletionException.class, () -> errorStage.toCompletableFuture().join());
+            CompletableFuture<String> errorFuture = errorStage.toCompletableFuture();
+            CompletionException thrown = assertThrows(CompletionException.class, errorFuture::join);
             assertEquals("stage-boom", thrown.getCause().getMessage());
             assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
         }
@@ -333,7 +334,7 @@ class RunWithSecurityAttributeInterceptorTest {
         @RunWithSecurityAttribute(name = "feature", value = "stage")
         CompletionStage<String> error() {
             future = new CompletableFuture<>();
-            return future;
+            return future.minimalCompletionStage();
         }
     }
 

--- a/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
+++ b/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
@@ -24,7 +24,11 @@ import io.micronaut.security.context.SecurityContextHolder;
 import io.micronaut.security.filters.SecurityFilter;
 import jakarta.inject.Singleton;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -157,6 +161,40 @@ class RunWithSecurityAttributeInterceptorTest {
     }
 
     @Test
+    void supportsGenericPublisherAndRestoresPerSubscription() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ReactiveAttributeService service = context.getBean(ReactiveAttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            Authentication laterAuthentication = Authentication.build("watson");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            Publisher<String> publisher = withRequest(request, service::genericPublisher);
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+
+            assertEquals("sherlock:reactive", withRequest(request, () -> Flux.from(publisher).single().block()));
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+
+            request.setAttribute(SecurityFilter.AUTHENTICATION, laterAuthentication);
+            assertEquals("watson:reactive", withRequest(request, () -> Flux.from(publisher).single().block()));
+            assertSame(laterAuthentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    @Test
+    void rejectsUnsupportedConcretePublisherReturnType() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ReactiveAttributeService service = context.getBean(ReactiveAttributeService.class);
+            MutableHttpRequest<?> request = authenticatedRequest(Authentication.build("sherlock"));
+
+            IllegalStateException thrown = assertThrows(IllegalStateException.class, () ->
+                withRequest(request, service::concretePublisher)
+            );
+
+            assertTrue(thrown.getMessage().contains("does not support concrete Publisher return type"));
+        }
+    }
+
+    @Test
     void restoresAfterCompletionStageCompletionAndError() {
         try (ApplicationContext context = ApplicationContext.run()) {
             CompletionStageAttributeService service = context.getBean(CompletionStageAttributeService.class);
@@ -193,6 +231,11 @@ class RunWithSecurityAttributeInterceptorTest {
     private static String currentAttributeValue() {
         Authentication authentication = SecurityContextHolder.getSecurityContext().getAuthentication();
         return authentication == null ? null : (String) authentication.getAttributes().get("feature");
+    }
+
+    private static String currentNameAndAttributeValue() {
+        Authentication authentication = SecurityContextHolder.getSecurityContext().getAuthentication();
+        return authentication == null ? null : authentication.getName() + ":" + authentication.getAttributes().get("feature");
     }
 
     @Singleton
@@ -265,6 +308,16 @@ class RunWithSecurityAttributeInterceptorTest {
             return Mono.<String>never()
                 .doOnSubscribe(subscription -> subscriptionValue = currentAttributeValue());
         }
+
+        @RunWithSecurityAttribute(name = "feature", value = "reactive")
+        Publisher<String> genericPublisher() {
+            return new TestPublisher<>(RunWithSecurityAttributeInterceptorTest::currentNameAndAttributeValue);
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "reactive")
+        TestPublisher<String> concretePublisher() {
+            return new TestPublisher<>(RunWithSecurityAttributeInterceptorTest::currentNameAndAttributeValue);
+        }
     }
 
     @Singleton
@@ -281,6 +334,43 @@ class RunWithSecurityAttributeInterceptorTest {
         CompletionStage<String> error() {
             future = new CompletableFuture<>();
             return future;
+        }
+    }
+
+    private static final class TestPublisher<T> implements Publisher<T> {
+        private final Supplier<T> supplier;
+
+        private TestPublisher(Supplier<T> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super T> subscriber) {
+            subscriber.onSubscribe(new Subscription() {
+                private boolean done;
+
+                @Override
+                public void request(long n) {
+                    if (done) {
+                        return;
+                    }
+                    done = true;
+                    if (n <= 0) {
+                        subscriber.onError(new IllegalArgumentException("Demand must be positive"));
+                        return;
+                    }
+                    T value = supplier.get();
+                    if (value != null) {
+                        subscriber.onNext(value);
+                    }
+                    subscriber.onComplete();
+                }
+
+                @Override
+                public void cancel() {
+                    done = true;
+                }
+            });
         }
     }
 }

--- a/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
+++ b/security/src/test/java/io/micronaut/security/annotation/RunWithSecurityAttributeInterceptorTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.annotation;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.context.ServerRequestContext;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.context.SecurityContextHolder;
+import io.micronaut.security.filters.SecurityFilter;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RunWithSecurityAttributeInterceptorTest {
+
+    @Test
+    void addsAttributeOnlyDuringSynchronousInvocation() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            AttributeService service = context.getBean(AttributeService.class);
+            Authentication authentication = Authentication.build("sherlock", List.of("ROLE_USER"), Map.of("existing", "yes"));
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            String value = withRequest(request, service::attributeValue);
+
+            assertEquals("scoped", value);
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+            assertEquals("yes", authentication.getAttributes().get("existing"));
+            assertFalse(authentication.getAttributes().containsKey("feature"));
+        }
+    }
+
+    @Test
+    void proceedsWithoutAuthentication() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            AttributeService service = context.getBean(AttributeService.class);
+            MutableHttpRequest<?> request = HttpRequest.GET("/attribute");
+
+            String value = withRequest(request, service::attributeValue);
+
+            assertNull(value);
+            assertTrue(request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).isEmpty());
+        }
+    }
+
+    @Test
+    void restoresAfterSynchronousException() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            AttributeService service = context.getBean(AttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            IllegalStateException thrown = assertThrows(IllegalStateException.class, () ->
+                withRequest(request, service::throwing)
+            );
+
+            assertEquals("boom", thrown.getMessage());
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    @Test
+    void restoresNestedAttributes() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            OuterAttributeService service = context.getBean(OuterAttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            List<String> values = withRequest(request, service::nestedValues);
+
+            assertEquals(List.of("outer", "inner", "outer"), values);
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    @Test
+    void classLevelAnnotationScopesAttributes() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            TypeLevelAttributeService service = context.getBean(TypeLevelAttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            String value = withRequest(request, service::attributeValue);
+
+            assertEquals("type", value);
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    @Test
+    void rejectsBlankAttributeName() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            BlankNameService service = context.getBean(BlankNameService.class);
+            MutableHttpRequest<?> request = authenticatedRequest(Authentication.build("sherlock"));
+
+            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
+                withRequest(request, service::attributeValue)
+            );
+
+            assertEquals("@RunWithSecurityAttribute name cannot be blank", thrown.getMessage());
+        }
+    }
+
+    @Test
+    void restoresAfterReactiveCompletionErrorAndCancellation() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ReactiveAttributeService service = context.getBean(ReactiveAttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            String value = withRequest(request, () -> service.attributeValue().block());
+            assertEquals("reactive", value);
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+
+            IllegalStateException thrown = assertThrows(IllegalStateException.class, () ->
+                withRequest(request, () -> service.error().block())
+            );
+            assertEquals("reactive-boom", thrown.getMessage());
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+
+            ServerRequestContext.with(request, () -> {
+                Disposable disposable = service.never().subscribe();
+                assertEquals("reactive", service.subscriptionValue);
+                disposable.dispose();
+            });
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    @Test
+    void restoresAfterCompletionStageCompletionAndError() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            CompletionStageAttributeService service = context.getBean(CompletionStageAttributeService.class);
+            Authentication authentication = Authentication.build("sherlock");
+            MutableHttpRequest<?> request = authenticatedRequest(authentication);
+
+            CompletionStage<String> stage = withRequest(request, service::attributeValue);
+            assertEquals("stage", request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class)
+                .map(auth -> auth.getAttributes().get("feature"))
+                .orElse(null));
+
+            service.future.complete("done");
+            assertEquals("done", stage.toCompletableFuture().join());
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+
+            CompletionStage<String> errorStage = withRequest(request, service::error);
+            service.future.completeExceptionally(new IllegalStateException("stage-boom"));
+            CompletionException thrown = assertThrows(CompletionException.class, () -> errorStage.toCompletableFuture().join());
+            assertEquals("stage-boom", thrown.getCause().getMessage());
+            assertSame(authentication, request.getAttribute(SecurityFilter.AUTHENTICATION, Authentication.class).orElse(null));
+        }
+    }
+
+    private static MutableHttpRequest<?> authenticatedRequest(Authentication authentication) {
+        MutableHttpRequest<?> request = HttpRequest.GET("/attribute");
+        request.setAttribute(SecurityFilter.AUTHENTICATION, authentication);
+        return request;
+    }
+
+    private static <T> T withRequest(MutableHttpRequest<?> request, Supplier<T> supplier) {
+        return ServerRequestContext.with(request, supplier);
+    }
+
+    private static String currentAttributeValue() {
+        Authentication authentication = SecurityContextHolder.getSecurityContext().getAuthentication();
+        return authentication == null ? null : (String) authentication.getAttributes().get("feature");
+    }
+
+    @Singleton
+    static class AttributeService {
+        @RunWithSecurityAttribute(name = "feature", value = "scoped")
+        String attributeValue() {
+            return currentAttributeValue();
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "scoped")
+        String throwing() {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    @Singleton
+    static class OuterAttributeService {
+        private final InnerAttributeService innerAttributeService;
+
+        OuterAttributeService(InnerAttributeService innerAttributeService) {
+            this.innerAttributeService = innerAttributeService;
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "outer")
+        List<String> nestedValues() {
+            return List.of(currentAttributeValue(), innerAttributeService.attributeValue(), currentAttributeValue());
+        }
+    }
+
+    @Singleton
+    static class InnerAttributeService {
+        @RunWithSecurityAttribute(name = "feature", value = "inner")
+        String attributeValue() {
+            return currentAttributeValue();
+        }
+    }
+
+    @Singleton
+    @RunWithSecurityAttribute(name = "feature", value = "type")
+    static class TypeLevelAttributeService {
+        String attributeValue() {
+            return currentAttributeValue();
+        }
+    }
+
+    @Singleton
+    static class BlankNameService {
+        @RunWithSecurityAttribute(name = "")
+        String attributeValue() {
+            return currentAttributeValue();
+        }
+    }
+
+    @Singleton
+    static class ReactiveAttributeService {
+        private String subscriptionValue;
+
+        @RunWithSecurityAttribute(name = "feature", value = "reactive")
+        Mono<String> attributeValue() {
+            return Mono.fromSupplier(RunWithSecurityAttributeInterceptorTest::currentAttributeValue);
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "reactive")
+        Mono<String> error() {
+            return Mono.error(new IllegalStateException("reactive-boom"));
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "reactive")
+        Mono<String> never() {
+            return Mono.<String>never()
+                .doOnSubscribe(subscription -> subscriptionValue = currentAttributeValue());
+        }
+    }
+
+    @Singleton
+    static class CompletionStageAttributeService {
+        private CompletableFuture<String> future;
+
+        @RunWithSecurityAttribute(name = "feature", value = "stage")
+        CompletionStage<String> attributeValue() {
+            future = new CompletableFuture<>();
+            return future;
+        }
+
+        @RunWithSecurityAttribute(name = "feature", value = "stage")
+        CompletionStage<String> error() {
+            future = new CompletableFuture<>();
+            return future;
+        }
+    }
+}

--- a/src/main/docs/guide/retrievingAuthenticatedUser/securityService.adoc
+++ b/src/main/docs/guide/retrievingAuthenticatedUser/securityService.adoc
@@ -9,3 +9,19 @@ The default supplier for `SecurityContext` uses server request attributes. You c
 If you use Micronaut Reactor and access api:security.utils.SecurityService[] within a reactive chain, add the following dependency to handle the https://docs.micronaut.io/latest/guide/#reactorContextPropagation[Reactor Context Propagation].
 
 dependency:context-propagation[groupId=io.micrometer]
+
+=== Run with a security attribute
+
+You can annotate a bean method with ann:security.annotation.RunWithSecurityAttribute[] to temporarily add one literal attribute to the current api:security.authentication.Authentication[] while the method executes:
+
+[source,java]
+----
+@RunWithSecurityAttribute(name = "tenant", value = "store-a")
+void processTenantWork() {
+    // code reached from this method can read the tenant attribute
+}
+----
+
+If no user is authenticated, the method proceeds unchanged and no authentication is created. The original authentication is restored after the method completes, throws an exception, or a reactive or `CompletionStage` result terminates.
+
+The annotation value is a literal string and is not evaluated as an expression. It also cannot grant access to the same route's ann:security.annotation.Secured[] check, because route authorization runs before the controller method executes.


### PR DESCRIPTION
## Summary
- Add `@RunWithSecurityAttribute` for scoped literal authentication attributes during annotated method execution.
- Add an interceptor that wraps the current `Authentication`, restores the original state across sync, reactive, and `CompletionStage` paths, and no-ops when no authentication exists.
- Document usage, literal value semantics, and the `@Secured` authorization timing limitation.

## Tests
- `./gradlew :micronaut-security-annotations:compileJava :micronaut-security:compileJava :micronaut-security:compileTestJava :micronaut-security:test --tests 'io.micronaut.security.annotation.RunWithSecurityAttributeInterceptorTest' --no-daemon`
- `./gradlew :micronaut-security-annotations:japiCmp :micronaut-security:japiCmp --no-daemon`
- `./gradlew :micronaut-security-annotations:checkstyleMain :micronaut-security:checkstyleMain :micronaut-security:checkstyleTest --no-daemon`

## PR Assets
Not applicable. This change has no rendered UI, generated binary artifact, screenshot, PDF, or report that needs PR-visible upload.

## Release Targeting
- Target branch: `5.1.x`
- Target release: `5.1.0`
- Micronaut organization project: `5.1.0 Release` (#147)

Closes #2114

---
###### ✨ This message was AI-generated using gpt-5
