### PR TITLE
Add JWT client authentication for OAuth token requests

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -497,29 +497,9 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
      */
     @ConfigurationProperties("token")
     @Requires(classes = MediaType.class)
-    public static class TokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration implements TokenEndpointConfiguration {
-        private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-
-        @NonNull
-        private MediaType contentType = DEFAULT_CONTENT_TYPE;
-
+    public static class TokenEndpointConfigurationProperties extends AbstractTokenEndpointConfigurationProperties {
         @Nullable
         private ClientAssertionConfigurationProperties clientAssertion;
-
-        @NonNull
-        @Override
-        public MediaType getContentType() {
-            return contentType;
-        }
-
-        /**
-         * The content type of token endpoint requests. Default value (application/x-www-form-urlencoded).
-         *
-         * @param contentType The content type
-         */
-        public void setContentType(@NonNull MediaType contentType) {
-            this.contentType = contentType;
-        }
 
         @NonNull
         @Override
@@ -542,7 +522,31 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         @ConfigurationProperties("client-assertion")
         public static class ClientAssertionConfigurationProperties extends AbstractClientAssertionConfigurationProperties {
         }
+    }
 
+    /**
+     * Shared token endpoint configuration.
+     */
+    abstract static class AbstractTokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration implements TokenEndpointConfiguration {
+        private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+        @NonNull
+        private MediaType contentType = DEFAULT_CONTENT_TYPE;
+
+        @NonNull
+        @Override
+        public MediaType getContentType() {
+            return contentType;
+        }
+
+        /**
+         * The content type of token endpoint requests. Default value (application/x-www-form-urlencoded).
+         *
+         * @param contentType The content type
+         */
+        public void setContentType(@NonNull MediaType contentType) {
+            this.contentType = contentType;
+        }
     }
 
     /**
@@ -979,28 +983,9 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
          */
         @ConfigurationProperties("token")
         @Requires(classes = MediaType.class)
-        public static class TokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration implements TokenEndpointConfiguration {
-            private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-            @NonNull
-            private MediaType contentType = DEFAULT_CONTENT_TYPE;
-
+        public static class TokenEndpointConfigurationProperties extends AbstractTokenEndpointConfigurationProperties {
             @Nullable
             private ClientAssertionConfigurationProperties clientAssertion;
-
-            @NonNull
-            @Override
-            public MediaType getContentType() {
-                return this.contentType;
-            }
-
-            /**
-             * The content type of token endpoint requests. Default value (application/x-www-form-urlencoded).
-             *
-             * @param contentType The content type
-             */
-            public void setContentType(@NonNull MediaType contentType) {
-                this.contentType = contentType;
-            }
 
             @NonNull
             @Override

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -21,6 +21,7 @@ import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.security.oauth2.configuration.endpoints.AuthorizationEndpointConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.ClientAssertionConfiguration;
 import io.micronaut.security.oauth2.configuration.endpoints.DefaultEndpointConfiguration;
 import io.micronaut.security.oauth2.configuration.endpoints.DefaultSecureEndpointConfiguration;
 import io.micronaut.security.oauth2.configuration.endpoints.EndSessionEndpointConfiguration;
@@ -495,8 +496,166 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
      * OAuth 2.0 token endpoint configuration.
      */
     @ConfigurationProperties("token")
-    public static class TokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration {
+    @Requires(classes = MediaType.class)
+    public static class TokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration implements TokenEndpointConfiguration {
+        private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 
+        @NonNull
+        private MediaType contentType = DEFAULT_CONTENT_TYPE;
+
+        @Nullable
+        private ClientAssertionConfigurationProperties clientAssertion;
+
+        @NonNull
+        @Override
+        public MediaType getContentType() {
+            return contentType;
+        }
+
+        /**
+         * The content type of token endpoint requests. Default value (application/x-www-form-urlencoded).
+         *
+         * @param contentType The content type
+         */
+        public void setContentType(@NonNull MediaType contentType) {
+            this.contentType = contentType;
+        }
+
+        @NonNull
+        @Override
+        public Optional<ClientAssertionConfiguration> getClientAssertion() {
+            return Optional.ofNullable(clientAssertion);
+        }
+
+        /**
+         * JWT client assertion configuration for token endpoint authentication.
+         *
+         * @param clientAssertion JWT client assertion configuration
+         */
+        public void setClientAssertion(@Nullable ClientAssertionConfigurationProperties clientAssertion) {
+            this.clientAssertion = clientAssertion;
+        }
+
+        /**
+         * JWT client assertion configuration.
+         */
+        @ConfigurationProperties("client-assertion")
+        public static class ClientAssertionConfigurationProperties extends AbstractClientAssertionConfigurationProperties {
+        }
+
+    }
+
+    /**
+     * JWT client assertion configuration.
+     */
+    public abstract static class AbstractClientAssertionConfigurationProperties implements ClientAssertionConfiguration {
+        @NonNull
+        private Duration lifetime = ClientAssertionConfiguration.DEFAULT_LIFETIME;
+
+        @Nullable
+        private String audience;
+
+        @Nullable
+        private String issuer;
+
+        @Nullable
+        private String subject;
+
+        @Nullable
+        private String signingAlgorithm;
+
+        @Nullable
+        private String signerName;
+
+        @NonNull
+        @Override
+        public Duration getLifetime() {
+            return lifetime;
+        }
+
+        /**
+         * JWT client assertion lifetime. Default value (5 minutes).
+         *
+         * @param lifetime JWT client assertion lifetime
+         */
+        public void setLifetime(@NonNull Duration lifetime) {
+            this.lifetime = lifetime;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getAudience() {
+            return Optional.ofNullable(audience);
+        }
+
+        /**
+         * JWT client assertion audience. Defaults to the token endpoint URL.
+         *
+         * @param audience JWT client assertion audience
+         */
+        public void setAudience(@Nullable String audience) {
+            this.audience = audience;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getIssuer() {
+            return Optional.ofNullable(issuer);
+        }
+
+        /**
+         * JWT client assertion issuer. Defaults to the OAuth client id.
+         *
+         * @param issuer JWT client assertion issuer
+         */
+        public void setIssuer(@Nullable String issuer) {
+            this.issuer = issuer;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSubject() {
+            return Optional.ofNullable(subject);
+        }
+
+        /**
+         * JWT client assertion subject. Defaults to the OAuth client id.
+         *
+         * @param subject JWT client assertion subject
+         */
+        public void setSubject(@Nullable String subject) {
+            this.subject = subject;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSigningAlgorithm() {
+            return Optional.ofNullable(signingAlgorithm);
+        }
+
+        /**
+         * JWS signing algorithm used for client_secret_jwt. Defaults to HS256.
+         *
+         * @param signingAlgorithm JWS signing algorithm
+         */
+        public void setSigningAlgorithm(@Nullable String signingAlgorithm) {
+            this.signingAlgorithm = signingAlgorithm;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSignerName() {
+            return Optional.ofNullable(signerName);
+        }
+
+        /**
+         * Named SignatureGeneratorConfiguration bean used for private_key_jwt.
+         *
+         * @param signerName Named SignatureGeneratorConfiguration bean
+         */
+        public void setSignerName(@Nullable String signerName) {
+            this.signerName = signerName;
+        }
     }
 
     /**
@@ -822,7 +981,11 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         @Requires(classes = MediaType.class)
         public static class TokenEndpointConfigurationProperties extends DefaultSecureEndpointConfiguration implements TokenEndpointConfiguration {
             private static final MediaType DEFAULT_CONTENT_TYPE = MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+            @NonNull
             private MediaType contentType = DEFAULT_CONTENT_TYPE;
+
+            @Nullable
+            private ClientAssertionConfigurationProperties clientAssertion;
 
             @NonNull
             @Override
@@ -837,6 +1000,28 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
              */
             public void setContentType(@NonNull MediaType contentType) {
                 this.contentType = contentType;
+            }
+
+            @NonNull
+            @Override
+            public Optional<ClientAssertionConfiguration> getClientAssertion() {
+                return Optional.ofNullable(clientAssertion);
+            }
+
+            /**
+             * JWT client assertion configuration for token endpoint authentication.
+             *
+             * @param clientAssertion JWT client assertion configuration
+             */
+            public void setClientAssertion(@Nullable ClientAssertionConfigurationProperties clientAssertion) {
+                this.clientAssertion = clientAssertion;
+            }
+
+            /**
+             * JWT client assertion configuration.
+             */
+            @ConfigurationProperties("client-assertion")
+            public static class ClientAssertionConfigurationProperties extends AbstractClientAssertionConfigurationProperties {
             }
         }
 

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -498,22 +498,13 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
     @ConfigurationProperties("token")
     @Requires(classes = MediaType.class)
     public static class TokenEndpointConfigurationProperties extends AbstractTokenEndpointConfigurationProperties {
-        @Nullable
-        private ClientAssertionConfigurationProperties clientAssertion;
-
-        @NonNull
-        @Override
-        public Optional<ClientAssertionConfiguration> getClientAssertion() {
-            return Optional.ofNullable(clientAssertion);
-        }
-
         /**
          * JWT client assertion configuration for token endpoint authentication.
          *
          * @param clientAssertion JWT client assertion configuration
          */
         public void setClientAssertion(@Nullable ClientAssertionConfigurationProperties clientAssertion) {
-            this.clientAssertion = clientAssertion;
+            setClientAssertionConfiguration(clientAssertion);
         }
 
         /**
@@ -533,6 +524,9 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         @NonNull
         private MediaType contentType = DEFAULT_CONTENT_TYPE;
 
+        @Nullable
+        private ClientAssertionConfiguration clientAssertion;
+
         @NonNull
         @Override
         public MediaType getContentType() {
@@ -546,6 +540,16 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
          */
         public void setContentType(@NonNull MediaType contentType) {
             this.contentType = contentType;
+        }
+
+        @NonNull
+        @Override
+        public Optional<ClientAssertionConfiguration> getClientAssertion() {
+            return Optional.ofNullable(clientAssertion);
+        }
+
+        void setClientAssertionConfiguration(@Nullable ClientAssertionConfiguration clientAssertion) {
+            this.clientAssertion = clientAssertion;
         }
     }
 
@@ -984,22 +988,13 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         @ConfigurationProperties("token")
         @Requires(classes = MediaType.class)
         public static class TokenEndpointConfigurationProperties extends AbstractTokenEndpointConfigurationProperties {
-            @Nullable
-            private ClientAssertionConfigurationProperties clientAssertion;
-
-            @NonNull
-            @Override
-            public Optional<ClientAssertionConfiguration> getClientAssertion() {
-                return Optional.ofNullable(clientAssertion);
-            }
-
             /**
              * JWT client assertion configuration for token endpoint authentication.
              *
              * @param clientAssertion JWT client assertion configuration
              */
             public void setClientAssertion(@Nullable ClientAssertionConfigurationProperties clientAssertion) {
-                this.clientAssertion = clientAssertion;
+                setClientAssertionConfiguration(clientAssertion);
             }
 
             /**

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/endpoints/ClientAssertionConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/endpoints/ClientAssertionConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.configuration.endpoints;
+
+import org.jspecify.annotations.NonNull;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * JWT client assertion configuration for token endpoint authentication.
+ *
+ * @since 5.1.0
+ */
+public interface ClientAssertionConfiguration {
+
+    /**
+     * Default assertion lifetime.
+     */
+    Duration DEFAULT_LIFETIME = Duration.ofMinutes(5);
+
+    /**
+     * Default JWS algorithm used for {@code client_secret_jwt}.
+     */
+    String DEFAULT_SIGNING_ALGORITHM = "HS256";
+
+    /**
+     * @return The assertion lifetime.
+     */
+    @NonNull
+    Duration getLifetime();
+
+    /**
+     * @return The optional assertion audience. Defaults to the token endpoint URL.
+     */
+    @NonNull
+    Optional<String> getAudience();
+
+    /**
+     * @return The optional assertion issuer. Defaults to the OAuth client id.
+     */
+    @NonNull
+    Optional<String> getIssuer();
+
+    /**
+     * @return The optional assertion subject. Defaults to the OAuth client id.
+     */
+    @NonNull
+    Optional<String> getSubject();
+
+    /**
+     * @return The optional JWS signing algorithm used for {@code client_secret_jwt}.
+     */
+    @NonNull
+    Optional<String> getSigningAlgorithm();
+
+    /**
+     * @return The optional signer bean name used for {@code private_key_jwt}.
+     */
+    @NonNull
+    Optional<String> getSignerName();
+}

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/endpoints/TokenEndpointConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/endpoints/TokenEndpointConfiguration.java
@@ -18,6 +18,8 @@ package io.micronaut.security.oauth2.configuration.endpoints;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.http.MediaType;
 
+import java.util.Optional;
+
 /**
  * TokenEndpoint Configuration.
  *
@@ -41,5 +43,14 @@ public interface TokenEndpointConfiguration extends SecureEndpointConfiguration 
     @NonNull
     static TokenEndpointConfigurationBuilder builder() {
         return new TokenEndpointConfigurationBuilder();
+    }
+
+    /**
+     * @return The optional JWT client assertion configuration.
+     * @since 5.1.0
+     */
+    @NonNull
+    default Optional<ClientAssertionConfiguration> getClientAssertion() {
+        return Optional.empty();
     }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClient.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClient.java
@@ -17,6 +17,8 @@ package io.micronaut.security.oauth2.endpoint.token.request;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.HttpRequest;
@@ -27,12 +29,18 @@ import io.micronaut.http.client.HttpClientConfiguration;
 import io.micronaut.http.client.LoadBalancer;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
+import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.ClientAssertionConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.TokenEndpointConfiguration;
 import io.micronaut.security.oauth2.endpoint.AuthenticationMethods;
 import io.micronaut.security.oauth2.endpoint.token.request.context.TokenRequestContext;
 import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
 import io.micronaut.security.oauth2.grants.SecureGrant;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,9 +62,13 @@ import org.slf4j.LoggerFactory;
 public class DefaultTokenEndpointClient implements TokenEndpointClient  {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultTokenEndpointClient.class);
+    private static final String KEY_CLIENT_ASSERTION_TYPE = "client_assertion_type";
+    private static final String KEY_CLIENT_ASSERTION = "client_assertion";
+    private static final String CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
     private final @Nullable BeanContext beanContext;
     private final Supplier<HttpClient> defaultTokenClient;
+    private final Optional<ClientAssertionGenerator> clientAssertionGenerator;
     private final ConcurrentHashMap<String, HttpClient> tokenClients = new ConcurrentHashMap<>();
 
     /**
@@ -65,7 +77,7 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
      */
     public DefaultTokenEndpointClient(@NonNull BeanContext beanContext,
                                       HttpClientConfiguration defaultClientConfiguration) {
-        this(beanContext, () -> beanContext.createBean(HttpClient.class, LoadBalancer.empty(), defaultClientConfiguration));
+        this(beanContext, () -> beanContext.createBean(HttpClient.class, LoadBalancer.empty(), defaultClientConfiguration), Optional.empty());
     }
 
     /**
@@ -74,16 +86,39 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
      */
     public DefaultTokenEndpointClient(@Nullable BeanContext beanContext,
                                       Supplier<HttpClient> defaultTokenClientSupplier) {
-        this.beanContext = beanContext;
-        this.defaultTokenClient = SupplierUtil.memoized(defaultTokenClientSupplier);
-
+        this(beanContext, defaultTokenClientSupplier, Optional.empty());
     }
 
     /**
      * @param client HttpClient
      */
     public DefaultTokenEndpointClient(HttpClient client) {
-        this(null, () -> client);
+        this(null, () -> client, Optional.empty());
+    }
+
+    /**
+     * @param beanContext Bean Context
+     * @param defaultTokenClientSupplier Default Token Client Supplier
+     * @param clientAssertionGenerator The optional client assertion generator
+     */
+    DefaultTokenEndpointClient(@Nullable BeanContext beanContext,
+                               Supplier<HttpClient> defaultTokenClientSupplier,
+                               Optional<ClientAssertionGenerator> clientAssertionGenerator) {
+        this.beanContext = beanContext;
+        this.clientAssertionGenerator = clientAssertionGenerator;
+        this.defaultTokenClient = SupplierUtil.memoized(defaultTokenClientSupplier);
+    }
+
+    /**
+     * @param beanContext The bean context
+     * @param defaultClientConfiguration The default client configuration
+     * @param clientAssertionGenerator The optional client assertion generator
+     */
+    @Inject
+    public DefaultTokenEndpointClient(BeanContext beanContext,
+                                      HttpClientConfiguration defaultClientConfiguration,
+                                      Optional<ClientAssertionGenerator> clientAssertionGenerator) {
+        this(beanContext, () -> beanContext.createBean(HttpClient.class, LoadBalancer.empty(), defaultClientConfiguration), clientAssertionGenerator);
     }
 
     @NonNull
@@ -142,6 +177,16 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
                         body.setClientId(clientConfiguration.getClientId());
                         body.setClientSecret(clientConfiguration.getClientSecret());
                     });
+        } else if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_JWT)) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Using client_secret_jwt authentication. A signed client assertion will be present in the body");
+            }
+            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.CLIENT_SECRET_JWT);
+        } else if (authMethodsSupported.contains(AuthenticationMethods.PRIVATE_KEY_JWT)) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Using private_key_jwt authentication. A signed client assertion will be present in the body");
+            }
+            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.PRIVATE_KEY_JWT);
         } else {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Unsupported or no authentication method. The client_id will be present in the body");
@@ -151,6 +196,40 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
                     .map(SecureGrant.class::cast)
                     .ifPresent(body -> body.setClientId(clientConfiguration.getClientId()));
         }
