### PR TITLE
Allow cookie token reading without cookie auth mode

### DIFF
--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/CookieEnabledSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/cookie/CookieEnabledSpec.groovy
@@ -1,10 +1,13 @@
 package io.micronaut.security.token.jwt.cookie
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.security.testutils.ApplicationContextSpecification
 import io.micronaut.security.token.cookie.AccessTokenCookieConfiguration
 import io.micronaut.security.token.cookie.CookieTokenReader
+import io.micronaut.security.token.cookie.TokenCookieClearerLogoutHandler
 import io.micronaut.security.token.cookie.TokenCookieConfigurationProperties
+import io.micronaut.security.token.cookie.TokenCookieLoginHandler
 import spock.lang.Unroll
 
 class CookieEnabledSpec extends ApplicationContextSpecification {
@@ -24,6 +27,44 @@ class CookieEnabledSpec extends ApplicationContextSpecification {
         then:
         def e = thrown(NoSuchBeanException)
         e.message.contains('No bean of type ['+clazz.name+'] exists.')
+
+        where:
+        clazz << [
+                AccessTokenCookieConfiguration,
+                TokenCookieConfigurationProperties,
+                CookieTokenReader,
+        ]
+
+        description = clazz.name
+    }
+
+    void "cookie token reader can be enabled without cookie authentication mode"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+                'micronaut.security.token.cookie.enabled': true,
+        ])
+
+        expect:
+        ctx.containsBean(AccessTokenCookieConfiguration)
+        ctx.containsBean(TokenCookieConfigurationProperties)
+        ctx.containsBean(CookieTokenReader)
+        !ctx.containsBean(TokenCookieLoginHandler)
+        !ctx.containsBean(TokenCookieClearerLogoutHandler)
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Unroll("without cookie authentication mode or explicit opt-in bean [#description] is not loaded")
+    void "cookie token beans are not loaded without authentication mode or explicit opt-in"(Class clazz, String description) {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([:])
+
+        expect:
+        !ctx.containsBean(clazz)
+
+        cleanup:
+        ctx.close()
 
         where:
         clazz << [

--- a/security/src/main/java/io/micronaut/security/token/cookie/CookieTokenReader.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/CookieTokenReader.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.cookie.Cookie;
-import io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition;
 import io.micronaut.security.token.reader.TokenReader;
 import jakarta.inject.Singleton;
 
@@ -32,7 +31,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Requires(classes = HttpRequest.class)
-@Requires(condition = CookieBasedAuthenticationModeCondition.class)
+@Requires(condition = TokenCookieEnabledCondition.class)
 @Requires(property = TokenCookieConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @Singleton
 public class CookieTokenReader implements TokenReader<HttpRequest<?>> {

--- a/security/src/main/java/io/micronaut/security/token/cookie/CookieTokenReader.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/CookieTokenReader.java
@@ -25,7 +25,7 @@ import jakarta.inject.Singleton;
 import java.util.Optional;
 
 /**
- * Reads the token from the configured io.micronaut.security.token.jwt.cookie.
+ * Reads the token from the configured {@value TokenCookieConfigurationProperties#PREFIX}.
  *
  * @author Sergio del Amo
  * @since 1.0

--- a/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieConfigurationProperties.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieConfigurationProperties.java
@@ -21,7 +21,6 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.cookie.CookieConfiguration;
-import io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition;
 import io.micronaut.security.token.config.TokenConfigurationProperties;
 import java.util.Optional;
 
@@ -31,7 +30,7 @@ import java.util.Optional;
  * @since 1.0
  */
 @Requires(classes = CookieConfiguration.class)
-@Requires(condition = CookieBasedAuthenticationModeCondition.class)
+@Requires(condition = TokenCookieEnabledCondition.class)
 @Requires(property = TokenCookieConfigurationProperties.PREFIX + ".enabled", notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
 @ConfigurationProperties(TokenCookieConfigurationProperties.PREFIX)
 public class TokenCookieConfigurationProperties extends AbstractAccessTokenCookieConfigurationProperties implements AccessTokenCookieConfiguration {

--- a/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieEnabledCondition.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieEnabledCondition.java
@@ -32,8 +32,8 @@ final class TokenCookieEnabledCondition implements Condition {
     public boolean matches(ConditionContext context) {
         PropertyResolver propertyResolver = context.getBeanContext().getBean(PropertyResolver.class);
         String propertyName = TokenCookieConfigurationProperties.PREFIX + ".enabled";
-        return propertyResolver.containsProperty(propertyName)
-            && propertyResolver.get(propertyName, Boolean.class).orElse(false)
-            || cookieBasedAuthenticationModeCondition.matches(context);
+        boolean explicitCookieTokenReaderOptIn = propertyResolver.containsProperty(propertyName)
+            && propertyResolver.get(propertyName, Boolean.class).orElse(false);
+        return explicitCookieTokenReaderOptIn || cookieBasedAuthenticationModeCondition.matches(context);
     }
 }

--- a/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieEnabledCondition.java
+++ b/security/src/main/java/io/micronaut/security/token/cookie/TokenCookieEnabledCondition.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.security.token.cookie;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+import io.micronaut.core.value.PropertyResolver;
+import io.micronaut.security.authentication.CookieBasedAuthenticationModeCondition;
+
+/**
+ * Condition that enables access-token cookie reading for cookie authentication modes or explicit opt-in.
+ */
+final class TokenCookieEnabledCondition implements Condition {
+
+    private final CookieBasedAuthenticationModeCondition cookieBasedAuthenticationModeCondition =
+        new CookieBasedAuthenticationModeCondition();
+
+    @Override
+    public boolean matches(ConditionContext context) {
+        PropertyResolver propertyResolver = context.getBeanContext().getBean(PropertyResolver.class);
+        String propertyName = TokenCookieConfigurationProperties.PREFIX + ".enabled";
+        return propertyResolver.containsProperty(propertyName)
+            && propertyResolver.get(propertyName, Boolean.class).orElse(false)
+            || cookieBasedAuthenticationModeCondition.matches(context);
+    }
+}

--- a/src/main/docs/guide/authenticationStrategies/jwt/reader/cookieToken.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/reader/cookieToken.adoc
@@ -5,6 +5,7 @@ The following sequence illustrates the authentication flow:
 image::jwt-cookie.svg[]
 
 Reading tokens from Cookies is disabled by default. Note that using JWT tokens from cookies requires JWT Authentication to be enabled.
+Set `micronaut.security.token.cookie.enabled=true` to read JWT tokens from cookies without enabling Cookie Authentication login and logout handlers.
 
 include::{includedir}configurationProperties/io.micronaut.security.token.cookie.TokenCookieConfigurationProperties.adoc[]
 

--- a/src/main/docs/guide/securityFilter/builtInAuthenticationFetchers/tokenAuthenticationFetcher/tokenReaders/cookieTokenReader.adoc
+++ b/src/main/docs/guide/securityFilter/builtInAuthenticationFetchers/tokenAuthenticationFetcher/tokenReaders/cookieTokenReader.adoc
@@ -1,5 +1,7 @@
 api:io.micronaut.security.token.cookie.CookieTokenReader[] attempts to read token from a request cookie.
 
+Set `micronaut.security.token.cookie.enabled=true` to enable cookie token reading without enabling the Cookie Authentication login and logout handlers.
+
 The following configuration properties are available to customize how the token will be read from a cookie:
 
 include::{includedir}configurationProperties/io.micronaut.security.token.cookie.TokenCookieConfigurationProperties.adoc[]


### PR DESCRIPTION
Fixes #962

## Summary
- enable access-token cookie reader/configuration when `micronaut.security.token.cookie.enabled=true` is explicitly set
- keep cookie login/logout handlers and refresh-cookie surfaces gated by the existing cookie/idtoken authentication mode
- document the independent cookie token reader opt-in

## Validation
- `./gradlew :micronaut-security:compileJava :micronaut-security-jwt:test --tests io.micronaut.security.token.jwt.cookie.CookieEnabledSpec --no-daemon`
- `./gradlew :micronaut-security:checkstyleMain --no-daemon` (build successful; existing generated descriptor Javadoc warning remains)

## Release Metadata
- Target branch: `5.1.x`
- Target release: `5.1.0`
- Micronaut organization project: `5.1.0 Release`

---
###### ✨ This message was AI-generated using gpt-5.5
