### PR TITLE
Complete OIDC metadata discovery during startup

### DIFF
--- a/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
+++ b/security-oauth2/src/main/java/io/micronaut/security/oauth2/client/OpenIdClientFactory.java
@@ -20,7 +20,6 @@ import io.micronaut.context.BeanProvider;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Parallel;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
@@ -74,7 +73,6 @@ class OpenIdClientFactory {
      * @param openIdProviderMetadataFetcher OpenID Provider metadata Fetcher
      * @return The OpenID configuration
      */
-    @Parallel
     @Context
     @EachBean(OpenIdClientConfiguration.class)
     DefaultOpenIdProviderMetadata openIdConfiguration(@Parameter OauthClientConfiguration oauthClientConfiguration,

--- a/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/OpenIdClientFactorySpec.groovy
+++ b/security-oauth2/src/test/groovy/io/micronaut/security/oauth2/client/OpenIdClientFactorySpec.groovy
@@ -22,32 +22,52 @@ import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.BlockingQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 class OpenIdClientFactorySpec extends Specification {
 
-    void "starting an app eagerly calls .well-known/openid-configuration with @Context and @Parallel"() {
+    @Issue("https://github.com/micronaut-projects/micronaut-security/issues/2263")
+    void "OpenID Connect metadata is fetched before application startup completes"() {
         given:
         int authServerPort = SocketUtils.findAvailableTcpPort()
         EmbeddedServer authServer = ApplicationContext.run(EmbeddedServer, [
                 'micronaut.server.port': authServerPort,
                 'spec.name': 'AuthServerOpenIdClientFactorySpec'
         ])
-        EmbeddedServer server = ApplicationContext.run(EmbeddedServer, [
+        OpenIdConfigurationController openIdConfigurationController = authServer.applicationContext.getBean(OpenIdConfigurationController)
+        openIdConfigurationController.delayResponse()
+        ExecutorService executor = Executors.newSingleThreadExecutor()
+        Future<EmbeddedServer> serverFuture
+        EmbeddedServer server
+
+        when:
+        serverFuture = executor.submit(() -> ApplicationContext.run(EmbeddedServer, [
                 'spec.name'                                           : 'OpenIdClientFactorySpec',
                 'micronaut.security.authentication'                   : 'cookie',
                 'micronaut.security.oauth2.clients.okta.openid.issuer': "http://localhost:${authServerPort}/oauth2/default",
-        ])
+        ]))
+
+        then:
+        openIdConfigurationController.awaitRequest()
+        !serverFuture.done
 
         when:
-        OpenIdConfigurationController openIdConfigurationController = authServer.applicationContext.getBean(OpenIdConfigurationController)
+        openIdConfigurationController.releaseResponse()
+        server = serverFuture.get(10, TimeUnit.SECONDS)
 
         then:
         openIdConfigurationController.invocations == 1
 
         cleanup:
+        openIdConfigurationController.releaseResponse()
+        executor.shutdownNow()
         authServer.close()
-        server.close()
+        server?.close()
     }
 
     @Issue("https://github.com/micronaut-projects/micronaut-security/issues/604")
@@ -114,11 +134,27 @@ class OpenIdClientFactorySpec extends Specification {
     @Controller("/oauth2/default/.well-known/openid-configuration")
     static class OpenIdConfigurationController {
         int invocations = 0
+        private final CountDownLatch requestReceived = new CountDownLatch(1)
+        private CountDownLatch responseAllowed = new CountDownLatch(0)
+
+        void delayResponse() {
+            responseAllowed = new CountDownLatch(1)
+        }
+
+        boolean awaitRequest() {
+            requestReceived.await(10, TimeUnit.SECONDS)
+        }
+
+        void releaseResponse() {
+            responseAllowed.countDown()
+        }
 
         @Secured(SecurityRule.IS_ANONYMOUS)
         @Get
         String index() {
             invocations++
+            requestReceived.countDown()
+            responseAllowed.await(10, TimeUnit.SECONDS)
             '{"issuer":"https://dev-133320.okta.com/oauth2/default","authorization_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/authorize","token_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/token","userinfo_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/userinfo","registration_endpoint":"https://dev-133320.okta.com/oauth2/v1/clients","jwks_uri":"https://dev-133320.okta.com/oauth2/default/v1/keys","response_types_supported":["code","id_token","code id_token","code token","id_token token","code id_token token"],"response_modes_supported":["query","fragment","form_post","okta_post_message"],"grant_types_supported":["authorization_code","implicit","refresh_token","password"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"scopes_supported":["openid","profile","email","address","phone","offline_access"],"token_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"claims_supported":["iss","ver","sub","aud","iat","exp","jti","auth_time","amr","idp","nonce","name","nickname","preferred_username","given_name","middle_name","family_name","email","email_verified","profile","zoneinfo","locale","address","phone_number","picture","website","gender","birthdate","updated_at","at_hash","c_hash"],"code_challenge_methods_supported":["S256"],"introspection_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/introspect","introspection_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"revocation_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/revoke","revocation_endpoint_auth_methods_supported":["client_secret_basic","client_secret_post","client_secret_jwt","private_key_jwt","none"],"end_session_endpoint":"https://dev-133320.okta.com/oauth2/default/v1/logout","request_parameter_supported":true,"request_object_signing_alg_values_supported":["HS256","HS384","HS512","RS256","RS384","RS512","ES256","ES384","ES512"]}'
         }
     }


### PR DESCRIPTION
OpenID provider metadata is retrieved using a blocking HTTP client. The fix for #604 annotated the metadata bean with both @Context and @Parallel to prevent lazy initialization from blocking a Netty event-loop thread.

@Context provides the required eager initialization, but @Parallel allows application startup to complete while that initialization is still running.

The first incoming request can therefore race the parallel initialization and resolve the metadata bean through the SecurityFilter dependency graph on its event-loop thread. The blocking request then triggers Micronaut's and Reactor's blocking guards.

Remove @Parallel while retaining @Context. Metadata discovery now completes synchronously on the startup thread before the server handles requests. This preserves the off-event-loop guarantee introduced for #604 while eliminating the first-request race.

Add a deterministic regression test that verifies application startup does not complete until the metadata response is available.

Fixes #2263