### PR TITLE
Document ClaimsAudienceProvider

### DIFF
--- a/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/claims/JWTClaimsSetGeneratorSpec.groovy
+++ b/security-jwt/src/test/groovy/io/micronaut/security/token/jwt/generator/claims/JWTClaimsSetGeneratorSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.security.token.jwt.generator.claims
 
 import io.micronaut.security.authentication.Authentication
 import io.micronaut.security.token.Claims
+import io.micronaut.security.token.claims.ClaimsAudienceProvider
 import io.micronaut.security.token.config.TokenConfiguration
 import spock.lang.Specification
 
@@ -25,5 +26,17 @@ class JWTClaimsSetGeneratorSpec extends Specification {
         expectedClaimsNames.each { String claimName ->
             assert claims.get(claimName)
         }
+    }
+
+    def "generateClaims includes aud claim when ClaimsAudienceProvider bean is present"() {
+        given:
+        ClaimsAudienceProvider claimsAudienceProvider = { ['https://api.example.com'] }
+        JWTClaimsSetGenerator generator = new JWTClaimsSetGenerator(new TokenConfiguration() {}, null, claimsAudienceProvider, null)
+
+        when:
+        Map<String, Object> claims = generator.generateClaims(Authentication.build('admin', ['ROLE_USER']), 3600)
+
+        then:
+        claims[Claims.AUDIENCE] == ['https://api.example.com']
     }
 }

--- a/src/main/docs/guide/authenticationStrategies/jwt/claimsGeneration.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/claimsGeneration.adoc
@@ -1,3 +1,20 @@
 If the built-in
 link:{api}/io/micronaut/security/token/jwt/generator/claims/JWTClaimsSetGenerator.html[JWTClaimsSetGenerator], does not
-fulfil your needs you can provide your own https://micronaut-projects.github.io/micronaut-core/latest/guide/#replaces[replacement] of link:{api}/io/micronaut/security/token/jwt/generator/claims/ClaimsGenerator.html[ClaimsGenerator].
+fulfil your needs, you can provide your own https://micronaut-projects.github.io/micronaut-core/latest/guide/#replaces[replacement] of api:io.micronaut.security.token.claims.ClaimsGenerator[].
+
+The built-in `JWTClaimsSetGenerator` adds the `aud` claim when the application provides a bean of type api:io.micronaut.security.token.claims.ClaimsAudienceProvider[].
+The value returned by `audience()` is used as the JWT audience:
+
+snippet::io.micronaut.docs.claimsaudience.CustomClaimsAudienceProvider[tags="clazz"]
+
+If another Micronaut application validates the generated JWT, configure the expected audience with `micronaut.security.token.jwt.claims-validators.audience`:
+
+[configuration]
+----
+micronaut:
+  security:
+    token:
+      jwt:
+        claims-validators:
+          audience: https://api.example.com
+----

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.groovy
@@ -8,10 +8,11 @@ import jakarta.inject.Singleton
 //tag::clazz[]
 @Singleton
 class CustomClaimsAudienceProvider implements ClaimsAudienceProvider {
+    private static final ArrayList<String> AUDIENCE = ["https://api.example.com"]
 
     @Override
     List<String> audience() {
-        ["https://api.example.com"]
+        AUDIENCE
     }
 }
 //end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.groovy