+    }
+
+    private <G, R extends TokenResponse> void secureRequestWithClientAssertion(@NonNull MutableHttpRequest<G> request,
+                                                                               TokenRequestContext<G, R> requestContext,
+                                                                               String authenticationMethod) {
+        ClientAssertionConfiguration clientAssertionConfiguration = clientAssertionConfiguration(requestContext.getClientConfiguration())
+                .orElse(DefaultClientAssertionConfiguration.INSTANCE);
+        String clientAssertion = clientAssertionGenerator
+                .orElseThrow(() -> new ConfigurationException("OAuth client " + requestContext.getClientConfiguration().getName() + " requires micronaut-security-jwt for " + authenticationMethod + " authentication"))
+                .generate(requestContext, clientAssertionConfiguration, authenticationMethod);
+
+        request.getBody()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .ifPresentOrElse(body -> {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> grant = (Map<String, String>) body;
+                    grant.put(SecureGrant.KEY_CLIENT_ID, requestContext.getClientConfiguration().getClientId());
+                    grant.remove(SecureGrant.KEY_CLIENT_SECRET);
+                    grant.put(KEY_CLIENT_ASSERTION_TYPE, CLIENT_ASSERTION_TYPE);
+                    grant.put(KEY_CLIENT_ASSERTION, clientAssertion);
+                }, () -> {
+                    throw new ConfigurationException("OAuth client assertion authentication requires a token request body map");
+                });
+    }
+
+    private Optional<ClientAssertionConfiguration> clientAssertionConfiguration(OauthClientConfiguration clientConfiguration) {
+        return clientConfiguration.getOpenid()
+                .flatMap(OpenIdClientConfiguration::getToken)
+                .flatMap(TokenEndpointConfiguration::getClientAssertion)
+                .or(() -> clientConfiguration.getToken()
+                        .filter(TokenEndpointConfiguration.class::isInstance)
+                        .map(TokenEndpointConfiguration.class::cast)
+                        .flatMap(TokenEndpointConfiguration::getClientAssertion));
     }
 
     /**
@@ -164,5 +243,65 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
             Optional<HttpClient> client = beanContext == null ? Optional.empty() : beanContext.findBean(HttpClient.class, Qualifiers.byName(provider));
             return client.orElseGet(defaultTokenClient);
         });
+    }
+
+    private static final class DefaultClientAssertionConfiguration implements ClientAssertionConfiguration {
+        private static final DefaultClientAssertionConfiguration INSTANCE = new DefaultClientAssertionConfiguration();
+
+        @NonNull
+        @Override
+        public Duration getLifetime() {
+            return DEFAULT_LIFETIME;
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getAudience() {
+            return Optional.empty();
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getIssuer() {
+            return Optional.empty();
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSubject() {
+            return Optional.empty();
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSigningAlgorithm() {
+            return Optional.empty();
+        }
+
+        @NonNull
+        @Override
+        public Optional<String> getSignerName() {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Internal strategy for generating OAuth2 token endpoint client assertions.
+     *
+     * @since 5.1.0
+     */
+    @Internal
+    public interface ClientAssertionGenerator {
+
+        /**
+         * @param requestContext The token request context
+         * @param clientAssertionConfiguration The client assertion configuration
+         * @param authenticationMethod The selected token endpoint authentication method
+         * @return The serialized client assertion
+         */
+        @NonNull
+        String generate(@NonNull TokenRequestContext<?, ? extends TokenResponse> requestContext,
+                        @NonNull ClientAssertionConfiguration clientAssertionConfiguration,
+                        @NonNull String authenticationMethod);
     }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClient.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClient.java
