### PR TITLE
Fix rendered guide link and CSRF title

### DIFF
--- a/src/main/docs/guide/authenticationStrategies/jwt/jwtValidation.adoc
+++ b/src/main/docs/guide/authenticationStrategies/jwt/jwtValidation.adoc
@@ -8,7 +8,7 @@ api:io.micronaut.security.token.jwt.signature.SignatureConfiguration[] or api:io
 
 The easiest way is to create a bean of type api:io.micronaut.security.token.jwt.signature.SignatureConfiguration[] is to have in your app a bean of type api:io.micronaut.security.token.jwt.signature.rsa.RSASignatureConfiguration[],
 api:io.micronaut.security.token.jwt.signature.ec.ECSignatureConfiguration[], or
-api:io.micronaut.security.token.jwt.signature.secret.SecretSignatureConfiguration[] which must be https://docs.micronaut.io/latest/guide/index.html#qualifiers[qualified] with `@Named` since the configuration beans are used by factories (api:io.micronaut.security.token.jwt.signature.rsa.RSASignatureFactory.html[],
+api:io.micronaut.security.token.jwt.signature.secret.SecretSignatureConfiguration[] which must be https://docs.micronaut.io/latest/guide/index.html#qualifiers[qualified] with `@Named` since the configuration beans are used by factories (api:io.micronaut.security.token.jwt.signature.rsa.RSASignatureFactory[],
 api:io.micronaut.security.token.jwt.signature.ec.ECSignatureConfiguration[]) or other beans (api:io.micronaut.security.token.jwt.signature.secret.SecretSignature[])  which use
 https://docs.micronaut.io/latest/guide/index.html#eachBean[@EachBean] to drive configuration.
 

--- a/src/main/docs/guide/csrf/csrfMitigations/syncronizerTokenPattern.adoc
+++ b/src/main/docs/guide/csrf/csrfMitigations/syncronizerTokenPattern.adoc
@@ -1,4 +1,4 @@
-https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern[Syncronizer Token Pattern].
+https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern[Synchronizer Token Pattern].
 
 ____
 In a synchronized token pattern, the server generates a CSRF token and shares it with the client before returning it,

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -98,7 +98,7 @@ csrf:
   csrfMitigations:
     title: CSRF Mitigations
     syncronizerTokenPattern:
-      title: Syncronizer Token Pattern
+      title: Synchronizer Token Pattern
       csrfAndSession: CSRF and Session
     doubleSubmitCookiePattern: Double Submit Cookie Pattern
     signedDoubleSubmitCookiePattern: Signed Double Submit Cookie Pattern


### PR DESCRIPTION
## Summary
- Correct the visible CSRF guide title and link text to "Synchronizer Token Pattern".
- Fix the JWT validation guide `api:` macro so `RSASignatureFactory` renders as a valid API link instead of `RSASignatureFactory.html/.html`.

## Validation
- `./gradlew publishGuide`
- Render check: generated `csrf.html` and `index.html` show "Synchronizer Token Pattern".
- Render check: generated `authenticationStrategies.html` and `index.html` link to `../api/io/micronaut/security/token/jwt/signature/rsa/RSASignatureFactory.html`.
- `./gradlew :micronaut-security:test --tests io.micronaut.docs.security.token.basicauth.BasicAuthSpec`
- Throwaway Micronaut Launch `security-jwt` Java 25 Gradle application: `./gradlew test`

## Paperclip
- Weekly User Guide Review project subtask: MNG-472.
- PR created from a clean worktree based on `origin/5.1.x`; the existing `paperclip/mng-279-reactive-logout-handler` workspace was left untouched.

---
###### ✨ This message was AI-generated using gpt-5.5