@@ -1,0 +1,17 @@
+package io.micronaut.docs.claimsaudience
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.security.token.claims.ClaimsAudienceProvider
+import jakarta.inject.Singleton
+
+@Requires(property = "spec.name", value = "claims-generation-docs")
+//tag::clazz[]
+@Singleton
+class CustomClaimsAudienceProvider implements ClaimsAudienceProvider {
+
+    @Override
+    List<String> audience() {
+        ["https://api.example.com"]
+    }
+}
+//end::clazz[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.docs.claimsaudience
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.token.Claims
+import io.micronaut.security.token.claims.ClaimsAudienceProvider
+import io.micronaut.security.token.claims.ClaimsGenerator
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@Property(name = "spec.name", value = "claims-generation-docs")
+@MicronautTest(startApplication = false)
+class CustomClaimsAudienceProviderSpec extends Specification {
+
+    @Inject
+    ClaimsAudienceProvider claimsAudienceProvider
+
+    @Inject
+    ClaimsGenerator claimsGenerator
+
+    void "custom claims audience provider supplies JWT audience claim"() {
+        when:
+        Map<String, Object> claims = claimsGenerator.generateClaims(Authentication.build("sherlock"), 3600)
+
+        then:
+        claimsAudienceProvider.audience() == ["https://api.example.com"]
+        claims[Claims.AUDIENCE] == ["https://api.example.com"]
+    }
+}

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.kt
@@ -1,0 +1,13 @@
+package io.micronaut.docs.claimsaudience
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.security.token.claims.ClaimsAudienceProvider
+import jakarta.inject.Singleton
+
+@Requires(property = "spec.name", value = "claims-generation-docs")
+//tag::clazz[]
+@Singleton
+class CustomClaimsAudienceProvider : ClaimsAudienceProvider {
+    override fun audience(): List<String> = listOf("https://api.example.com")
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderTest.kt
+++ b/test-suite-kotlin/src/test/kotlin/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderTest.kt
@@ -1,0 +1,30 @@
+package io.micronaut.docs.claimsaudience
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.security.token.Claims
+import io.micronaut.security.token.claims.ClaimsAudienceProvider
+import io.micronaut.security.token.claims.ClaimsGenerator
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@Property(name = "spec.name", value = "claims-generation-docs")
+@MicronautTest(startApplication = false)
+class CustomClaimsAudienceProviderTest {
+
+    @Inject
+    lateinit var claimsAudienceProvider: ClaimsAudienceProvider
+
+    @Inject
+    lateinit var claimsGenerator: ClaimsGenerator
+
+    @Test
+    fun customClaimsAudienceProviderSuppliesJwtAudienceClaim() {
+        val claims = claimsGenerator.generateClaims(Authentication.build("sherlock"), 3600)
+
+        Assertions.assertEquals(listOf("https://api.example.com"), claimsAudienceProvider.audience())
+        Assertions.assertEquals(listOf("https://api.example.com"), claims[Claims.AUDIENCE])
+    }
+}

--- a/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.java
+++ b/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.java
@@ -1,0 +1,19 @@
+package io.micronaut.docs.claimsaudience;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.security.token.claims.ClaimsAudienceProvider;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Requires(property = "spec.name", value = "claims-generation-docs")
+//tag::clazz[]
+@Singleton
+class CustomClaimsAudienceProvider implements ClaimsAudienceProvider {
+
+    @Override
+    public List<String> audience() {
+        return List.of("https://api.example.com");
+    }
+}
+//end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.java
+++ b/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProvider.java
@@ -10,10 +10,11 @@ import java.util.List;
 //tag::clazz[]
 @Singleton
 class CustomClaimsAudienceProvider implements ClaimsAudienceProvider {
+    private static final List<String> AUDIENCE = List.of("https://api.example.com");
 
     @Override
     public List<String> audience() {
-        return List.of("https://api.example.com");
+        return AUDIENCE;
     }
 }
 //end::clazz[]

--- a/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderTest.java
+++ b/test-suite/src/test/java/io/micronaut/docs/claimsaudience/CustomClaimsAudienceProviderTest.java
@@ -1,0 +1,34 @@
+package io.micronaut.docs.claimsaudience;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.token.Claims;
+import io.micronaut.security.token.claims.ClaimsAudienceProvider;
+import io.micronaut.security.token.claims.ClaimsGenerator;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "claims-generation-docs")
+@MicronautTest(startApplication = false)
+class CustomClaimsAudienceProviderTest {
+
+    @Inject
+    ClaimsAudienceProvider claimsAudienceProvider;
+
+    @Inject
+    ClaimsGenerator claimsGenerator;
+
+    @Test
+    void customClaimsAudienceProviderSuppliesJwtAudienceClaim() {
+        Map<String, Object> claims = claimsGenerator.generateClaims(Authentication.build("sherlock"), 3600);
+
+        assertEquals(List.of("https://api.example.com"), claimsAudienceProvider.audience());
+        assertEquals(List.of("https://api.example.com"), claims.get(Claims.AUDIENCE));
+    }
+}


### PR DESCRIPTION
Closes #401.

## Summary

- Document that providing a `ClaimsAudienceProvider` bean lets `JWTClaimsSetGenerator` populate the JWT `aud` claim.
- Add source-backed Java, Groovy, and Kotlin `CustomClaimsAudienceProvider` docs snippets using `https://api.example.com`.
- Add focused coverage proving `Claims.AUDIENCE` is emitted when a provider is supplied.

## Verification

- `git diff --check origin/5.1.x...HEAD`
- `./gradlew :micronaut-security-jwt:test --tests io.micronaut.security.token.jwt.generator.claims.JWTClaimsSetGeneratorSpec`
- `./gradlew :test-suite:compileTestJava :test-suite-groovy:compileTestGroovy :test-suite-kotlin:compileTestKotlin`
- `./gradlew publishGuide`
- Rendered `claimsGeneration.html` contains Java, Kotlin, and Groovy `CustomClaimsAudienceProvider` variants, `ClaimsAudienceProvider`, `https://api.example.com`, and `micronaut.security.token.jwt.claims-validators.audience`; rejected JTI terms are absent.

## Release Metadata

- Target branch: `5.1.x`
- Type label: `type: docs`
- Micronaut organization project selected by QA: `5.1.0 Release` (#147)
- Project-link status: not applied because the available GitHub token has `read:project` but lacks the `project` scope required by `addProjectV2ItemById`.
- Paperclip issue: MNG-227

## Reviewer Routing

- Linked GitHub issue creator: `sdelamo`
- Reviewer request status: attempted through the GitHub review-request API; GitHub rejected it with `Review cannot be requested from pull request author.` because this PR was created with `sdelamo` as the authenticated author.

## PR Assets

- [Rendered Claims Generation guide](https://raw.githubusercontent.com/micronaut-projects/micronaut-security/95b61ef5e529c0cfa81c5bafe9e237a955c0f2fe/assets/pr-2207/0b53379be481/claimsGeneration.html)

---
###### ✨ This message was AI-generated using gpt-5