@@ -162,47 +162,62 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
         }
 
         if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_BASIC)) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Using client_secret_basic authentication. Adding an Authorization header");
-            }
-            request.basicAuth(clientConfiguration.getClientId(), clientConfiguration.getClientSecret());
-        } else if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_POST)) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Using client_secret_post authentication. The client_id and client_secret will be present in the body");
-            }
-            request.getBody()
-                    .filter(SecureGrant.class::isInstance)
-                    .map(SecureGrant.class::cast)
-                    .ifPresent(body -> {
-                        body.setClientId(clientConfiguration.getClientId());
-                        body.setClientSecret(clientConfiguration.getClientSecret());
-                    });
-        } else if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_JWT)) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Using client_secret_jwt authentication. A signed client assertion will be present in the body");
-            }
-            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.CLIENT_SECRET_JWT);
-        } else if (authMethodsSupported.contains(AuthenticationMethods.PRIVATE_KEY_JWT)) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Using private_key_jwt authentication. A signed client assertion will be present in the body");
-            }
-            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.PRIVATE_KEY_JWT);
-        } else {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Unsupported or no authentication method. The client_id will be present in the body");
-            }
-            request.getBody()
-                    .filter(SecureGrant.class::isInstance)
-                    .map(SecureGrant.class::cast)
-                    .ifPresent(body -> body.setClientId(clientConfiguration.getClientId()));
+            secureRequestWithClientSecretBasic(request, clientConfiguration);
+            return;
         }
