### PR TITLE
Allow disabling OpenID provider metadata fetch

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
@@ -24,6 +24,7 @@ import io.micronaut.context.annotation.Parallel;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.client.HttpClientRegistry;
@@ -78,8 +79,10 @@ class OpenIdClientFactory {
     @EachBean(OpenIdClientConfiguration.class)
     DefaultOpenIdProviderMetadata openIdConfiguration(@Parameter OauthClientConfiguration oauthClientConfiguration,
                                                       @Parameter OpenIdClientConfiguration openIdClientConfiguration,
-                                                      @Parameter OpenIdProviderMetadataFetcher openIdProviderMetadataFetcher) {
-        DefaultOpenIdProviderMetadata providerMetadata = openIdProviderMetadataFetcher.fetch();
+                                                      @Parameter @Nullable OpenIdProviderMetadataFetcher openIdProviderMetadataFetcher) {
+        DefaultOpenIdProviderMetadata providerMetadata = openIdProviderMetadataFetcher == null
+            ? new DefaultOpenIdProviderMetadata(openIdClientConfiguration.getName())
+            : openIdProviderMetadataFetcher.fetch();
         overrideFromConfig(providerMetadata, openIdClientConfiguration, oauthClientConfiguration);
         return providerMetadata;
     }
@@ -125,6 +128,10 @@ class OpenIdClientFactory {
     private void overrideFromConfig(DefaultOpenIdProviderMetadata configuration,
                                     OpenIdClientConfiguration openIdClientConfiguration,
                                     OauthClientConfiguration oauthClientConfiguration) {
+        if (StringUtils.isEmpty(configuration.getIssuer())) {
+            openIdClientConfiguration.getIssuer().ifPresent(url -> configuration.setIssuer(url.toString()));
+        }
+
         openIdClientConfiguration.getJwksUri().ifPresent(configuration::setJwksUri);
 
         oauthClientConfiguration.getIntrospection().ifPresent(introspection -> {

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactory.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactory.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.core.annotation.Internal;
 import org.jspecify.annotations.NonNull;
 import io.micronaut.http.client.HttpClient;
@@ -46,6 +47,10 @@ public class OpenIdProviderMetadataFetcherFactory {
     @NonNull
     public OpenIdProviderMetadataFetcher createOpenIdProviderMetadataFetcher(@Parameter OpenIdClientConfiguration openIdClientConfiguration,
                                                                              @Client HttpClient issuerClient) {
+        if (!openIdClientConfiguration.isFetchConfiguration()) {
+            throw new DisabledBeanException("OpenID provider metadata fetching is disabled for provider [" +
+                openIdClientConfiguration.getName() + "]");
+        }
         return new DefaultOpenIdProviderMetadataFetcher(openIdClientConfiguration, issuerClient);
     }
 }

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -545,7 +545,8 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
         }
 
         /**
-         * Whether the OpenID configuration should be fetched by visiting the value returned by issuer value plus {@code /.well-known/openid-configuration}. Default value: true.
+         * Whether the OpenID configuration should be fetched from the discovery endpoint derived from {@link #getIssuer()} and {@link #getConfigurationPath()}. Default value: true.
+         *
          * @param fetchConfiguration Whether the OpenID configuration should be fetched
          */
         public void setFetchConfiguration(boolean fetchConfiguration) {

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthClientConfigurationProperties.java
@@ -518,8 +518,10 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
     public static class OpenIdClientConfigurationProperties implements OpenIdClientConfiguration {
 
         private static final String DEFAULT_CONFIG_PATH = "/.well-known/openid-configuration";
+        private static final boolean DEFAULT_FETCH_CONFIGURATION = true;
         private final String name;
 
+        private boolean fetchConfiguration = DEFAULT_FETCH_CONFIGURATION;
         private URL issuer;
         private String configurationPath = DEFAULT_CONFIG_PATH;
         private String jwksUri;
@@ -535,6 +537,19 @@ public class OauthClientConfigurationProperties implements OauthClientConfigurat
          */
         OpenIdClientConfigurationProperties(@Parameter String name) {
             this.name = name;
+        }
+
+        @Override
+        public boolean isFetchConfiguration() {
+            return fetchConfiguration;
+        }
+
+        /**
+         * Whether the OpenID configuration should be fetched by visiting the value returned by issuer value plus {@code /.well-known/openid-configuration}. Default value: true.
+         * @param fetchConfiguration Whether the OpenID configuration should be fetched
+         */
+        public void setFetchConfiguration(boolean fetchConfiguration) {
+            this.fetchConfiguration = fetchConfiguration;
         }
 
         @NonNull

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
@@ -35,7 +35,7 @@ public interface OpenIdClientConfiguration extends Named {
 
     /**
      * @since 5.3.0
-     * @return Whether the OpenID configuration should be fetched by visiting the value returned by {{@link #getIssuer()}} plus {@code /.well-known/openid-configuration}.
+     * @return Whether the OpenID configuration should be fetched from the discovery endpoint derived from {@link #getIssuer()} and {@link #getConfigurationPath()}.
      */
     default boolean isFetchConfiguration() {
         return true;

--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OpenIdClientConfiguration.java
@@ -34,6 +34,14 @@ public interface OpenIdClientConfiguration extends Named {
     Boolean DEFAULT_PROTECTED_RESOURCE_METADATA = true;
 
     /**
+     * @since 5.3.0
+     * @return Whether the OpenID configuration should be fetched by visiting the value returned by {{@link #getIssuer()}} plus {@code /.well-known/openid-configuration}.
+     */
+    default boolean isFetchConfiguration() {
+        return true;
+    }
+
+    /**
      * @return URL that the OpenID provider asserts as its issuer identifier.
      */
     Optional<URL> getIssuer();
@@ -42,7 +50,7 @@ public interface OpenIdClientConfiguration extends Named {
      * @return The OpenID configuration path
      */
     String getConfigurationPath();
-    
+
     /**
      * @return The JWKS configuration
      */

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
@@ -1,0 +1,37 @@
+package io.micronaut.security.oauth2.client;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.security.oauth2.configuration.OpenIdClientConfiguration;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "micronaut.security.oauth2.clients.chesscom.openid.authorization.url", value = "https://oauth.chess.com/authorize")
+@Property(name = "micronaut.security.oauth2.clients.chesscom.openid.token.url", value = "https://oauth.chess.com/token")
+@Property(name = "micronaut.security.oauth2.clients.chesscom.openid.jwks-uri", value = "https://oauth.chess.com/certs")
+@Property(name = "micronaut.security.oauth2.clients.chesscom.openid.issuer", value = "https://oauth.chess.com")
+@Property(name = "micronaut.security.oauth2.clients.chesscom.openid.fetch-configuration", value = StringUtils.FALSE)
+@MicronautTest(startApplication = false)
+class OpenIdProviderMetadataFetcherFactoryDisableTest {
+
+    @Inject
+    BeanContext beanContext;
+
+    @Test
+    void youCanDisableABeanOfTypeOpenIdProviderMetadataFetcher() {
+        assertTrue(beanContext.containsBean(OpenIdClientConfiguration.class, Qualifiers.byName("chesscom")));
+        assertTrue(beanContext.containsBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom")));
+        DefaultOpenIdProviderMetadata metadata = beanContext.getBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom"));
+        assertEquals("https://oauth.chess.com/authorize", metadata.getAuthorizationEndpoint());
+        assertEquals("https://oauth.chess.com/token", metadata.getTokenEndpoint());
+        assertEquals("https://oauth.chess.com/certs", metadata.getJwksUri());
+        assertEquals("https://oauth.chess.com", metadata.getIssuer());
+    }
+
+}

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
@@ -26,7 +26,6 @@ class OpenIdProviderMetadataFetcherFactoryDisableTest {
     @Test
     void youCanDisableABeanOfTypeOpenIdProviderMetadataFetcher() {
         assertTrue(beanContext.containsBean(OpenIdClientConfiguration.class, Qualifiers.byName("chesscom")));
-        assertTrue(!beanContext.containsBean(OpenIdProviderMetadataFetcher.class, Qualifiers.byName("chesscom")));
         assertTrue(beanContext.containsBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom")));
         DefaultOpenIdProviderMetadata metadata = beanContext.getBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom"));
         assertEquals("https://oauth.chess.com/authorize", metadata.getAuthorizationEndpoint());

--- a/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
+++ b/security-oauth2/src/test/java/io/micronaut/security/oauth2/client/OpenIdProviderMetadataFetcherFactoryDisableTest.java
@@ -26,6 +26,7 @@ class OpenIdProviderMetadataFetcherFactoryDisableTest {
     @Test
     void youCanDisableABeanOfTypeOpenIdProviderMetadataFetcher() {
         assertTrue(beanContext.containsBean(OpenIdClientConfiguration.class, Qualifiers.byName("chesscom")));
+        assertTrue(!beanContext.containsBean(OpenIdProviderMetadataFetcher.class, Qualifiers.byName("chesscom")));
         assertTrue(beanContext.containsBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom")));
         DefaultOpenIdProviderMetadata metadata = beanContext.getBean(DefaultOpenIdProviderMetadata.class, Qualifiers.byName("chesscom"));
         assertEquals("https://oauth.chess.com/authorize", metadata.getAuthorizationEndpoint());


### PR DESCRIPTION
Add an OpenID client `fetch-configuration` option that defaults to enabled and disables the OpenIdProviderMetadataFetcher bean when set to false.

When fetching is disabled, provider metadata is created from the local client configuration instead, including the issuer, authorization, token, and JWKS values. Add test coverage for an OAuth client that uses only configured OpenID metadata without fetching the discovery document.

Unfortunately, there are OpenID OAuth providers such as [chess.com, which doesn’t expose OpenID auto-configuration endpoints](https://chesscom.notion.site/Getting-started-with-Chess-com-OAuth-2-0-Server-5958e57c8c934a3aa7abda2d670969e8). In these cases, you want to set the issuer for claim validation without visiting the /.well-known/openid-configuration endpoint on startup.