+        if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_POST)) {
+            secureRequestWithClientSecretPost(request, clientConfiguration);
+            return;
+        }
+        if (authMethodsSupported.contains(AuthenticationMethods.CLIENT_SECRET_JWT)) {
+            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.CLIENT_SECRET_JWT);
+            return;
+        }
+        if (authMethodsSupported.contains(AuthenticationMethods.PRIVATE_KEY_JWT)) {
+            secureRequestWithClientAssertion(request, requestContext, AuthenticationMethods.PRIVATE_KEY_JWT);
+            return;
+        }
+        secureRequestWithClientId(request, clientConfiguration);
+    }
+
+    private <G> void secureRequestWithClientSecretBasic(MutableHttpRequest<G> request,
+                                                        OauthClientConfiguration clientConfiguration) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Using client_secret_basic authentication. Adding an Authorization header");
+        }
+        request.basicAuth(clientConfiguration.getClientId(), clientConfiguration.getClientSecret());
+    }
+
+    private <G> void secureRequestWithClientSecretPost(MutableHttpRequest<G> request,
+                                                       OauthClientConfiguration clientConfiguration) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Using client_secret_post authentication. The client_id and client_secret will be present in the body");
+        }
+        request.getBody()
+                .filter(SecureGrant.class::isInstance)
+                .map(SecureGrant.class::cast)
+                .ifPresent(body -> {
+                    body.setClientId(clientConfiguration.getClientId());
+                    body.setClientSecret(clientConfiguration.getClientSecret());
+                });
+    }
+
+    private <G> void secureRequestWithClientId(MutableHttpRequest<G> request,
+                                               OauthClientConfiguration clientConfiguration) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Unsupported or no authentication method. The client_id will be present in the body");
+        }
+        request.getBody()
+                .filter(SecureGrant.class::isInstance)
+                .map(SecureGrant.class::cast)
+                .ifPresent(body -> body.setClientId(clientConfiguration.getClientId()));
     }
 
     private <G, R extends TokenResponse> void secureRequestWithClientAssertion(@NonNull MutableHttpRequest<G> request,
                                                                                TokenRequestContext<G, R> requestContext,
                                                                                String authenticationMethod) {
         ClientAssertionConfiguration clientAssertionConfiguration = clientAssertionConfiguration(requestContext.getClientConfiguration())
-                .orElse(DefaultClientAssertionConfiguration.INSTANCE);
+                .orElseGet(DefaultClientAssertionConfiguration::new);
         String clientAssertion = clientAssertionGenerator
                 .orElseThrow(() -> new ConfigurationException("OAuth client " + requestContext.getClientConfiguration().getName() + " requires micronaut-security-jwt for " + authenticationMethod + " authentication"))
                 .generate(requestContext, clientAssertionConfiguration, authenticationMethod);
@@ -212,13 +227,13 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
                 .map(Map.class::cast)
                 .ifPresentOrElse(body -> {
                     @SuppressWarnings("unchecked")
-                    Map<String, String> grant = (Map<String, String>) body;
+                    Map<String, String> grant = body;
                     grant.put(SecureGrant.KEY_CLIENT_ID, requestContext.getClientConfiguration().getClientId());
                     grant.remove(SecureGrant.KEY_CLIENT_SECRET);
                     grant.put(KEY_CLIENT_ASSERTION_TYPE, CLIENT_ASSERTION_TYPE);
                     grant.put(KEY_CLIENT_ASSERTION, clientAssertion);
                 }, () -> {
-                    throw new ConfigurationException("OAuth client assertion authentication requires a token request body map");
+                    throw new ConfigurationException("OAuth client " + requestContext.getClientConfiguration().getName() + " requires a token request body map for " + authenticationMethod + " authentication");
                 });
     }
 
@@ -246,7 +261,6 @@ public class DefaultTokenEndpointClient implements TokenEndpointClient  {
     }
 
     private static final class DefaultClientAssertionConfiguration implements ClientAssertionConfiguration {
-        private static final DefaultClientAssertionConfiguration INSTANCE = new DefaultClientAssertionConfiguration();
 
         @NonNull
         @Override

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/JwtClientAssertionGenerator.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/endpoint/token/request/JwtClientAssertionGenerator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.endpoint.token.request;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.ClientAssertionConfiguration;
+import io.micronaut.security.oauth2.endpoint.AuthenticationMethods;
+import io.micronaut.security.oauth2.endpoint.token.request.DefaultTokenEndpointClient.ClientAssertionGenerator;
+import io.micronaut.security.oauth2.endpoint.token.request.context.TokenRequestContext;
+import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
+import io.micronaut.security.token.jwt.signature.SignatureGeneratorConfiguration;
+import io.micronaut.security.token.jwt.signature.secret.SecretSignature;
+import io.micronaut.security.token.jwt.signature.secret.SecretSignatureConfiguration;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * JWT-backed OAuth2 token endpoint client assertion generator.
+ */
+@Singleton
+@Requires(classes = SignatureGeneratorConfiguration.class)
+final class JwtClientAssertionGenerator implements ClientAssertionGenerator {
+
+    private final BeanContext beanContext;
+
+    JwtClientAssertionGenerator(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @NonNull
+    @Override
+    public String generate(@NonNull TokenRequestContext<?, ? extends TokenResponse> requestContext,
+                           @NonNull ClientAssertionConfiguration clientAssertionConfiguration,
+                           @NonNull String authenticationMethod) {
+        SignatureGeneratorConfiguration signature = switch (authenticationMethod) {
+            case AuthenticationMethods.CLIENT_SECRET_JWT -> clientSecretSignature(requestContext.getClientConfiguration(), clientAssertionConfiguration);
+            case AuthenticationMethods.PRIVATE_KEY_JWT -> privateKeySignature(requestContext.getClientConfiguration(), clientAssertionConfiguration);
+            default -> throw new ConfigurationException("Unsupported OAuth client assertion authentication method: " + authenticationMethod);
+        };
+        try {
+            SignedJWT signedJWT = signature.sign(clientAssertionClaims(requestContext, clientAssertionConfiguration));
+            return signedJWT.serialize();
+        } catch (JOSEException e) {
+            throw new ConfigurationException("Could not generate OAuth client assertion: " + e.getMessage(), e);
+        }
+    }
+
+    private SignatureGeneratorConfiguration clientSecretSignature(OauthClientConfiguration clientConfiguration,
+                                                                 ClientAssertionConfiguration clientAssertionConfiguration) {
+        String clientSecret = clientConfiguration.getClientSecret();
+        if (StringUtils.isEmpty(clientSecret)) {
+            throw new ConfigurationException("OAuth client " + clientConfiguration.getName() + " requires a client secret for client_secret_jwt authentication");
+        }
+        JWSAlgorithm algorithm = new JWSAlgorithm(clientAssertionConfiguration.getSigningAlgorithm()
+                .orElse(ClientAssertionConfiguration.DEFAULT_SIGNING_ALGORITHM));
+        SecretSignatureConfiguration secretSignatureConfiguration = new SecretSignatureConfiguration(clientConfiguration.getName());
+        secretSignatureConfiguration.setSecret(clientSecret);
+        secretSignatureConfiguration.setJwsAlgorithm(algorithm);
+        SecretSignature signature = new SecretSignature(secretSignatureConfiguration);
+        if (!signature.supports(algorithm)) {
+            throw new ConfigurationException("OAuth client " + clientConfiguration.getName() + " client_secret_jwt does not support signing algorithm " + algorithm.getName());
+        }
+        return signature;
+    }
+
+    private SignatureGeneratorConfiguration privateKeySignature(OauthClientConfiguration clientConfiguration,
+                                                               ClientAssertionConfiguration clientAssertionConfiguration) {
+        SignatureGeneratorConfiguration signature = clientAssertionConfiguration.getSignerName()
+                .map(signerName -> beanContext.findBean(SignatureGeneratorConfiguration.class, Qualifiers.byName(signerName))
+                        .orElseThrow(() -> new ConfigurationException("OAuth client " + clientConfiguration.getName() + " private_key_jwt signer not found: " + signerName)))
+                .orElseGet(() -> singleSignatureGenerator(clientConfiguration));
+        if (signature instanceof SecretSignature) {
+            throw new ConfigurationException("OAuth client " + clientConfiguration.getName() + " private_key_jwt requires an asymmetric SignatureGeneratorConfiguration bean");
+        }
+        return signature;
+    }
+
+    private SignatureGeneratorConfiguration singleSignatureGenerator(OauthClientConfiguration clientConfiguration) {
+        Collection<SignatureGeneratorConfiguration> signatures = beanContext.getBeansOfType(SignatureGeneratorConfiguration.class);
+        if (signatures.isEmpty()) {
+            throw new ConfigurationException("OAuth client " + clientConfiguration.getName() + " requires a SignatureGeneratorConfiguration bean for private_key_jwt authentication");
+        }
+        if (signatures.size() > 1) {
+            throw new ConfigurationException("OAuth client " + clientConfiguration.getName() + " private_key_jwt has multiple SignatureGeneratorConfiguration beans; set token.client-assertion.signer-name");
+        }
+        return signatures.iterator().next();
+    }
+
+    private JWTClaimsSet clientAssertionClaims(TokenRequestContext<?, ? extends TokenResponse> requestContext,
+                                              ClientAssertionConfiguration clientAssertionConfiguration) {
+        Duration lifetime = clientAssertionConfiguration.getLifetime();
+        if (lifetime.isZero() || lifetime.isNegative()) {
+            throw new ConfigurationException("OAuth client assertion lifetime must be positive");
+        }
+        OauthClientConfiguration clientConfiguration = requestContext.getClientConfiguration();
+        Date issuedAt = new Date();
+        Date expiration = Date.from(issuedAt.toInstant().plus(lifetime));
+        String clientId = clientConfiguration.getClientId();
+        return new JWTClaimsSet.Builder()
+                .issuer(clientAssertionConfiguration.getIssuer().orElse(clientId))
+                .subject(clientAssertionConfiguration.getSubject().orElse(clientId))
+                .audience(clientAssertionConfiguration.getAudience().orElse(requestContext.getEndpoint().getUrl()))
+                .issueTime(issuedAt)
+                .expirationTime(expiration)
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
@@ -2,9 +2,11 @@ package io.micronaut.security.oauth2.configuration;
 
 import io.micronaut.context.annotation.Property;
 import io.micronaut.security.oauth2.configuration.endpoints.SecureEndpointConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.TokenEndpointConfiguration;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,6 +15,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @Property(name = "micronaut.security.oauth2.clients.stravanew.authorization.url", value = "https://www.strava.com/oauth/authorize")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.token.url", value = "https://www.strava.com/oauth/token")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.token.authentication-method", value = "client_secret_post")
+@Property(name = "micronaut.security.oauth2.clients.stravanew.token.client-assertion.lifetime", value = "PT2M")
+@Property(name = "micronaut.security.oauth2.clients.stravanew.token.client-assertion.audience", value = "https://www.strava.com/oauth/token")
+@Property(name = "micronaut.security.oauth2.clients.stravanew.token.client-assertion.signing-algorithm", value = "HS384")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.client-id", value = "xxx")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.client-secret", value = "yyy")
 @MicronautTest(startApplication = false)
@@ -43,6 +48,18 @@ class OauthClientConfigurationTest {
         SecureEndpointConfiguration tokenNewEndpoint = stravaNewConfiguration.getToken().get();
         assertTrue(tokenNewEndpoint.getAuthenticationMethod().isPresent());
         assertEquals("client_secret_post", tokenNewEndpoint.getAuthenticationMethod().get());
+    }
+
+    @Test
+    void clientAssertionConfigurationIsBound() {
+        assertTrue(stravaNewConfiguration.getToken().isPresent());
+        SecureEndpointConfiguration tokenNewEndpoint = stravaNewConfiguration.getToken().get();
+        assertInstanceOf(TokenEndpointConfiguration.class, tokenNewEndpoint);
+        TokenEndpointConfiguration tokenEndpointConfiguration = (TokenEndpointConfiguration) tokenNewEndpoint;
+        assertTrue(tokenEndpointConfiguration.getClientAssertion().isPresent());
+        assertEquals(Duration.ofMinutes(2), tokenEndpointConfiguration.getClientAssertion().get().getLifetime());
+        assertEquals("https://www.strava.com/oauth/token", tokenEndpointConfiguration.getClientAssertion().get().getAudience().orElseThrow());
+        assertEquals("HS384", tokenEndpointConfiguration.getClientAssertion().get().getSigningAlgorithm().orElseThrow());
     }
 
 }

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationTest.java
@@ -20,11 +20,20 @@ import static org.junit.jupiter.api.Assertions.*;
 @Property(name = "micronaut.security.oauth2.clients.stravanew.token.client-assertion.signing-algorithm", value = "HS384")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.client-id", value = "xxx")
 @Property(name = "micronaut.security.oauth2.clients.stravanew.client-secret", value = "yyy")
+@Property(name = "micronaut.security.oauth2.clients.okta.client-id", value = "xxx")
+@Property(name = "micronaut.security.oauth2.clients.okta.openid.token.url", value = "https://dev-123456.okta.com/oauth2/v1/token")
+@Property(name = "micronaut.security.oauth2.clients.okta.openid.token.client-assertion.lifetime", value = "PT3M")
+@Property(name = "micronaut.security.oauth2.clients.okta.openid.token.client-assertion.audience", value = "https://dev-123456.okta.com/oauth2/v1/token")
+@Property(name = "micronaut.security.oauth2.clients.okta.openid.token.client-assertion.signer-name", value = "assertion")
 @MicronautTest(startApplication = false)
 class OauthClientConfigurationTest {
     @Inject
     @Named("stravanew")
     OauthClientConfiguration stravaNewConfiguration;
+
+    @Inject
+    @Named("okta")
+    OauthClientConfiguration oktaConfiguration;
 
     @Test
     void authorizationServerDefaultsToNull() {
@@ -60,6 +69,17 @@ class OauthClientConfigurationTest {
         assertEquals(Duration.ofMinutes(2), tokenEndpointConfiguration.getClientAssertion().get().getLifetime());
         assertEquals("https://www.strava.com/oauth/token", tokenEndpointConfiguration.getClientAssertion().get().getAudience().orElseThrow());
         assertEquals("HS384", tokenEndpointConfiguration.getClientAssertion().get().getSigningAlgorithm().orElseThrow());
+    }
+
+    @Test
+    void openIdClientAssertionConfigurationIsBound() {
+        assertTrue(oktaConfiguration.getOpenid().isPresent());
+        assertTrue(oktaConfiguration.getOpenid().get().getToken().isPresent());
+        TokenEndpointConfiguration tokenEndpointConfiguration = oktaConfiguration.getOpenid().get().getToken().get();
+        assertTrue(tokenEndpointConfiguration.getClientAssertion().isPresent());
+        assertEquals(Duration.ofMinutes(3), tokenEndpointConfiguration.getClientAssertion().get().getLifetime());
+        assertEquals("https://dev-123456.okta.com/oauth2/v1/token", tokenEndpointConfiguration.getClientAssertion().get().getAudience().orElseThrow());
+        assertEquals("assertion", tokenEndpointConfiguration.getClientAssertion().get().getSignerName().orElseThrow());
     }
 
 }

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClientClientAssertionTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClientClientAssertionTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.oauth2.endpoint.token.request;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.client.DefaultHttpClientConfiguration;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.server.util.HttpHostResolver;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.oauth2.configuration.OauthClientConfiguration;
+import io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties;
+import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
+import io.micronaut.security.oauth2.configuration.endpoints.SecureEndpointConfiguration;
+import io.micronaut.security.oauth2.endpoint.AuthenticationMethods;
+import io.micronaut.security.oauth2.endpoint.DefaultSecureEndpoint;
+import io.micronaut.security.oauth2.endpoint.SecureEndpoint;
+import io.micronaut.security.oauth2.endpoint.token.request.context.TokenRequestContext;
+import io.micronaut.security.oauth2.endpoint.token.response.TokenErrorResponse;
+import io.micronaut.security.oauth2.endpoint.token.response.TokenResponse;
+import io.micronaut.security.oauth2.grants.SecureGrant;
+import io.micronaut.security.oauth2.grants.SecureGrantMap;
+import io.micronaut.security.rules.SecurityRule;
+import io.micronaut.security.token.jwt.signature.SignatureGeneratorConfiguration;
+import io.micronaut.runtime.server.EmbeddedServer;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultTokenEndpointClientClientAssertionTest {
+
+    private static final String TOKEN_URL = "https://authorization-server.example.com/oauth/token";
+    private static final String CLIENT_ID = "client-id";
+    private static final String CLIENT_SECRET = "012345678901234567890123456789012345678901234567";
+    private static final String CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    private static final String INTEGRATION_SPEC_NAME = "DefaultTokenEndpointClientClientAssertionIntegrationTest";
+
+    @Test
+    void clientSecretBasicBehaviorIsUnchanged() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+            Map<String, String> grant = new SecureGrantMap();
+            MutableHttpRequest<Map<String, String>> request = request(grant);
+
+            client.secure(request, context(AuthenticationMethods.CLIENT_SECRET_BASIC, clientConfiguration(CLIENT_SECRET, Optional.empty(), Optional.empty())));
+
+            assertTrue(request.getHeaders().contains("Authorization"));
+            assertFalse(grant.containsKey(SecureGrant.KEY_CLIENT_ID));
+            assertFalse(grant.containsKey(SecureGrant.KEY_CLIENT_SECRET));
+        }
+    }
+
+    @Test
+    void clientSecretPostBehaviorIsUnchanged() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+            Map<String, String> grant = new SecureGrantMap();
+            MutableHttpRequest<Map<String, String>> request = request(grant);
+
+            client.secure(request, context(AuthenticationMethods.CLIENT_SECRET_POST, clientConfiguration(CLIENT_SECRET, Optional.empty(), Optional.empty())));
+
+            assertFalse(request.getHeaders().contains("Authorization"));
+            assertEquals(CLIENT_ID, grant.get(SecureGrant.KEY_CLIENT_ID));
+            assertEquals(CLIENT_SECRET, grant.get(SecureGrant.KEY_CLIENT_SECRET));
+        }
+    }
+
+    @Test
+    void clientSecretJwtAddsClientAssertionParameters() throws ParseException, JOSEException {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+            OauthClientConfigurationProperties.TokenEndpointConfigurationProperties token = tokenEndpointConfiguration();
+            OauthClientConfigurationProperties.TokenEndpointConfigurationProperties.ClientAssertionConfigurationProperties clientAssertion = new OauthClientConfigurationProperties.TokenEndpointConfigurationProperties.ClientAssertionConfigurationProperties();
+            clientAssertion.setLifetime(Duration.ofMinutes(2));
+            clientAssertion.setIssuer("issuer");
+            clientAssertion.setSubject("subject");
+            clientAssertion.setAudience("audience");
+            clientAssertion.setSigningAlgorithm("HS384");
+            token.setClientAssertion(clientAssertion);
+            Map<String, String> grant = new SecureGrantMap();
+            grant.put(SecureGrant.KEY_CLIENT_SECRET, "must-be-removed");
+            MutableHttpRequest<Map<String, String>> request = request(grant);
+
+            client.secure(request, context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration(CLIENT_SECRET, Optional.of(token), Optional.empty())));
+
+            assertFalse(request.getHeaders().contains("Authorization"));
+            assertEquals(CLIENT_ID, grant.get(SecureGrant.KEY_CLIENT_ID));
+            assertFalse(grant.containsKey(SecureGrant.KEY_CLIENT_SECRET));
+            assertEquals("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", grant.get("client_assertion_type"));
+            SignedJWT jwt = SignedJWT.parse(grant.get("client_assertion"));
+            assertEquals(JWSAlgorithm.HS384, jwt.getHeader().getAlgorithm());
+            assertTrue(jwt.verify(new MACVerifier(CLIENT_SECRET)));
+            JWTClaimsSet claims = jwt.getJWTClaimsSet();
+            assertEquals("issuer", claims.getIssuer());
+            assertEquals("subject", claims.getSubject());
+            assertEquals(List.of("audience"), claims.getAudience());
+            assertNotNull(claims.getIssueTime());
+            assertNotNull(claims.getExpirationTime());
+            assertNotNull(claims.getJWTID());
+        }
+    }
+
+    @Test
+    void sendRequestPostsClientAssertionAcceptedByTokenEndpoint() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of("spec.name", INTEGRATION_SPEC_NAME))) {
+            ApplicationContext context = server.getApplicationContext();
+            try (HttpClient httpClient = context.createBean(HttpClient.class, server.getURL())) {
+                context.registerSingleton(HttpClient.class, httpClient, Qualifiers.byName("test"));
+                TokenRequestContext<Map<String, String>, TokenResponse> requestContext = context(
+                        server.getURL() + "/token",
+                        AuthenticationMethods.CLIENT_SECRET_JWT,
+                        clientConfiguration(CLIENT_SECRET, Optional.empty(), Optional.empty())
+                );
+
+                TokenResponse tokenResponse = Flux.from(client(context).sendRequest(requestContext)).blockFirst();
+
+                assertNotNull(tokenResponse);
+                assertEquals("accepted", tokenResponse.getAccessToken());
+            }
+        }
+    }
+
+    @Test
+    void clientSecretJwtGeneratesAssertionPerRequest() throws ParseException {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+            OauthClientConfiguration clientConfiguration = clientConfiguration(CLIENT_SECRET, Optional.empty(), Optional.empty());
+            Map<String, String> firstGrant = new SecureGrantMap();
+            Map<String, String> secondGrant = new SecureGrantMap();
+
+            client.secure(request(firstGrant), context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration));
+            client.secure(request(secondGrant), context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration));
+
+            assertNotEquals(
+                    SignedJWT.parse(firstGrant.get("client_assertion")).getJWTClaimsSet().getJWTID(),
+                    SignedJWT.parse(secondGrant.get("client_assertion")).getJWTClaimsSet().getJWTID()
+            );
+        }
+    }
+
+    @Test
+    void privateKeyJwtUsesConfiguredSigner() throws ParseException {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "private-key-jwt"))) {
+            ExposedTokenEndpointClient client = client(context);
+            OauthClientConfigurationProperties.TokenEndpointConfigurationProperties token = tokenEndpointConfiguration();
+            OauthClientConfigurationProperties.TokenEndpointConfigurationProperties.ClientAssertionConfigurationProperties clientAssertion = new OauthClientConfigurationProperties.TokenEndpointConfigurationProperties.ClientAssertionConfigurationProperties();
+            clientAssertion.setSignerName("assertion");
+            token.setClientAssertion(clientAssertion);
+            Map<String, String> grant = new SecureGrantMap();
+
+            client.secure(request(grant), context(AuthenticationMethods.PRIVATE_KEY_JWT, clientConfiguration(null, Optional.of(token), Optional.empty())));
+
+            SignedJWT jwt = SignedJWT.parse(grant.get("client_assertion"));
+            assertEquals(JWSAlgorithm.RS256, jwt.getHeader().getAlgorithm());
+            assertEquals("assertion-kid", jwt.getHeader().getKeyID());
+            assertEquals(CLIENT_ID, jwt.getJWTClaimsSet().getIssuer());
+            assertEquals(CLIENT_ID, jwt.getJWTClaimsSet().getSubject());
+            assertEquals(List.of(TOKEN_URL), jwt.getJWTClaimsSet().getAudience());
+        }
+    }
+
+    @Test
+    void missingClientSecretFailsClosed() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+
+            ConfigurationException exception = assertThrows(ConfigurationException.class,
+                    () -> client.secure(request(new SecureGrantMap()), context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()))));
+
+            assertTrue(exception.getMessage().contains("requires a client secret"));
+        }
+    }
+
+    @Test
+    void missingPrivateKeySignerFailsClosed() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            ExposedTokenEndpointClient client = client(context);
+
+            ConfigurationException exception = assertThrows(ConfigurationException.class,
+                    () -> client.secure(request(new SecureGrantMap()), context(AuthenticationMethods.PRIVATE_KEY_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()))));
+
+            assertTrue(exception.getMessage().contains("requires a SignatureGeneratorConfiguration bean"));
+        }
+    }
+
+    private static MutableHttpRequest<Map<String, String>> request(Map<String, String> grant) {
+        return HttpRequest.POST(TOKEN_URL, grant);
+    }
+
+    private static TokenRequestContext<Map<String, String>, TokenResponse> context(String authenticationMethod,
+                                                                                   OauthClientConfiguration clientConfiguration) {
+        return new TestTokenRequestContext(new DefaultSecureEndpoint(TOKEN_URL, Set.of(authenticationMethod)), clientConfiguration);
+    }
+
+    private static TokenRequestContext<Map<String, String>, TokenResponse> context(String url,
+                                                                                   String authenticationMethod,
+                                                                                   OauthClientConfiguration clientConfiguration) {
+        return new TestTokenRequestContext(new DefaultSecureEndpoint(url, Set.of(authenticationMethod)), clientConfiguration);
+    }
+
+    private static OauthClientConfiguration clientConfiguration(String clientSecret,
+                                                               Optional<SecureEndpointConfiguration> token,
+                                                               Optional<OpenIdClientConfiguration> openid) {
+        OauthClientConfiguration clientConfiguration = mock(OauthClientConfiguration.class);
+        when(clientConfiguration.getName()).thenReturn("test");
+        when(clientConfiguration.getClientId()).thenReturn(CLIENT_ID);
+        when(clientConfiguration.getClientSecret()).thenReturn(clientSecret);
+        when(clientConfiguration.getToken()).thenReturn(token);
+        when(clientConfiguration.getOpenid()).thenReturn(openid);
+        return clientConfiguration;
+    }
+
+    private static OauthClientConfigurationProperties.TokenEndpointConfigurationProperties tokenEndpointConfiguration() {
+        OauthClientConfigurationProperties.TokenEndpointConfigurationProperties token = new OauthClientConfigurationProperties.TokenEndpointConfigurationProperties();
+        token.setUrl(TOKEN_URL);
+        return token;
+    }
+
+    private static ExposedTokenEndpointClient client(ApplicationContext context) {
+        return new ExposedTokenEndpointClient(
+                context,
+                new DefaultHttpClientConfiguration(),
+                context.findBean(DefaultTokenEndpointClient.ClientAssertionGenerator.class)
+        );
+    }
+
+    private static final class ExposedTokenEndpointClient extends DefaultTokenEndpointClient {
+
+        ExposedTokenEndpointClient(ApplicationContext beanContext,
+                                   HttpClientConfiguration defaultClientConfiguration,
+                                   Optional<ClientAssertionGenerator> clientAssertionGenerator) {
+            super(beanContext, defaultClientConfiguration, clientAssertionGenerator);
+        }
+
+        void secure(MutableHttpRequest<Map<String, String>> request,
+                    TokenRequestContext<Map<String, String>, TokenResponse> requestContext) {
+            secureRequest(request, requestContext);
+        }
+    }
+
+    private record TestTokenRequestContext(SecureEndpoint endpoint,
+                                           OauthClientConfiguration clientConfiguration) implements TokenRequestContext<Map<String, String>, TokenResponse> {
+
+        @Override
+        public Map<String, String> getGrant() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public Argument<TokenResponse> getResponseType() {
+            return Argument.of(TokenResponse.class);
+        }
+
+        @Override
+        public Argument<?> getErrorResponseType() {
+            return Argument.of(TokenErrorResponse.class);
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            return MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+        }
+
+        @Override
+        public SecureEndpoint getEndpoint() {
+            return endpoint;
+        }
+
+        @Override
+        public OauthClientConfiguration getClientConfiguration() {
+            return clientConfiguration;
+        }
+    }
+
+    @Singleton
+    @Named("assertion")
+    @Requires(property = "spec.name", value = "private-key-jwt")
+    static final class TestRsaSignatureGenerator implements SignatureGeneratorConfiguration {
+        private static final KeyPair KEY_PAIR = keyPair();
+
+        @Override
+        public SignedJWT sign(JWTClaimsSet claims) throws JOSEException {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("assertion-kid").build(), claims);
+            jwt.sign(new RSASSASigner((RSAPrivateKey) KEY_PAIR.getPrivate()));
+            return jwt;
+        }
+
+        @Override
+        public String supportedAlgorithmsMessage() {
+            return "Only RSA algorithms are supported";
+        }
+
+        @Override
+        public boolean supports(JWSAlgorithm algorithm) {
+            return JWSAlgorithm.Family.RSA.contains(algorithm);
+        }
+
+        @Override
+        public boolean verify(SignedJWT jwt) throws JOSEException {
+            return jwt.verify(new RSASSAVerifier((RSAPublicKey) KEY_PAIR.getPublic()));
+        }
+
+        private static KeyPair keyPair() {
+            try {
+                KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+                generator.initialize(2048);
+                return generator.generateKeyPair();
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    @Controller("/token")
+    @Requires(property = "spec.name", value = INTEGRATION_SPEC_NAME)
+    static final class ClientAssertionTokenController {
+        private final HttpHostResolver httpHostResolver;
+
+        ClientAssertionTokenController(HttpHostResolver httpHostResolver) {
+            this.httpHostResolver = httpHostResolver;
+        }
+
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Secured(SecurityRule.IS_ANONYMOUS)
+        @Post
+        HttpResponse<TokenResponse> token(HttpRequest<?> request, @Body Map<String, String> body) throws ParseException, JOSEException {
+            if (!CLIENT_ID.equals(body.get(SecureGrant.KEY_CLIENT_ID))) {
+                return HttpResponse.badRequest();
+            }
+            if (body.containsKey(SecureGrant.KEY_CLIENT_SECRET)) {
+                return HttpResponse.badRequest();
+            }
+            if (!CLIENT_ASSERTION_TYPE.equals(body.get("client_assertion_type"))) {
+                return HttpResponse.badRequest();
+            }
+            String clientAssertion = body.get("client_assertion");
+            if (clientAssertion == null) {
+                return HttpResponse.badRequest();
+            }
+            SignedJWT jwt = SignedJWT.parse(clientAssertion);
+            if (!jwt.verify(new MACVerifier(CLIENT_SECRET))) {
+                return HttpResponse.badRequest();
+            }
+            JWTClaimsSet claims = jwt.getJWTClaimsSet();
+            String tokenUrl = httpHostResolver.resolve(request) + request.getPath();
+            if (!CLIENT_ID.equals(claims.getIssuer())
+                    || !CLIENT_ID.equals(claims.getSubject())
+                    || !claims.getAudience().contains(tokenUrl)
+                    || claims.getJWTID() == null) {
+                return HttpResponse.badRequest();
+            }
+            return HttpResponse.ok(new TokenResponse("accepted", "bearer"));
+        }
+    }
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClientClientAssertionTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/endpoint/token/request/DefaultTokenEndpointClientClientAssertionTest.java
@@ -88,7 +88,7 @@ class DefaultTokenEndpointClientClientAssertionTest {
     private static final String CLIENT_ID = "client-id";
     private static final String CLIENT_SECRET = "012345678901234567890123456789012345678901234567";
     private static final String CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
-    private static final String INTEGRATION_SPEC_NAME = "DefaultTokenEndpointClientClientAssertionIntegrationTest";
+    private static final String INTEGRATION_SPEC_NAME = "DefaultTokenEndpointClientClientAssertionTest";
 
     @Test
     void clientSecretBasicBehaviorIsUnchanged() {
@@ -218,9 +218,11 @@ class DefaultTokenEndpointClientClientAssertionTest {
     void missingClientSecretFailsClosed() {
         try (ApplicationContext context = ApplicationContext.run()) {
             ExposedTokenEndpointClient client = client(context);
+            MutableHttpRequest<Map<String, String>> request = request(new SecureGrantMap());
+            TokenRequestContext<Map<String, String>, TokenResponse> requestContext = context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()));
 
             ConfigurationException exception = assertThrows(ConfigurationException.class,
-                    () -> client.secure(request(new SecureGrantMap()), context(AuthenticationMethods.CLIENT_SECRET_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()))));
+                    () -> client.secure(request, requestContext));
 
             assertTrue(exception.getMessage().contains("requires a client secret"));
         }
@@ -230,9 +232,11 @@ class DefaultTokenEndpointClientClientAssertionTest {
     void missingPrivateKeySignerFailsClosed() {
         try (ApplicationContext context = ApplicationContext.run()) {
             ExposedTokenEndpointClient client = client(context);
+            MutableHttpRequest<Map<String, String>> request = request(new SecureGrantMap());
+            TokenRequestContext<Map<String, String>, TokenResponse> requestContext = context(AuthenticationMethods.PRIVATE_KEY_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()));
 
             ConfigurationException exception = assertThrows(ConfigurationException.class,
-                    () -> client.secure(request(new SecureGrantMap()), context(AuthenticationMethods.PRIVATE_KEY_JWT, clientConfiguration(null, Optional.empty(), Optional.empty()))));
+                    () -> client.secure(request, requestContext));
 
             assertTrue(exception.getMessage().contains("requires a SignatureGeneratorConfiguration bean"));
         }

--- a/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
@@ -48,7 +48,7 @@ micronaut:
           client-secret: <<my client secret>>
           token:
             url: https://github.com/login/oauth/access_token
-            auth-method: client_secret_jwt
+            authentication-method: client_secret_jwt
             client-assertion:
               lifetime: 2m
               signing-algorithm: HS256
@@ -73,7 +73,7 @@ micronaut:
           client-id: <<my client id>>
           token:
             url: https://github.com/login/oauth/access_token
-            auth-method: private_key_jwt
+            authentication-method: private_key_jwt
             client-assertion:
               signer-name: assertion
               lifetime: 2m

--- a/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/oauth2-authorization-code/oauth2-configuration.adoc
@@ -31,8 +31,56 @@ micronaut:
 - Optionally specify desired `scopes`
 - Provide an `authorization` endpoint URL
 - Additionally, the `token` endpoint URL and authentication method
-- `auth-method` is one of api:security.oauth2.endpoint.AuthenticationMethod[]. Choose the one your provider requires.
+- `auth-method` is one of api:security.oauth2.endpoint.AuthenticationMethods[]. Choose the one your provider requires.
 
-Authentication methods are not clearly defined in link:https://tools.ietf.org/html/rfc6749#section-3.2.1[RFC 6749], however most OAuth 2.0 providers either accept `client-secret-basic` (basic authentication with id and secret), or `client-secret-post` (client id and secret are sent in the request body).
+Authentication methods are not clearly defined in link:https://tools.ietf.org/html/rfc6749#section-3.2.1[RFC 6749], however most OAuth 2.0 providers either accept `client_secret_basic` (basic authentication with id and secret), or `client_secret_post` (client id and secret are sent in the request body).
+
+Micronaut also supports link:https://www.rfc-editor.org/rfc/rfc7523#section-2.2[RFC 7523 JWT client authentication] for token endpoint requests. With `client_secret_jwt`, the OAuth client secret signs a short-lived JWT assertion:
+
+[configuration]
+----
+micronaut:
+  security:
+    oauth2:
+      clients:
+        github:
+          client-id: <<my client id>>
+          client-secret: <<my client secret>>
+          token:
+            url: https://github.com/login/oauth/access_token
+            auth-method: client_secret_jwt
+            client-assertion:
+              lifetime: 2m
+              signing-algorithm: HS256
+----
+
+With `private_key_jwt`, configure a JWT signature generator and point the token endpoint at that signer:
+
+[configuration]
+----
+micronaut:
+  security:
+    token:
+      jwt:
+        signatures:
+          rsa:
+            assertion:
+              # configure private signing material for this signer
+              jws-algorithm: RS256
+    oauth2:
+      clients:
+        github:
+          client-id: <<my client id>>
+          token:
+            url: https://github.com/login/oauth/access_token
+            auth-method: private_key_jwt
+            client-assertion:
+              signer-name: assertion
+              lifetime: 2m
+----
+
+For both JWT methods, Micronaut sends `client_id`, `client_assertion_type`, and `client_assertion` in the token request body. By default the assertion issuer and subject are the client id, the audience is the token endpoint URL, and each request gets a new `jti`. Keep client secrets and private keys out of logs and source control.
+
+include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$TokenEndpointConfigurationProperties$ClientAssertionConfigurationProperties.adoc[]
 
 TIP: To disable a specific client for any given environment, set `enabled: false` within the client configuration.

--- a/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-configuration.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-configuration.adoc
@@ -36,7 +36,7 @@ micronaut:
                     openid:
                         issuer: <<my openid issuer>>
                         token:
-                            auth-method: client_secret_jwt
+                            authentication-method: client_secret_jwt
                             client-assertion:
                                 lifetime: 2m
                                 signing-algorithm: HS256
@@ -62,7 +62,7 @@ micronaut:
                     openid:
                         issuer: <<my openid issuer>>
                         token:
-                            auth-method: private_key_jwt
+                            authentication-method: private_key_jwt
                             client-assertion:
                                 signer-name: assertion
                                 lifetime: 2m

--- a/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-configuration.adoc
+++ b/src/main/docs/guide/oauth/flows/authorization-code/openid-authorization-code/openid-configuration.adoc
@@ -22,6 +22,54 @@ micronaut:
 
 The issuer URL will be used to discover the endpoints exposed by the provider.
 
+If the provider requires JWT client authentication at the token endpoint, configure the discovered token endpoint authentication method explicitly. For `client_secret_jwt`, the OAuth client secret signs the assertion:
+
+[configuration]
+----
+micronaut:
+    security:
+        oauth2:
+            clients:
+                okta:
+                    client-id: <<my client id>>
+                    client-secret: <<my client secret>>
+                    openid:
+                        issuer: <<my openid issuer>>
+                        token:
+                            auth-method: client_secret_jwt
+                            client-assertion:
+                                lifetime: 2m
+                                signing-algorithm: HS256
+----
+
+For `private_key_jwt`, configure a JWT signature generator and select it by name:
+
+[configuration]
+----
+micronaut:
+    security:
+        token:
+            jwt:
+                signatures:
+                    rsa:
+                        assertion:
+                            # configure private signing material for this signer
+                            jws-algorithm: RS256
+        oauth2:
+            clients:
+                okta:
+                    client-id: <<my client id>>
+                    openid:
+                        issuer: <<my openid issuer>>
+                        token:
+                            auth-method: private_key_jwt
+                            client-assertion:
+                                signer-name: assertion
+                                lifetime: 2m
+----
+
+For both JWT methods, Micronaut sends `client_id`, `client_assertion_type`, and `client_assertion` in the token request body. By default the assertion issuer and subject are the client id, the audience is the token endpoint URL, and each request gets a new `jti`. Keep client secrets and private keys out of logs and source control.
+
 TIP: To disable a specific client for any given environment, set `enabled: false` within the client configuration.
 
 See the following tables for the configuration options:
@@ -29,6 +77,7 @@ See the following tables for the configuration options:
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties.adoc[]
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$AuthorizationEndpointConfigurationProperties.adoc[]
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$TokenEndpointConfigurationProperties.adoc[]
+include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$TokenEndpointConfigurationProperties$ClientAssertionConfigurationProperties.adoc[]
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$EndSessionConfigurationProperties.adoc[]
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$RegistrationEndpointConfigurationProperties.adoc[]
 include::{includedir}configurationProperties/io.micronaut.security.oauth2.configuration.OauthClientConfigurationProperties$OpenIdClientConfigurationProperties$UserInfoEndpointConfigurationProperties.adoc[]


### PR DESCRIPTION
## Summary
- Add token endpoint JWT client assertion support for `client_secret_jwt` and `private_key_jwt`.
- Add `token.client-assertion.*` and `openid.token.client-assertion.*` configuration for lifetime, audience, issuer, subject, signing algorithm, and signer selection.
- Cover request shaping, fail-closed misconfiguration, signer behavior, per-request `jti`, embedded token endpoint handling, and docs for OAuth/OpenID configuration.

## Release Target
- Target branch: `5.1.x`
- Release target: `5.1.0`
- Micronaut organization project: `5.1.0 Release`
- Type label: `type: enhancement`

## Tests
- `git diff --check origin/5.1.x...HEAD`
- `./gradlew :micronaut-security-oauth2:test --tests 'io.micronaut.security.oauth2.endpoint.token.request.DefaultTokenEndpointClientClientAssertionTest' --rerun-tasks`

## PR Assets
None. This change updates source, tests, and AsciiDoc documentation only; no rendered screenshots, PDFs, logs, archives, or generated binary artifacts are required.

Closes #1511

---
###### ✨ This message was AI-generated using gpt-5
